### PR TITLE
Update S1479: "Switch with too many cases" should ignore empty, fall-…

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TooManyLabelsInSwitch.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TooManyLabelsInSwitch.cs
@@ -61,19 +61,13 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    var labels = NumberOfLabels(switchNode);
-
-                    if (labels > Maximum)
+                    var numberOfSections = switchNode.Sections.Count;
+                    if (numberOfSections > Maximum)
                     {
-                        c.ReportDiagnostic(Diagnostic.Create(rule, switchNode.SwitchKeyword.GetLocation(), Maximum, labels));
+                        c.ReportDiagnostic(Diagnostic.Create(rule, switchNode.SwitchKeyword.GetLocation(), Maximum, numberOfSections));
                     }
                 },
                 SyntaxKind.SwitchStatement);
-        }
-
-        private static int NumberOfLabels(SwitchStatementSyntax node)
-        {
-            return node.Sections.Sum(e => e.Labels.Count);
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/TooManyLabelsInSwitch.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/TooManyLabelsInSwitch.cs
@@ -20,8 +20,7 @@
                     break;
             }
 
-            switch (n) // Noncompliant {{Consider reworking this 'switch' to reduce the number of 'case' from 3 to at most 2.}}
-//          ^^^^^^
+            switch (n)
             {
                 case 0:
                 case 1:
@@ -39,6 +38,18 @@
                 case MyEnum.C:
                     break;
                 case MyEnum.D:
+                    break;
+                default:
+                    break;
+            }
+
+            switch (n) // Noncompliant {{Consider reworking this 'switch' to reduce the number of 'case' from 3 to at most 2.}}
+//          ^^^^^^
+            {
+                case 0:
+                case 1:
+                    break;
+                case 2:
                     break;
                 default:
                     break;


### PR DESCRIPTION
…through cases
Fix #388