### PR TITLE
Fix S2386: Do not raise if the readonly field is initialized with a known immutable collection

### DIFF
--- a/sonaranalyzer-dotnet/rspec/cs/S2386_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S2386_c#.html
@@ -12,16 +12,21 @@ public class A
 }
 </pre>
 <h2>Exceptions</h2>
-<p>The issue won't raise if the type of the field inherits/implements one (at least) of the following types:</p>
+<p>No issue is reported:</p>
 <ul>
-  <li> <code>System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</code> </li>
-  <li> <code>System.Collections.ObjectModel.ReadOnlyDictionary&lt;TKey, TValue&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableArray&lt;T&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableDictionary&lt;TKey, TValue&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableList&lt;T&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableSet&lt;T&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableStack&lt;T&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableQueue&lt;T&gt;</code> </li>
+  <li> If the type of the field inherits/implements one (at least) of the following types:
+    <ul>
+      <li> <code>System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</code> </li>
+      <li> <code>System.Collections.ObjectModel.ReadOnlyDictionary&lt;TKey, TValue&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableArray&lt;T&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableDictionary&lt;TKey, TValue&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableList&lt;T&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableSet&lt;T&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableStack&lt;T&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableQueue&lt;T&gt;</code> </li>
+    </ul> </li>
+  <li> If the field is <code>readonly</code> and is initialized inline with an immutable type (i.e. inherits/implements one of the types in the
+  previous list). </li>
 </ul>
 <h2>See</h2>
 <ul>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MutableFieldsShouldNotBe.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MutableFieldsShouldNotBe.cs
@@ -98,15 +98,15 @@ namespace SonarAnalyzer.Rules
             var namedTypeSymbol = symbol as INamedTypeSymbol;
             if (namedTypeSymbol != null)
             {
-                return IsOrDerivesOrImplementsAny(namedTypeSymbol.ConstructedFrom, InvalidMutableTypes) &&
-                    !IsOrDerivesOrImplementsAny(namedTypeSymbol.ConstructedFrom, AllowedTypes);
+                return namedTypeSymbol.ConstructedFrom.DerivesOrImplementsAny(InvalidMutableTypes) &&
+                    !namedTypeSymbol.ConstructedFrom.DerivesOrImplementsAny(AllowedTypes);
             }
 
             var typeSymbol = symbol as ITypeSymbol;
             if (typeSymbol != null)
             {
-                return IsOrDerivesOrImplementsAny(typeSymbol, InvalidMutableTypes) &&
-                    !IsOrDerivesOrImplementsAny(typeSymbol, AllowedTypes);
+                return typeSymbol.DerivesOrImplementsAny(InvalidMutableTypes) &&
+                    !typeSymbol.DerivesOrImplementsAny(AllowedTypes);
             }
 
             return false;
@@ -114,24 +114,8 @@ namespace SonarAnalyzer.Rules
 
         private static bool IsValidReadOnlyInitializer(ISymbol symbol)
         {
-            if (symbol == null)
-            {
-                return false;
-            }
-
             var methodSymbol = symbol as IMethodSymbol;
-            if (methodSymbol != null)
-            {
-                return IsOrDerivesOrImplementsAny(methodSymbol.ReturnType, AllowedTypes);
-            }
-
-            return false;
-        }
-
-        private static bool IsOrDerivesOrImplementsAny(ITypeSymbol typeSymbol, ISet<KnownType> knownTypes)
-        {
-            return typeSymbol.IsAny(knownTypes) ||
-                typeSymbol.DerivesOrImplementsAny(knownTypes);
+            return methodSymbol != null && methodSymbol.ReturnType.DerivesOrImplementsAny(AllowedTypes);
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MutableFieldsShouldNotBePublicReadonly.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MutableFieldsShouldNotBePublicReadonly.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using System.Collections.Immutable;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MutableFieldsShouldNotBePublicStatic.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MutableFieldsShouldNotBePublicStatic.cs
@@ -19,14 +19,11 @@
  */
 
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using System.Collections.Immutable;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S2386.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S2386.html
@@ -12,16 +12,21 @@ public class A
 }
 </pre>
 <h2>Exceptions</h2>
-<p>The issue won't raise if the type of the field inherits/implements one (at least) of the following types:</p>
+<p>No issue is reported:</p>
 <ul>
-  <li> <code>System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</code> </li>
-  <li> <code>System.Collections.ObjectModel.ReadOnlyDictionary&lt;TKey, TValue&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableArray&lt;T&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableDictionary&lt;TKey, TValue&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableList&lt;T&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableSet&lt;T&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableStack&lt;T&gt;</code> </li>
-  <li> <code>System.Collections.Immutable.IImmutableQueue&lt;T&gt;</code> </li>
+  <li> If the type of the field inherits/implements one (at least) of the following types:
+    <ul>
+      <li> <code>System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</code> </li>
+      <li> <code>System.Collections.ObjectModel.ReadOnlyDictionary&lt;TKey, TValue&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableArray&lt;T&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableDictionary&lt;TKey, TValue&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableList&lt;T&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableSet&lt;T&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableStack&lt;T&gt;</code> </li>
+      <li> <code>System.Collections.Immutable.IImmutableQueue&lt;T&gt;</code> </li>
+    </ul> </li>
+  <li> If the field is <code>readonly</code> and is initialized inline with an immutable type (i.e. inherits/implements one of the types in the
+  previous list). </li>
 </ul>
 <h2>See</h2>
 <ul>

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MutableFieldsShouldNotBePublicReadonly.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MutableFieldsShouldNotBePublicReadonly.cs
@@ -28,6 +28,11 @@ namespace Tests.Diagnostics
         public readonly ImmutableArray<string> immutableArray; // Compliant
         public readonly ImmutableSortedSet<string> immutableSortedSet; // Compliant
         public static readonly ImmutableSortedSet<string> staticReadonlyImmutableSortedSet; // Compliant
+
+        public readonly ISet<string> iSetInitializaedWithImmutableSet = ImmutableHashSet.Create("a", "b");
+        public readonly IList<string> iListInitializaedWithImmutableArray = ImmutableArray.Create("a", "b");
+        public readonly IList<string> iListInitializaedWithImmutableList = ImmutableList.Create("a", "b");
+        public readonly IDictionary<string, string> iDictionaryInitializaedWithImmutableDictionary = ImmutableDictionary.Create<string, string>();
     }
 
     class GenericCompliantCases<T>
@@ -47,5 +52,9 @@ namespace Tests.Diagnostics
         public readonly SortedList<string, string> sortedListString; // Noncompliant
         public readonly ObservableCollection<string> observableCollectionString; // Noncompliant
         public readonly Foo foo; // Noncompliant
+
+        public readonly ISet<string> isetInitializaedWithHashSet = new HashSet<string> { "a", "b" }; // Noncompliant
+        public readonly IList<string> iListInitializaedWithList = new List<string> { "a", "b" }; // Noncompliant
+        public readonly IDictionary<string, string> iDictionaryInitializaedWithDictionary = new Dictionary<string, string>(); // Noncompliant
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MutableFieldsShouldNotBePublicStatic.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MutableFieldsShouldNotBePublicStatic.cs
@@ -10,6 +10,8 @@ namespace Tests.Diagnostics
 
     class CompliantCases<T>
     {
+        public int;
+
         protected static bool[] bools; // Compliant
         private static int[] ints; // Compliant
         internal static float[] floats; // Compliant
@@ -28,6 +30,8 @@ namespace Tests.Diagnostics
         public static ImmutableArray<string> immutableArray; // Compliant
         public static ImmutableSortedSet<string> immutableSortedSet; // Compliant
         public static readonly ImmutableSortedSet<string> staticReadonlyImmutableSortedSet; // Compliant
+
+        public static IImmutableList<string> iImmutableListWithInitialization = ImmutableList.Create("a", "b");
 
         public static readonly ISet<string> iSetInitializaedWithImmutableSet = ImmutableHashSet.Create("a", "b");
         public static readonly IList<string> iListInitializaedWithImmutableArray = ImmutableArray.Create("a", "b");

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MutableFieldsShouldNotBePublicStatic.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MutableFieldsShouldNotBePublicStatic.cs
@@ -28,6 +28,11 @@ namespace Tests.Diagnostics
         public static ImmutableArray<string> immutableArray; // Compliant
         public static ImmutableSortedSet<string> immutableSortedSet; // Compliant
         public static readonly ImmutableSortedSet<string> staticReadonlyImmutableSortedSet; // Compliant
+
+        public static readonly ISet<string> iSetInitializaedWithImmutableSet = ImmutableHashSet.Create("a", "b");
+        public static readonly IList<string> iListInitializaedWithImmutableArray = ImmutableArray.Create("a", "b");
+        public static readonly IList<string> iListInitializaedWithImmutableList = ImmutableList.Create("a", "b");
+        public static readonly IDictionary<string, string> iDictionaryInitializaedWithImmutableDictionary = ImmutableDictionary.Create<string, string>();
     }
 
     class GenericCompliantCases<T>
@@ -47,5 +52,14 @@ namespace Tests.Diagnostics
         public static SortedList<string, string> sortedListString; // Noncompliant
         public static ObservableCollection<string> observableCollectionString; // Noncompliant
         public static Foo foo; // Noncompliant
+
+        public static readonly ISet<string> isetInitializaedWithHashSet = new HashSet<string> { "a", "b" }; // Noncompliant
+        public static readonly IList<string> iListInitializaedWithList = new List<string> { "a", "b" }; // Noncompliant
+        public static readonly IDictionary<string, string> iDictionaryInitializaedWithDictionary = new Dictionary<string, string>(); // Noncompliant
+
+        public static ISet<string> iSetInitializaedWithImmutableSet = ImmutableHashSet.Create("a", "b"); // Noncompliant
+        public static IList<string> iListInitializaedWithImmutableArray = ImmutableArray.Create("a", "b"); // Noncompliant
+        public static IList<string> iListInitializaedWithImmutableList = ImmutableList.Create("a", "b"); // Noncompliant
+        public static IDictionary<string, string> iDictionaryInitializaedWithImmutableDictionary = ImmutableDictionary.Create<string, string>(); // Noncompliant
     }
 }


### PR DESCRIPTION
Fix #472 