### PR TITLE
Fix S2275: Rule should not report on multiple ':' in formatting methods

### DIFF
--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/StringFormatRuntimeExceptionFreeValidator.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/StringFormatRuntimeExceptionFreeValidator.cs
@@ -52,6 +52,7 @@ namespace Tests.Diagnostics
 
             s = string.Format("{0test}", 42); // Noncompliant {{Invalid string format, all format items should comply with the following pattern '{index[,alignment][:formatString]}'.}}
             s = string.Format("{0,test}", 42); // Noncompliant
+            s = string.Format("{0.0}", 42); // Noncompliant
             s = string.Format("{0:C,10}", 42);
             s = string.Format("{0:hh:mm:ss}", DateTime.Now);
             s = string.Format("{0:dd/MM/yyyy}", DateTime.Now);

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/StringFormatRuntimeExceptionFreeValidator.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/StringFormatRuntimeExceptionFreeValidator.cs
@@ -50,11 +50,15 @@ namespace Tests.Diagnostics
 
             s = string.Format(null, arg0: 1); // Noncompliant {{Invalid string format, the format string cannot be null.}}
 
-            s = string.Format("{0:C,10}", 42); // Noncompliant {{Invalid string format, all format items should comply with the following pattern '{index[,alignment][:formatString]}'.}}
-
-            s = string.Format("{0test}", 42); // Noncompliant {{Invalid string format, all format item indexes should be numbers.}}
-
-            s = string.Format("{0,test}", 42); // Noncompliant {{Invalid string format, all format item alignments should be numbers.}}
+            s = string.Format("{0test}", 42); // Noncompliant {{Invalid string format, all format items should comply with the following pattern '{index[,alignment][:formatString]}'.}}
+            s = string.Format("{0,test}", 42); // Noncompliant
+            s = string.Format("{0:C,10}", 42);
+            s = string.Format("{0:hh:mm:ss}", DateTime.Now);
+            s = string.Format("{0:dd/MM/yyyy}", DateTime.Now);
+            s = string.Format("{0:(###) ###-####}", 8005551212);
+            s = string.Format("{0:(###) ###-####}", 8005551212);
+            s = string.Format("{0:0,.}", 1500.42);
+            s = string.Format("{0:0,0}", 1500.42);
         }
 
         void System_Console_Write(string[] args)


### PR DESCRIPTION
Fix #222 