### PR TITLE
Fix S1939: Extends and implements list entries should not be redundant

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -169,6 +169,7 @@ namespace SonarAnalyzer.Rules.CSharp
             return baseList.Types
                 .Select(baseType => semanticModel.GetSymbolInfo(baseType.Type).Symbol as INamedTypeSymbol)
                 .Where(symbol => symbol != null)
+                .Distinct()
                 .Select(symbol => new Tuple<INamedTypeSymbol, ICollection<INamedTypeSymbol>>(symbol, symbol.AllInterfaces))
                 .ToMultiValueDictionary(kv => kv.Item1, kv => kv.Item2);
         }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCasesForRuleFailure/InvalidSyntax.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCasesForRuleFailure/InvalidSyntax.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text
@@ -7,6 +8,8 @@ using System.Threading.Tasks;
 namespace SonarAnalyzer.UnitTest.TestCasesForRuleFailure
 {
     public void Method2(int i, int j) { }
+
+    class DuplicatedInterfaces: IList, IList {}
 
     class InvalidSyntax
     {


### PR DESCRIPTION
Fix #386