### PR TITLE
SonarC# fails when parsing xUnit test results with empty <assembly> tags

### DIFF
--- a/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResults.java
+++ b/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResults.java
@@ -51,7 +51,7 @@ public class UnitTestResults {
   }
 
   double passedPercentage() {
-    return passed * 100.0 / tests();
+    return tests != 0 ? (passed * 100.0 / tests) : 0;
   }
 
   public int skipped() {

--- a/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
+++ b/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
@@ -65,7 +65,7 @@ public class XUnitTestResultsFileParser implements UnitTestResultsParser {
 
     private void handleAssemblyTag(XmlParserHelper xmlParserHelper) {
       if (xmlParserHelper.stream().getAttributeCount() == 0) {
-        LOG.warn("One of the assembly contains no test result, please make sure this is expected.");
+        LOG.warn("One of the assemblies contains no test result, please make sure this is expected.");
         return;
       }
 

--- a/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
+++ b/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
@@ -64,6 +64,11 @@ public class XUnitTestResultsFileParser implements UnitTestResultsParser {
     }
 
     private void handleAssemblyTag(XmlParserHelper xmlParserHelper) {
+      if (xmlParserHelper.stream().getAttributeCount() == 0) {
+        LOG.warn("One of the assembly contains no test result, please make sure this is expected.");
+        return;
+      }
+
       int total = xmlParserHelper.getRequiredIntAttribute("total");
       int passed = xmlParserHelper.getRequiredIntAttribute("passed");
       int failed = xmlParserHelper.getRequiredIntAttribute("failed");

--- a/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParserTest.java
+++ b/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParserTest.java
@@ -22,6 +22,8 @@ package org.sonar.plugins.dotnet.tests;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LoggerLevel;
 
 import java.io.File;
 
@@ -32,6 +34,9 @@ public class XUnitTestResultsFileParserTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
+
+  @Rule
+  public LogTester logTester = new LogTester();
 
   @Test
   public void no_counters() {
@@ -95,4 +100,17 @@ public class XUnitTestResultsFileParserTest {
     assertThat(results.executionTime()).isNull();
   }
 
+  @Test
+  public void empty() {
+    UnitTestResults results = new UnitTestResults();
+    new XUnitTestResultsFileParser().accept(new File("src/test/resources/xunit/empty.xml"), results);
+
+    assertThat(logTester.logs(LoggerLevel.WARN)).contains("One of the assemblies contains no test result, please make sure this is expected.");
+    assertThat(results.tests()).isEqualTo(0);
+    assertThat(results.passedPercentage()).isEqualTo(0);
+    assertThat(results.skipped()).isEqualTo(0);
+    assertThat(results.failures()).isEqualTo(0);
+    assertThat(results.errors()).isEqualTo(0);
+    assertThat(results.executionTime()).isNull();
+  }
 }

--- a/sonar-dotnet-tests-library/src/test/resources/xunit/empty.xml
+++ b/sonar-dotnet-tests-library/src/test/resources/xunit/empty.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assemblies timestamp="06/19/2017 11:18:42">
+    <assembly />
+</assemblies>


### PR DESCRIPTION
Fix #406 