### PR TITLE
Fix S1940: "Inverted boolean checks" should not suggest inversion for Nullable<T>

### DIFF
--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.Batch.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.Batch.cs
@@ -33,6 +33,18 @@ namespace Tests.Diagnostics
             SomeFunc(a < 10); // Fixed
         }
 
+        public void TestNullables()
+        {
+            int? a = 5;
+
+            bool b = !(a < 5); // Compliant
+            b = !(a <= 5); // Compliant
+            b = !(a > 5); // Compliant
+            b = !(a >= 5); // Compliant
+            b = a != 5; // Fixed
+            b = a == 5; // Fixed
+        }
+
         public static void SomeFunc(bool x) { }
 
         public static bool operator ==     (BooleanCheckInverted a, BooleanCheckInverted b)

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.cs
@@ -33,6 +33,18 @@ namespace Tests.Diagnostics
             SomeFunc(a < 10); // Fixed
         }
 
+        public void TestNullables()
+        {
+            int? a = 5;
+
+            bool b = !(a < 5); // Compliant
+            b = !(a <= 5); // Compliant
+            b = !(a > 5); // Compliant
+            b = !(a >= 5); // Compliant
+            b = a != 5; // Fixed
+            b = a == 5; // Fixed
+        }
+
         public static void SomeFunc(bool x) { }
 
         public static bool operator ==     (BooleanCheckInverted a, BooleanCheckInverted b)

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.cs
@@ -35,6 +35,18 @@ namespace Tests.Diagnostics
             SomeFunc(!(a >= 10)); // Noncompliant
         }
 
+        public void TestNullables()
+        {
+            int? a = 5;
+
+            bool b = !(a < 5); // Compliant
+            b = !(a <= 5); // Compliant
+            b = !(a > 5); // Compliant
+            b = !(a >= 5); // Compliant
+            b = !(a == 5); // Noncompliant
+            b = !(a != 5); // Noncompliant
+        }
+
         public static void SomeFunc(bool x) { }
 
         public static bool operator ==     (BooleanCheckInverted a, BooleanCheckInverted b)


### PR DESCRIPTION
Fix #297 