### PR TITLE
InvalidCastToInterface: do not raise S1944 when casting to Nullable<T>

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterface.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterface.cs
@@ -156,6 +156,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 var type = semanticModel.GetTypeInfo(castExpression.Type).Type;
 
                 if (type == null ||
+                    type.OriginalDefinition.Is(KnownType.System_Nullable_T) ||
                     !semanticModel.Compilation.ClassifyConversion(typeExpression, type).IsNullable ||
                     !programState.PeekValue().HasConstraint(ObjectConstraint.Null, programState))
                 {

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/InvalidCastToInterface.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/InvalidCastToInterface.cs
@@ -100,6 +100,11 @@ namespace Tests.Diagnostics
             int? i = null;
             var n = (NullableTest)i; // don't care, custom cast
         }
+        public void Test5()
+        {
+            int? i = null;
+            var d = (double?)i;
+        }
 
         public static explicit operator NullableTest(int? i)
         {


### PR DESCRIPTION
This is a port of https://github.com/SonarSource/sonaranalyzer-dotnet/pull/1164