### PR TITLE
Rule S4060: Non-abstract attributes should be sealed

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S4060.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S4060.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S4060",
+"message":  "Seal this attribute or make it abstract.",
+"location":  {
+"uri":  "Nancy\src\Nancy\Diagnostics\DescriptionAttribute.cs",
+"region":  {
+"startLine":  6,
+"startColumn":  18,
+"endLine":  6,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S4060",
+"message":  "Seal this attribute or make it abstract.",
+"location":  {
+"uri":  "Nancy\src\Nancy\Diagnostics\TemplateAttribute.cs",
+"region":  {
+"startLine":  6,
+"startColumn":  18,
+"endLine":  6,
+"endColumn":  35
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.CustomModule-{F56F3983-0C34-4AEC-B418-A8AFFA63F1C4}-S4060.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.CustomModule-{F56F3983-0C34-4AEC-B418-A8AFFA63F1C4}-S4060.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S4060",
+"message":  "Seal this attribute or make it abstract.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Demo.CustomModule\NancyRouteAttribute.cs",
+"region":  {
+"startLine":  5,
+"startColumn":  18,
+"endLine":  5,
+"endColumn":  37
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Validation-{F417B81C-B914-4BFD-8299-6BBD11072B01}-S4060.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Validation-{F417B81C-B914-4BFD-8299-6BBD11072B01}-S4060.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S4060",
+"message":  "Seal this attribute or make it abstract.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Demo.Validation\Models\OddLengthStringAttribute.cs",
+"region":  {
+"startLine":  5,
+"startColumn":  18,
+"endLine":  5,
+"endColumn":  42
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/rspec/cs/S4060_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S4060_c#.html
@@ -1,0 +1,54 @@
+<p>The .NET framework class library provides methods for retrieving custom attributes. Sealing the attribute eliminates the search through the
+inheritance hierarchy, and can improve performance.</p>
+<p>This rule raises an issue when a public type inherits from <code>System.Attribute</code>, is not abstract, and is not sealed.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+    [AttributeUsage(AttributeTargets.Class|AttributeTargets.Struct)]
+    public class MyAttribute: Attribute // Noncompliant
+    {
+        private string nameValue;
+        public MyAttribute(string name)
+        {
+            nameValue = name;
+        }
+
+        public string Name
+        {
+            get
+            {
+                return nameValue;
+            }
+        }
+    }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+    [AttributeUsage(AttributeTargets.Class|AttributeTargets.Struct)]
+    public sealed class MyAttribute: Attribute
+    {
+        private string nameValue;
+        public MyAttribute(string name)
+        {
+            nameValue = name;
+        }
+
+        public string Name
+        {
+            get
+            {
+                return nameValue;
+            }
+        }
+    }
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/rspec/cs/S4060_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S4060_c#.json
@@ -1,0 +1,13 @@
+{
+  "title": "Non-abstract attributes should be sealed",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "2min"
+  },
+  "tags": [
+    "performance"
+  ],
+  "defaultSeverity": "Minor"
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.Designer.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.Designer.cs
@@ -18493,6 +18493,87 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sonar Code Smell.
+        /// </summary>
+        internal static string S3972_Category {
+            get {
+                return ResourceManager.GetString("S3972_Category", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Code is clearest when each statement has its own line. Nonetheless, it is not uncommon to combine on the same line an if and it&apos;s resulting then statement. However, when an if is appended to the line with a previous if&apos;s closing } it is either an error - else is missing - or the prelude to a future error as maintainers fail to understand that the two statements are unconnected..
+        /// </summary>
+        internal static string S3972_Description {
+            get {
+                return ResourceManager.GetString("S3972_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to True.
+        /// </summary>
+        internal static string S3972_IsActivatedByDefault {
+            get {
+                return ResourceManager.GetString("S3972_IsActivatedByDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Constant/Issue.
+        /// </summary>
+        internal static string S3972_Remediation {
+            get {
+                return ResourceManager.GetString("S3972_Remediation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 10min.
+        /// </summary>
+        internal static string S3972_RemediationCost {
+            get {
+                return ResourceManager.GetString("S3972_RemediationCost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Critical.
+        /// </summary>
+        internal static string S3972_Severity {
+            get {
+                return ResourceManager.GetString("S3972_Severity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to suspicious.
+        /// </summary>
+        internal static string S3972_Tags {
+            get {
+                return ResourceManager.GetString("S3972_Tags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Conditionals should start on new lines.
+        /// </summary>
+        internal static string S3972_Title {
+            get {
+                return ResourceManager.GetString("S3972_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CODE_SMELL.
+        /// </summary>
+        internal static string S3972_Type {
+            get {
+                return ResourceManager.GetString("S3972_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sonar Bug.
         /// </summary>
         internal static string S3981_Category {
@@ -20739,6 +20820,87 @@ namespace SonarAnalyzer {
         internal static string S4041_Type {
             get {
                 return ResourceManager.GetString("S4041_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sonar Code Smell.
+        /// </summary>
+        internal static string S4060_Category {
+            get {
+                return ResourceManager.GetString("S4060_Category", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The .NET framework class library provides methods for retrieving custom attributes. Sealing the attribute eliminates the search through the inheritance hierarchy, and can improve performance..
+        /// </summary>
+        internal static string S4060_Description {
+            get {
+                return ResourceManager.GetString("S4060_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to False.
+        /// </summary>
+        internal static string S4060_IsActivatedByDefault {
+            get {
+                return ResourceManager.GetString("S4060_IsActivatedByDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Constant/Issue.
+        /// </summary>
+        internal static string S4060_Remediation {
+            get {
+                return ResourceManager.GetString("S4060_Remediation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 2min.
+        /// </summary>
+        internal static string S4060_RemediationCost {
+            get {
+                return ResourceManager.GetString("S4060_RemediationCost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minor.
+        /// </summary>
+        internal static string S4060_Severity {
+            get {
+                return ResourceManager.GetString("S4060_Severity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to performance.
+        /// </summary>
+        internal static string S4060_Tags {
+            get {
+                return ResourceManager.GetString("S4060_Tags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Non-abstract attributes should be sealed.
+        /// </summary>
+        internal static string S4060_Title {
+            get {
+                return ResourceManager.GetString("S4060_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CODE_SMELL.
+        /// </summary>
+        internal static string S4060_Type {
+            get {
+                return ResourceManager.GetString("S4060_Type", resourceCulture);
             }
         }
         

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -6268,7 +6268,7 @@
     <value>Code is clearest when each statement has its own line. Nonetheless, it is not uncommon to combine on the same line an if and it's resulting then statement. However, when an if is appended to the line with a previous if's closing } it is either an error - else is missing - or the prelude to a future error as maintainers fail to understand that the two statements are unconnected.</value>
   </data>
   <data name="S3972_IsActivatedByDefault" xml:space="preserve">
-    <value>False</value>
+    <value>True</value>
   </data>
   <data name="S3972_Remediation" xml:space="preserve">
     <value>Constant/Issue</value>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -6268,7 +6268,7 @@
     <value>Code is clearest when each statement has its own line. Nonetheless, it is not uncommon to combine on the same line an if and it's resulting then statement. However, when an if is appended to the line with a previous if's closing } it is either an error - else is missing - or the prelude to a future error as maintainers fail to understand that the two statements are unconnected.</value>
   </data>
   <data name="S3972_IsActivatedByDefault" xml:space="preserve">
-    <value>True</value>
+    <value>False</value>
   </data>
   <data name="S3972_Remediation" xml:space="preserve">
     <value>Constant/Issue</value>
@@ -7036,6 +7036,33 @@
     <value>Type names should not match namespaces</value>
   </data>
   <data name="S4041_Type" xml:space="preserve">
+    <value>CODE_SMELL</value>
+  </data>
+  <data name="S4060_Category" xml:space="preserve">
+    <value>Sonar Code Smell</value>
+  </data>
+  <data name="S4060_Description" xml:space="preserve">
+    <value>The .NET framework class library provides methods for retrieving custom attributes. Sealing the attribute eliminates the search through the inheritance hierarchy, and can improve performance.</value>
+  </data>
+  <data name="S4060_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S4060_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S4060_RemediationCost" xml:space="preserve">
+    <value>2min</value>
+  </data>
+  <data name="S4060_Severity" xml:space="preserve">
+    <value>Minor</value>
+  </data>
+  <data name="S4060_Tags" xml:space="preserve">
+    <value>performance</value>
+  </data>
+  <data name="S4060_Title" xml:space="preserve">
+    <value>Non-abstract attributes should be sealed</value>
+  </data>
+  <data name="S4060_Type" xml:space="preserve">
     <value>CODE_SMELL</value>
   </data>
   <data name="S4061_Category" xml:space="preserve">

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/AvoidUnsealedAttributes.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/AvoidUnsealedAttributes.cs
@@ -1,0 +1,69 @@
+/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2017 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(DiagnosticId)]
+    public sealed class AvoidUnsealedAttributes : SonarDiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "S4060";
+        private const string MessageFormat = "Seal this attribute or make it abstract.";
+
+        private static readonly DiagnosticDescriptor rule =
+            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionInNonGenerated(
+                c =>
+                {
+                    if (c.IsTest())
+                    {
+                        return;
+                    }
+
+                    var classDeclaration = (ClassDeclarationSyntax)c.Node;
+                    var classSymbol = c.SemanticModel.GetDeclaredSymbol(classDeclaration);
+
+                    if (classDeclaration.Identifier.IsMissing ||
+                        classSymbol == null ||
+                        !classSymbol.DerivesFrom(KnownType.System_Attribute) ||
+                        classSymbol.GetEffectiveAccessibility() != Accessibility.Public ||
+                        classSymbol.IsAbstract||
+                        classSymbol.IsSealed)
+                    {
+                        return;
+                    }
+
+                    c.ReportDiagnostic(Diagnostic.Create(rule, classDeclaration.Identifier.GetLocation()));
+                }, SyntaxKind.ClassDeclaration);
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/AvoidUnsealedAttributes.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/AvoidUnsealedAttributes.cs
@@ -52,17 +52,15 @@ namespace SonarAnalyzer.Rules.CSharp
                     var classDeclaration = (ClassDeclarationSyntax)c.Node;
                     var classSymbol = c.SemanticModel.GetDeclaredSymbol(classDeclaration);
 
-                    if (classDeclaration.Identifier.IsMissing ||
-                        classSymbol == null ||
-                        !classSymbol.DerivesFrom(KnownType.System_Attribute) ||
-                        classSymbol.GetEffectiveAccessibility() != Accessibility.Public ||
-                        classSymbol.IsAbstract||
-                        classSymbol.IsSealed)
+                    if (!classDeclaration.Identifier.IsMissing &&
+                        classSymbol != null &&
+                        classSymbol.DerivesFrom(KnownType.System_Attribute) &&
+                        classSymbol.IsPubliclyAccessible() &&
+                        !classSymbol.IsAbstract &&
+                        !classSymbol.IsSealed)
                     {
-                        return;
+                        c.ReportDiagnostic(Diagnostic.Create(rule, classDeclaration.Identifier.GetLocation()));
                     }
-
-                    c.ReportDiagnostic(Diagnostic.Create(rule, classDeclaration.Identifier.GetLocation()));
                 }, SyntaxKind.ClassDeclaration);
         }
     }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
@@ -254,6 +254,15 @@ namespace SonarAnalyzer.Helpers
             return result;
         }
 
+        public static bool IsPubliclyAccessible(this ISymbol symbol)
+        {
+            var effectiveAccessibility = GetEffectiveAccessibility(symbol);
+
+            return effectiveAccessibility == Accessibility.Public ||
+                effectiveAccessibility == Accessibility.Protected ||
+                effectiveAccessibility == Accessibility.ProtectedOrInternal;
+        }
+
         public static bool IsConstructor(this ISymbol symbol)
         {
             return symbol.Kind == SymbolKind.Method && symbol.Name == ".ctor";

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S4060.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S4060.html
@@ -1,0 +1,54 @@
+<p>The .NET framework class library provides methods for retrieving custom attributes. Sealing the attribute eliminates the search through the
+inheritance hierarchy, and can improve performance.</p>
+<p>This rule raises an issue when a public type inherits from <code>System.Attribute</code>, is not abstract, and is not sealed.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+    [AttributeUsage(AttributeTargets.Class|AttributeTargets.Struct)]
+    public class MyAttribute: Attribute // Noncompliant
+    {
+        private string nameValue;
+        public MyAttribute(string name)
+        {
+            nameValue = name;
+        }
+
+        public string Name
+        {
+            get
+            {
+                return nameValue;
+            }
+        }
+    }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System;
+
+namespace MyLibrary
+{
+    [AttributeUsage(AttributeTargets.Class|AttributeTargets.Struct)]
+    public sealed class MyAttribute: Attribute
+    {
+        private string nameValue;
+        public MyAttribute(string name)
+        {
+            nameValue = name;
+        }
+
+        public string Name
+        {
+            get
+            {
+                return nameValue;
+            }
+        }
+    }
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTests.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTests.cs
@@ -4057,7 +4057,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
             //["4057"],
             //["4058"],
             //["4059"],
-            //["4060"],
+            ["4060"] = "CODE_SMELL",
             ["4061"] = "CODE_SMELL",
             //["4062"],
             //["4063"],

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Rules/AvoidUnsealedAttributesTest.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Rules/AvoidUnsealedAttributesTest.cs
@@ -1,0 +1,37 @@
+/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2017 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Rules.CSharp;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class AvoidUnsealedAttributesTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void AvoidUnsealedAttributes()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\AvoidUnsealedAttributes.cs",
+                new AvoidUnsealedAttributes());
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.cs
@@ -7,13 +7,28 @@ namespace Tests.Diagnostics
     {
     }
 
-    private class Foo : Attribute // Compliant - private
-    { }
+    protected class MyOtherAttribute : Attribute // Noncompliant
+    {
+    }
+
+    protected internal class MyOtherAttribute2 : Attribute // Noncompliant
+    {
+    }
 
     public sealed class Bar : Attribute // Compliant - sealed
     { }
 
     public abstract class FooBar : Attribute // Compliant - abstract
     {
+    }
+
+    public sealed class Attr : Attribute
+    {
+        private class InnerAttr : Attribute // Compliant - private
+        {
+            public class InnerInnerAttr : Attribute // Compliant - effective accessibility is private
+            {
+            }
+        }
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Tests.Diagnostics
+{
+    public class MyAttribute : Attribute // Noncompliant {{Seal this attribute or make it abstract.}}
+//               ^^^^^^^^^^^
+    {
+    }
+
+    private class Foo : Attribute // Compliant - private
+    { }
+
+    public sealed class Bar : Attribute // Compliant - sealed
+    { }
+
+    public abstract class FooBar : Attribute // Compliant - abstract
+    {
+    }
+}


### PR DESCRIPTION
Fix #501