### PR TITLE
Update S2387, Rule S4025: "Child class fields shadowing parent fields…

### DIFF
--- a/sonaranalyzer-dotnet/rspec/cs/S2387_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S2387_c#.html
@@ -1,5 +1,5 @@
 <p>Having a variable with the same name in two unrelated classes is fine, but do the same thing within a class hierarchy and you'll get confusion at
-best, chaos at worst. Perhaps even worse is the case where a child class field varies from the name of a parent class only by case.</p>
+best, chaos at worst. </p>
 <h2>Noncompliant Code Example</h2>
 <pre>
 public class Fruit
@@ -33,7 +33,8 @@ public class Raspberry : Fruit
 }
 </pre>
 <h2>Exceptions</h2>
-<p>This rule ignores <code>private</code> parent class fields, but in all other such cases, the child class field should be renamed.</p>
+<p>This rule ignores same-name fields that are <code>static</code> in both the parent and child classes. It also ignores <code>private</code> parent
+class fields, but in all other such cases, the child class field should be renamed.</p>
 <pre>
 public class Fruit
 {

--- a/sonaranalyzer-dotnet/rspec/cs/S4025_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S4025_c#.html
@@ -1,0 +1,45 @@
+<p>Having a field in a child class with a name that differs from a parent class' field only by capitalization is sure to cause confusion. Such child
+class fields should be renamed.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+public class Fruit
+{
+  protected string plantingSeason;
+  //...
+}
+
+public class Raspberry : Fruit
+{
+  protected string plantingseason;  // Noncompliant
+  // ...
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+public class Fruit
+{
+  protected string plantingSeason;
+  //...
+}
+
+public class Raspberry : Fruit
+{
+  protected string whenToPlant;
+  // ...
+}
+</pre>
+<p>Or</p>
+<pre>
+public class Fruit
+{
+  protected string plantingSeason;
+  //...
+}
+
+public class Raspberry : Fruit
+{
+  // field removed; parent field will be used instead
+  // ...
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/rspec/cs/S4025_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S4025_c#.json
@@ -1,0 +1,13 @@
+{
+  "title": "Child class fields should not differ from parent class fields only be capitalization",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "pitfall"
+  ],
+  "defaultSeverity": "Critical"
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -3025,7 +3025,7 @@
     <value>Sonar Code Smell</value>
   </data>
   <data name="S2387_Description" xml:space="preserve">
-    <value>Having a variable with the same name in two unrelated classes is fine, but do the same thing within a class hierarchy and you'll get confusion at best, chaos at worst. Perhaps even worse is the case where a child class field varies from the name of a parent class only by case.</value>
+    <value>Having a variable with the same name in two unrelated classes is fine, but do the same thing within a class hierarchy and you'll get confusion at best, chaos at worst. </value>
   </data>
   <data name="S2387_IsActivatedByDefault" xml:space="preserve">
     <value>False</value>
@@ -6712,6 +6712,33 @@
     <value>Interfaces should not be empty</value>
   </data>
   <data name="S4023_Type" xml:space="preserve">
+    <value>CODE_SMELL</value>
+  </data>
+  <data name="S4025_Category" xml:space="preserve">
+    <value>Sonar Code Smell</value>
+  </data>
+  <data name="S4025_Description" xml:space="preserve">
+    <value>Having a field in a child class with a name that differs from a parent class' field only by capitalization is sure to cause confusion. Such child class fields should be renamed.</value>
+  </data>
+  <data name="S4025_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S4025_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S4025_RemediationCost" xml:space="preserve">
+    <value>5min</value>
+  </data>
+  <data name="S4025_Severity" xml:space="preserve">
+    <value>Critical</value>
+  </data>
+  <data name="S4025_Tags" xml:space="preserve">
+    <value>pitfall</value>
+  </data>
+  <data name="S4025_Title" xml:space="preserve">
+    <value>Child class fields should not differ from parent class fields only be capitalization</value>
+  </data>
+  <data name="S4025_Type" xml:space="preserve">
     <value>CODE_SMELL</value>
   </data>
   <data name="S4026_Category" xml:space="preserve">

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S2387.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S2387.html
@@ -1,5 +1,5 @@
 <p>Having a variable with the same name in two unrelated classes is fine, but do the same thing within a class hierarchy and you'll get confusion at
-best, chaos at worst. Perhaps even worse is the case where a child class field varies from the name of a parent class only by case.</p>
+best, chaos at worst. </p>
 <h2>Noncompliant Code Example</h2>
 <pre>
 public class Fruit
@@ -33,7 +33,8 @@ public class Raspberry : Fruit
 }
 </pre>
 <h2>Exceptions</h2>
-<p>This rule ignores <code>private</code> parent class fields, but in all other such cases, the child class field should be renamed.</p>
+<p>This rule ignores same-name fields that are <code>static</code> in both the parent and child classes. It also ignores <code>private</code> parent
+class fields, but in all other such cases, the child class field should be renamed.</p>
 <pre>
 public class Fruit
 {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S4025.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S4025.html
@@ -1,0 +1,45 @@
+<p>Having a field in a child class with a name that differs from a parent class' field only by capitalization is sure to cause confusion. Such child
+class fields should be renamed.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+public class Fruit
+{
+  protected string plantingSeason;
+  //...
+}
+
+public class Raspberry : Fruit
+{
+  protected string plantingseason;  // Noncompliant
+  // ...
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+public class Fruit
+{
+  protected string plantingSeason;
+  //...
+}
+
+public class Raspberry : Fruit
+{
+  protected string whenToPlant;
+  // ...
+}
+</pre>
+<p>Or</p>
+<pre>
+public class Fruit
+{
+  protected string plantingSeason;
+  //...
+}
+
+public class Raspberry : Fruit
+{
+  // field removed; parent field will be used instead
+  // ...
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTests.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTests.cs
@@ -4022,7 +4022,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
             ["4022"] = "CODE_SMELL",
             ["4023"] = "CODE_SMELL",
             //["4024"],
-            //["4025"],
+            ["4025"] = "CODE_SMELL",
             ["4026"] = "CODE_SMELL",
             ["4027"] = "CODE_SMELL",
             //["4028"],

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Rules/FieldShadowsParentFieldTest.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Rules/FieldShadowsParentFieldTest.cs
@@ -30,7 +30,16 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void FieldShadowsParentField()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\FieldShadowsParentField.cs", new FieldShadowsParentField());
+            Verifier.VerifyAnalyzer(@"TestCases\FieldShadowsParentField.cs",
+                new FieldShadowsParentField());
+        }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void FieldsShouldNotDifferByCapitalization()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\FieldsShouldNotDifferByCapitalization.cs",
+                new FieldShadowsParentField());
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/FieldShadowsParentField.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/FieldShadowsParentField.cs
@@ -5,17 +5,13 @@ namespace Tests.TestCases
     public class Fruit
     {
         protected int ripe;
-        protected int flesh;
-
-        // ...
-        private int flesh_color;
+        protected static int leafs;
     }
 
     public class Raspberry : Fruit
     {
         private bool ripe;  // Noncompliant {{'ripe' is the name of a field in 'Fruit'.}}
 //                   ^^^^
-        private static int FLESH; // Noncompliant {{'FLESH' differs only by case from 'flesh' in 'Fruit'.}}
-        private static int FLESH_COLOR;
+        protected static int leafs; // Compliant, static is ignored
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/FieldsShouldNotDifferByCapitalization.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/FieldsShouldNotDifferByCapitalization.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Tests.TestCases
+{
+    public class Fruit
+    {
+        protected int flesh;
+        private int flesh_color;
+    }
+
+    public class Raspberry : Fruit
+    {
+        private int fLeSh; // Noncompliant {{Rename this field; it may be confused with 'flesh' in 'Fruit'.}}
+        private static int FLESH; // Noncompliant {{Rename this field; it may be confused with 'flesh' in 'Fruit'.}}
+        private static int FLESH_COLOR; // Compliant, base class field is private
+    }
+}


### PR DESCRIPTION
…" should ignore "static" fields, field names that differ by case are handled by S4025