### PR TITLE
Fix Symbolic Execution: Invalid nameof() should be properly handled

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/SymbolicExecution/InvocationVisitor.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/SymbolicExecution/InvocationVisitor.cs
@@ -79,11 +79,14 @@ namespace SonarAnalyzer.Helpers.FlowAnalysis.Common
 
         private ProgramState HandleNameofExpression()
         {
-            SymbolicValue arg1;
-
-            var newProgramState = programState
-                .PopValue(out arg1)
-                .PopValue();
+            // First pop should handle nameof argument but if nameof is empty (invalid) there is only one item in the
+            // ExpressionStack (the nameof itself) so we don't want to pop the second time.
+            // NB: We decided not to stop the execution of the DataFlow Analysis.
+            var newProgramState = programState.PopValue();
+            if (!newProgramState.ExpressionStack.IsEmpty)
+            {
+                newProgramState = newProgramState.PopValue();
+            }
 
             var nameof = new SymbolicValue();
             newProgramState = newProgramState.PushValue(nameof);

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
@@ -525,6 +525,12 @@ namespace Tests.Diagnostics
         }
 
         void DoSomething() { }
+
+        void TestNameOf()
+        {
+            var x = $"{nameof()}";
+            x.ToString();
+        }
     }
 
     static class Extensions


### PR DESCRIPTION
Fix #423 