### PR TITLE
Rule S4005: "System.Uri" argument should be passed instead of string

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Self.Tests-{CA24ED85-DD68-4C10-B80A-D81C6745FCB8}-S4005.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Self.Tests-{CA24ED85-DD68-4C10-B80A-D81C6745FCB8}-S4005.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S4005",
+"message":  "Call the overload that takes a 'System.Uri' as an argument instead.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Hosting.Self.Tests\NancySelfHostFixture.cs",
+"region":  {
+"startLine":  183,
+"startColumn":  38,
+"endLine":  183,
+"endColumn":  88
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/rspec/cs/S4005_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S4005_c#.html
@@ -1,0 +1,49 @@
+<p>String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The <code>System.Uri</code>
+class is a safe alternative and should be preferred.</p>
+<p>This rule raises an issue when a called method has a string parameter with a name containing "uri", "Uri", "urn", "Urn", "url" or "Url" and the
+declaring type contains a corresponding overload that takes a <code>System.Uri</code> as a parameter.</p>
+<p>When there is a choice between two overloads that differ only regarding the representation of a URI, the user should choose the overload that takes
+a <code>System.Uri</code> argument.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+   public class Foo
+   {
+      public void FetchResource(string uriString) { }
+      public void FetchResource(Uri uri) { }
+
+      public string ReadResource(string uriString, string name, bool isLocal) { }
+      public string ReadResource(Uri uri, string name, bool isLocal) { }
+
+      public void Main() {
+        FetchResource("http://www.mysite.com"); // Noncompliant
+        ReadResource("http://www.mysite.com", "foo-resource", true); // Noncompliant
+      }
+   }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+   public class Foo
+   {
+      public void FetchResource(string uriString) { }
+      public void FetchResource(Uri uri) { }
+
+      public string ReadResource(string uriString, string name, bool isLocal) { }
+      public string ReadResource(Uri uri, string name, bool isLocal) { }
+
+      public void Main() {
+        FetchResource(new Uri("http://www.mysite.com"));
+        ReadResource(new Uri("http://www.mysite.com"), "foo-resource", true);
+      }
+   }
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/rspec/cs/S4005_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S4005_c#.json
@@ -1,0 +1,13 @@
+{
+  "title": "\"System.Uri\" argument should be passed instead of string",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "2min"
+  },
+  "tags": [
+    
+  ],
+  "defaultSeverity": "Major"
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -5649,6 +5649,30 @@
   <data name="S4004_Title" xml:space="preserve">
     <value>Collection properties should be readonly</value>
   </data>
+  <data name="S4005_Category" xml:space="preserve">
+    <value>Sonar Code Smell</value>
+  </data>
+  <data name="S4005_Description" xml:space="preserve">
+    <value>String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The System.Uri class is a safe alternative and should be preferred.</value>
+  </data>
+  <data name="S4005_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S4005_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S4005_RemediationCost" xml:space="preserve">
+    <value>2min</value>
+  </data>
+  <data name="S4005_Severity" xml:space="preserve">
+    <value>Major</value>
+  </data>
+  <data name="S4005_Tags" xml:space="preserve">
+    <value />
+  </data>
+  <data name="S4005_Title" xml:space="preserve">
+    <value>"System.Uri" argument should be passed instead of string</value>
+  </data>
   <data name="S818_Category" xml:space="preserve">
     <value>Sonar Code Smell</value>
   </data>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
@@ -116,24 +116,19 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>
                 {
-                    var invokedMethod = c.SemanticModel.GetSymbolInfo(c.Node).Symbol as IMethodSymbol;
-                    if (invokedMethod == null)
+                    var invokedMethodSymbol = c.SemanticModel.GetSymbolInfo(c.Node).Symbol as IMethodSymbol;
+                    if (invokedMethodSymbol == null || invokedMethodSymbol.IsInType(KnownType.System_Uri))
                     {
                         return;
                     }
 
-                    if (invokedMethod.IsInType(KnownType.System_Uri))
+                    var stringUrlParams = GetStringUrlParamIndexes(invokedMethodSymbol);
+                    if (stringUrlParams.Count == 0)
                     {
                         return;
                     }
 
-                    var stringUrlParams = GetStringUrlParamIndexes(invokedMethod);
-                    if (!stringUrlParams.Any())
-                    {
-                        return;
-                    }
-
-                    if (HasOverloadThatUsesUriTypeInPlaceOfString(invokedMethod, stringUrlParams))
+                    if (HasOverloadThatUsesUriTypeInPlaceOfString(invokedMethodSymbol, stringUrlParams))
                     {
                         c.ReportDiagnostic(Diagnostic.Create(rule_S4005, c.Node.GetLocation()));
                     }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
@@ -138,7 +138,8 @@ namespace SonarAnalyzer.Rules.CSharp
                         c.ReportDiagnostic(Diagnostic.Create(rule_S4005, c.Node.GetLocation()));
                     }
                 },
-                SyntaxKind.InvocationExpression);
+                SyntaxKind.InvocationExpression,
+                SyntaxKind.ObjectCreationExpression);
         }
 
         private bool HasOverloadThatUsesUriTypeInPlaceOfString(IMethodSymbol originalMethodSymbol, ISet<int> paramIdx)

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
@@ -34,6 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [Rule(DiagnosticId_RuleS3994)]
     [Rule(DiagnosticId_RuleS3995)]
     [Rule(DiagnosticId_RuleS3996)]
+    [Rule(DiagnosticId_RuleS4005)]
     public sealed class UseUriInsteadOfString : SonarDiagnosticAnalyzer
     {
         #region Rule definition
@@ -51,10 +52,15 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat_RuleS3996 = "Change this property type to 'System.Uri'.";
         private static readonly DiagnosticDescriptor rule_S3996 =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId_RuleS3996, MessageFormat_RuleS3996, RspecStrings.ResourceManager);
+
+        internal const string DiagnosticId_RuleS4005 = "S4005";
+        private const string MessageFormat_RuleS4005 = "Call the overload that takes a 'System.Uri' as an argument instead.";
+        private static readonly DiagnosticDescriptor rule_S4005 =
+            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId_RuleS4005, MessageFormat_RuleS4005, RspecStrings.ResourceManager);
         #endregion
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-            => ImmutableArray.Create(rule_S3994, rule_S3995, rule_S3996);
+            => ImmutableArray.Create(rule_S3994, rule_S3995, rule_S3996, rule_S4005);
 
         private static readonly HashSet<string> UrlNameVariants = new HashSet<string> { "uri", "url", "urn" };
 
@@ -106,6 +112,33 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
                 },
                 SyntaxKind.PropertyDeclaration);
+
+            context.RegisterSyntaxNodeActionInNonGenerated(
+                c =>
+                {
+                    var invokedMethod = c.SemanticModel.GetSymbolInfo(c.Node).Symbol as IMethodSymbol;
+                    if (invokedMethod == null)
+                    {
+                        return;
+                    }
+
+                    if (invokedMethod.IsInType(KnownType.System_Uri))
+                    {
+                        return;
+                    }
+
+                    var stringUrlParams = GetStringUrlParamIndexes(invokedMethod);
+                    if (!stringUrlParams.Any())
+                    {
+                        return;
+                    }
+
+                    if (HasOverloadThatUsesUriTypeInPlaceOfString(invokedMethod, stringUrlParams))
+                    {
+                        c.ReportDiagnostic(Diagnostic.Create(rule_S4005, c.Node.GetLocation()));
+                    }
+                },
+                SyntaxKind.InvocationExpression);
         }
 
         private bool HasOverloadThatUsesUriTypeInPlaceOfString(IMethodSymbol originalMethodSymbol, ISet<int> paramIdx)

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Rules/UseUriInsteadOfStringTest.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Rules/UseUriInsteadOfStringTest.cs
@@ -33,5 +33,13 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(@"TestCases\UseUriInsteadOfString.cs",
                 new UseUriInsteadOfString());
         }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void UseUriInsteadOfStringMethodOverloads()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\UseUriInsteadOfStringMethodOverloads.cs",
+                new UseUriInsteadOfString());
+        }
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/UseUriInsteadOfStringMethodOverloads.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/UseUriInsteadOfStringMethodOverloads.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Tests.Diagnostics
+{
+    class Program
+    {
+        public static void FetchResource(string uriString) { }
+        public static void FetchResource(Uri uri) { }
+
+        public static void FetchResource2(Uri uri, bool whatever) { }
+        public static void FetchResource2(string stringUri, bool whatever) { }
+
+        public static void FetchResource3(object stringUri, bool whatever) { }
+
+        public static void FetchResource4(string stringUri, bool whatever) { }
+//                                        ^^^^^^ Noncompliant {{Either change this parameter type to 'System.Uri' or provide an overload which takes a 'System.Uri' parameter.}}
+        public static void FetchResource4(object stringUri, bool whatever) { }
+
+        public static void FetchResource5(Uri uri, Uri url) { }
+        public static void FetchResource5(string stringUri, string stringUrl) { }
+
+
+        public static void FetchResource6(Uri uri, Uri url) { }
+        public static void FetchResource6(string stringUri, string stringUrl, bool extraParam) { } // Noncompliant
+                                                                                                   // Noncompliant@-1
+
+        static void Main()
+        {
+            FetchResource("www.sonarsource.com");
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant {{Call the overload that takes a 'System.Uri' as an argument instead.}}
+            FetchResource(new Uri("www.sonarsource.com"));
+
+            FetchResource2("www.sonarsource.com", true);
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant {{Call the overload that takes a 'System.Uri' as an argument instead.}}
+            FetchResource2(new Uri("www.sonarsource.com"), true);
+
+            FetchResource3("www.sonarsource.com", true);
+
+            FetchResource4("www.sonarsource.com", true);
+
+            FetchResource5("www.sonarsource.com", "www.sonarqube.com"); // Noncompliant
+
+            FetchResource6("www.sonarsource.com", "www.sonarqube.com");
+
+            Uri result;
+            // Note there is an overload Uri.TryCreate(Uri, UriKind, out Uri), which should not be flagged
+            Uri.TryCreate("", UriKind.Absolute, out result);
+            Uri.TryCreate(new object(), UriKind.Absolute, out result);
+
+            result = new Uri("foo");
+            result = new Uri("foo", true);
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/UseUriInsteadOfStringMethodOverloads.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/UseUriInsteadOfStringMethodOverloads.cs
@@ -4,6 +4,9 @@ namespace Tests.Diagnostics
 {
     class Program
     {
+        Program(Uri uri) { }
+        Program(string stringUri) { }
+
         public static void FetchResource(string uriString) { }
         public static void FetchResource(Uri uri) { }
 
@@ -26,6 +29,8 @@ namespace Tests.Diagnostics
 
         static void Main()
         {
+            var p = new Program("www.sonarsource.com"); // Noncompliant
+
             FetchResource("www.sonarsource.com");
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant {{Call the overload that takes a 'System.Uri' as an argument instead.}}
             FetchResource(new Uri("www.sonarsource.com"));


### PR DESCRIPTION
Fix  #281