### PR TITLE
Rule S3994: URI Parameters should not be strings

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S3994.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S3994.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy\Extensions\ContextExtensions.cs",
+"region":  {
+"startLine":  148,
+"startColumn":  66,
+"endLine":  148,
+"endColumn":  72
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Authentication.Forms-{E8B18958-7C8A-4FBA-AF00-3041C34A20CE}-S3994.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Authentication.Forms-{E8B18958-7C8A-4FBA-AF00-3041C34A20CE}-S3994.json
@@ -1,0 +1,82 @@
+{
+"issues":  [
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Authentication.Forms\FormsAuthentication.cs",
+"region":  {
+"startLine":  105,
+"startColumn":  135,
+"endLine":  105,
+"endColumn":  141
+}
+}
+},
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Authentication.Forms\FormsAuthentication.cs",
+"region":  {
+"startLine":  163,
+"startColumn":  80,
+"endLine":  163,
+"endColumn":  86
+}
+}
+},
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Authentication.Forms\ModuleExtensions.cs",
+"region":  {
+"startLine":  20,
+"startColumn":  116,
+"endLine":  20,
+"endColumn":  122
+}
+}
+},
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Authentication.Forms\ModuleExtensions.cs",
+"region":  {
+"startLine":  35,
+"startColumn":  127,
+"endLine":  35,
+"endColumn":  133
+}
+}
+},
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Authentication.Forms\ModuleExtensions.cs",
+"region":  {
+"startLine":  58,
+"startColumn":  65,
+"endLine":  58,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Authentication.Forms\ModuleExtensions.cs",
+"region":  {
+"startLine":  71,
+"startColumn":  76,
+"endLine":  71,
+"endColumn":  82
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Self-{AA7F66EB-EC2C-47DE-855F-30B3E6EF2134}-S3994.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Self-{AA7F66EB-EC2C-47DE-855F-30B3E6EF2134}-S3994.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Hosting.Self\NetSh.cs",
+"region":  {
+"startLine":  18,
+"startColumn":  38,
+"endLine":  18,
+"endColumn":  44
+}
+}
+},
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Hosting.Self\NetSh.cs",
+"region":  {
+"startLine":  32,
+"startColumn":  46,
+"endLine":  32,
+"endColumn":  52
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests-{776D244D-BC4D-4BBB-A478-CAF2D04520E1}-S3994.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests-{776D244D-BC4D-4BBB-A478-CAF2D04520E1}-S3994.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Tests\Unit\Extensions\ContextExtensionsFixture.cs",
+"region":  {
+"startLine":  197,
+"startColumn":  61,
+"endLine":  197,
+"endColumn":  67
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.Razor-{2C6F51DF-015C-4DB6-B44C-0E5E4F25E2A9}-S3994.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.Razor-{2C6F51DF-015C-4DB6-B44C-0E5E4F25E2A9}-S3994.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3994",
+"message":  "Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.",
+"location":  {
+"uri":  "Nancy\src\Nancy.ViewEngines.Razor\NancyRazorViewBase.cs",
+"region":  {
+"startLine":  385,
+"startColumn":  42,
+"endLine":  385,
+"endColumn":  48
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/rspec/cs/S3994_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S3994_c#.html
@@ -1,0 +1,37 @@
+<p>String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The <code>System.Uri</code>
+class is a safe alternative and should be preferred. At minimum, an overload of the method taking a <code>System.Uri</code> as a parameter should be
+provided in each class that contains a method with an apparent Uri passed as a <code>string</code>.</p>
+<p>This rule raises issues when a method has a string parameter with a name containing "uri", "Uri", "urn", "Urn", "url" or "Url", and the type
+doesn't declare a corresponding overload taking an <code>System.Uri</code> parameter instead.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+   public class MyClass
+   {
+
+      public void FetchResource(string uriString) { } // Noncompliant
+   }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+   public class MyClass
+   {
+
+      public void FetchResource(string uriString)
+      {
+          FetchResource(new Uri(uriString));
+      }
+
+      public void FetchResource(Uri uri) { }
+   }
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/rspec/cs/S3994_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S3994_c#.json
@@ -1,0 +1,13 @@
+{
+  "title": "URI Parameters should not be strings",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "10min"
+  },
+  "tags": [
+    
+  ],
+  "defaultSeverity": "Major"
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -5505,6 +5505,30 @@
   <data name="S3993_Title" xml:space="preserve">
     <value>Custom attributes should be marked with "System.AttributeUsageAttribute"</value>
   </data>
+  <data name="S3994_Category" xml:space="preserve">
+    <value>Sonar Code Smell</value>
+  </data>
+  <data name="S3994_Description" xml:space="preserve">
+    <value>String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The System.Uri class is a safe alternative and should be preferred. At minimum, an overload of the method taking a System.Uri as a parameter should be provided in each class that contains a method with an apparent Uri passed as a string.</value>
+  </data>
+  <data name="S3994_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S3994_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S3994_RemediationCost" xml:space="preserve">
+    <value>10min</value>
+  </data>
+  <data name="S3994_Severity" xml:space="preserve">
+    <value>Major</value>
+  </data>
+  <data name="S3994_Tags" xml:space="preserve">
+    <value />
+  </data>
+  <data name="S3994_Title" xml:space="preserve">
+    <value>URI Parameters should not be strings</value>
+  </data>
   <data name="S3995_Category" xml:space="preserve">
     <value>Sonar Code Smell</value>
   </data>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -97,6 +97,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType System_AttributeUsageAttribute = new KnownType("System.AttributeUsageAttribute");
         public static readonly KnownType System_CLSCompliantAttribute = new KnownType("System.CLSCompliantAttribute");
         public static readonly KnownType System_MarshalByRefObject = new KnownType("System.MarshalByRefObject");
+        public static readonly KnownType System_Uri = new KnownType("System.Uri");
 
         public static readonly KnownType System_Collections_Generic_IReadOnlyCollection_T = new KnownType("System.Collections.Generic.IReadOnlyCollection<T>");
         public static readonly KnownType System_Collections_Generic_IReadOnlyDictionary_TKey_TValue = new KnownType("System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>");

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S3994.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S3994.html
@@ -1,0 +1,37 @@
+<p>String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The <code>System.Uri</code>
+class is a safe alternative and should be preferred. At minimum, an overload of the method taking a <code>System.Uri</code> as a parameter should be
+provided in each class that contains a method with an apparent Uri passed as a <code>string</code>.</p>
+<p>This rule raises issues when a method has a string parameter with a name containing "uri", "Uri", "urn", "Urn", "url" or "Url", and the type
+doesn't declare a corresponding overload taking an <code>System.Uri</code> parameter instead.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+   public class MyClass
+   {
+
+      public void FetchResource(string uriString) { } // Noncompliant
+   }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+   public class MyClass
+   {
+
+      public void FetchResource(string uriString)
+      {
+          FetchResource(new Uri(uriString));
+      }
+
+      public void FetchResource(Uri uri) { }
+   }
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S4005.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S4005.html
@@ -1,0 +1,49 @@
+<p>String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The <code>System.Uri</code>
+class is a safe alternative and should be preferred.</p>
+<p>This rule raises an issue when a called method has a string parameter with a name containing "uri", "Uri", "urn", "Urn", "url" or "Url" and the
+declaring type contains a corresponding overload that takes a <code>System.Uri</code> as a parameter.</p>
+<p>When there is a choice between two overloads that differ only regarding the representation of a URI, the user should choose the overload that takes
+a <code>System.Uri</code> argument.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+   public class Foo
+   {
+      public void FetchResource(string uriString) { }
+      public void FetchResource(Uri uri) { }
+
+      public string ReadResource(string uriString, string name, bool isLocal) { }
+      public string ReadResource(Uri uri, string name, bool isLocal) { }
+
+      public void Main() {
+        FetchResource("http://www.mysite.com"); // Noncompliant
+        ReadResource("http://www.mysite.com", "foo-resource", true); // Noncompliant
+      }
+   }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+   public class Foo
+   {
+      public void FetchResource(string uriString) { }
+      public void FetchResource(Uri uri) { }
+
+      public string ReadResource(string uriString, string name, bool isLocal) { }
+      public string ReadResource(Uri uri, string name, bool isLocal) { }
+
+      public void Main() {
+        FetchResource(new Uri("http://www.mysite.com"));
+        ReadResource(new Uri("http://www.mysite.com"), "foo-resource", true);
+      }
+   }
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/UseUriInsteadOfString.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/UseUriInsteadOfString.cs
@@ -33,6 +33,8 @@ namespace Tests.Diagnostics
         string FooUrlBar{ get; set; } // Noncompliant {{Change this property type to 'System.Uri'.}}
         string AUrlMethod() => ""; // Noncompliant {{Change this return type to 'System.Uri'.}}
         string UrlMethod() => ""; // Noncompliant {{Change this return type to 'System.Uri'.}}
+        int ThisIsAnUrlProperty { get; set; } // Compliant
+        int ThisIsAnUrlMethod() => 1; // Compliant
 
 
         // Urn
@@ -60,5 +62,25 @@ namespace Tests.Diagnostics
         string urifoo { get; set; } // Compliant
         string urlfoo { get; set; } // Compliant
         string urnfoo { get; set; } // Compliant
+
+        string OverloadedMethod(string url) => ""; // Compliant
+        string OverloadedMethod(Uri url) => ""; // Compliant
+
+        string ParamTest(string uri) => ""; // Noncompliant {{Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.}}
+//                       ^^^^^^
+        string ParamTest2(int url) => ""; // Compliant
+        string ParamTestOverload(string uriParam) => ""; // Noncompliant {{Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.}}
+//                               ^^^^^^
+        string ParamTestOverload(int uriParam) => ""; // Compliant
+        string MultipleParams(string uriParam, object urnParam, string urlParam, string andThisIsFine) => "";
+//                            ^^^^^^ Noncompliant {{Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.}}
+//                                                              ^^^^^^ Noncompliant@-1 {{Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.}}
+
+        string AllUrlWrong(string url, string uri, string urn) => "";
+//      ^^^^^^ Noncompliant {{Change this return type to 'System.Uri'.}}
+//                         ^^^^^^ Noncompliant@-1 {{Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.}}
+//                                     ^^^^^^ Noncompliant@-2 {{Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.}}
+//                                                 ^^^^^^ Noncompliant@-3 {{Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.}}
+
     }
 }


### PR DESCRIPTION
Fix #268 