### PR TITLE
Update S927: C#: parameter names should match base declaration and other partial definitions

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S927.json
@@ -1,0 +1,69 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'pipelineItem' to 'syncDelegate'.",
+"location":  {
+"uri":  "Nancy\src\Nancy\AfterPipeline.cs",
+"region":  {
+"startLine":  68,
+"startColumn":  126,
+"endLine":  68,
+"endColumn":  138
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'pipelineItem' to 'syncDelegate'.",
+"location":  {
+"uri":  "Nancy\src\Nancy\BeforePipeline.cs",
+"region":  {
+"startLine":  71,
+"startColumn":  144,
+"endLine":  71,
+"endColumn":  156
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'container' to 'existingContainer'.",
+"location":  {
+"uri":  "Nancy\src\Nancy\DefaultNancyBootstrapper.cs",
+"region":  {
+"startLine":  56,
+"startColumn":  80,
+"endLine":  56,
+"endColumn":  89
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn'.",
+"location":  {
+"uri":  "Nancy\src\Nancy\DefaultNancyBootstrapper.cs",
+"region":  {
+"startLine":  131,
+"startColumn":  132,
+"endLine":  131,
+"endColumn":  159
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'compareValue' to 'obj'.",
+"location":  {
+"uri":  "Nancy\src\Nancy\DynamicDictionaryValue.cs",
+"region":  {
+"startLine":  170,
+"startColumn":  44,
+"endLine":  170,
+"endColumn":  56
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'pipelineItem' to 'syncDelegate'.",
+"message":  "Rename parameter 'pipelineItem' to 'syncDelegate' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy\AfterPipeline.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'pipelineItem' to 'syncDelegate'.",
+"message":  "Rename parameter 'pipelineItem' to 'syncDelegate' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy\BeforePipeline.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'container' to 'existingContainer'.",
+"message":  "Rename parameter 'container' to 'existingContainer' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy\DefaultNancyBootstrapper.cs",
 "region":  {
@@ -41,7 +41,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn'.",
+"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy\DefaultNancyBootstrapper.cs",
 "region":  {
@@ -54,7 +54,20 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'compareValue' to 'obj'.",
+"message":  "Rename parameter 'compareValue' to 'other' to match the interface declaration.",
+"location":  {
+"uri":  "Nancy\src\Nancy\DynamicDictionaryValue.cs",
+"region":  {
+"startLine":  155,
+"startColumn":  51,
+"endLine":  155,
+"endColumn":  63
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'compareValue' to 'obj' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy\DynamicDictionaryValue.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Authentication.Forms.Tests-{4E974051-38C2-4B5D-A6B1-F265A428A673}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Authentication.Forms.Tests-{4E974051-38C2-4B5D-A6B1-F265A428A673}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'existingContainer' to 'container'.",
+"message":  "Rename parameter 'existingContainer' to 'container' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Tests\Fakes\FakeDefaultNancyBootstrapper.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'existingContainer' to 'container'.",
+"message":  "Rename parameter 'existingContainer' to 'container' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Tests\Fakes\FakeDefaultNancyBootstrapper.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Authentication.Forms.Tests-{4E974051-38C2-4B5D-A6B1-F265A428A673}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Authentication.Forms.Tests-{4E974051-38C2-4B5D-A6B1-F265A428A673}-S927.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'existingContainer' to 'container'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Tests\Fakes\FakeDefaultNancyBootstrapper.cs",
+"region":  {
+"startLine":  74,
+"startColumn":  76,
+"endLine":  74,
+"endColumn":  93
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'existingContainer' to 'container'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Tests\Fakes\FakeDefaultNancyBootstrapper.cs",
+"region":  {
+"startLine":  97,
+"startColumn":  80,
+"endLine":  97,
+"endColumn":  97
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Authentication.Forms-{98940A30-1B48-4F71-A6BA-85F0AAF31A2F}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Authentication.Forms-{98940A30-1B48-4F71-A6BA-85F0AAF31A2F}-S927.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'requestContainer' to 'container'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Demo.Authentication.Forms\FormsAuthBootstrapper.cs",
+"region":  {
+"startLine":  25,
+"startColumn":  65,
+"endLine":  25,
+"endColumn":  81
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Authentication.Forms-{98940A30-1B48-4F71-A6BA-85F0AAF31A2F}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Authentication.Forms-{98940A30-1B48-4F71-A6BA-85F0AAF31A2F}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'requestContainer' to 'container'.",
+"message":  "Rename parameter 'requestContainer' to 'container' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Demo.Authentication.Forms\FormsAuthBootstrapper.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Authentication.Stateless-{BAE74CD5-57C2-40E3-8F7A-EDE5721C2ACC}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Authentication.Stateless-{BAE74CD5-57C2-40E3-8F7A-EDE5721C2ACC}-S927.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'requestContainer' to 'container'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Demo.Authentication.Stateless\StatelessAuthBootstrapper.cs",
+"region":  {
+"startLine":  9,
+"startColumn":  65,
+"endLine":  9,
+"endColumn":  81
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Authentication.Stateless-{BAE74CD5-57C2-40E3-8F7A-EDE5721C2ACC}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Authentication.Stateless-{BAE74CD5-57C2-40E3-8F7A-EDE5721C2ACC}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'requestContainer' to 'container'.",
+"message":  "Rename parameter 'requestContainer' to 'container' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Demo.Authentication.Stateless\StatelessAuthBootstrapper.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Hosting.Aspnet-{E127FED3-01C0-41BA-BF83-D8DCDD827D6A}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Hosting.Aspnet-{E127FED3-01C0-41BA-BF83-D8DCDD827D6A}-S927.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'existingContainer' to 'container'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Demo.Hosting.Aspnet\DemoBootstrapper.cs",
+"region":  {
+"startLine":  21,
+"startColumn":  80,
+"endLine":  21,
+"endColumn":  97
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'existingContainer' to 'container'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Demo.Hosting.Aspnet\DemoBootstrapper.cs",
+"region":  {
+"startLine":  50,
+"startColumn":  76,
+"endLine":  50,
+"endColumn":  93
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Hosting.Aspnet-{E127FED3-01C0-41BA-BF83-D8DCDD827D6A}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Hosting.Aspnet-{E127FED3-01C0-41BA-BF83-D8DCDD827D6A}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'existingContainer' to 'container'.",
+"message":  "Rename parameter 'existingContainer' to 'container' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Demo.Hosting.Aspnet\DemoBootstrapper.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'existingContainer' to 'container'.",
+"message":  "Rename parameter 'existingContainer' to 'container' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Demo.Hosting.Aspnet\DemoBootstrapper.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Aspnet-{15B7F794-0BB2-4B66-AD78-4A951F1209B2}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Aspnet-{15B7F794-0BB2-4B66-AD78-4A951F1209B2}-S927.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'container' to 'existingContainer'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Hosting.Aspnet\DefaultNancyAspNetBootstrapper.cs",
+"region":  {
+"startLine":  107,
+"startColumn":  80,
+"endLine":  107,
+"endColumn":  89
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Hosting.Aspnet\DefaultNancyAspNetBootstrapper.cs",
+"region":  {
+"startLine":  203,
+"startColumn":  132,
+"endLine":  203,
+"endColumn":  159
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Aspnet-{15B7F794-0BB2-4B66-AD78-4A951F1209B2}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Aspnet-{15B7F794-0BB2-4B66-AD78-4A951F1209B2}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'container' to 'existingContainer'.",
+"message":  "Rename parameter 'container' to 'existingContainer' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Hosting.Aspnet\DefaultNancyAspNetBootstrapper.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn'.",
+"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Hosting.Aspnet\DefaultNancyAspNetBootstrapper.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing-{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing-{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}-S927.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'container' to 'existingContainer'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Testing\ConfigurableBootstrapper.cs",
+"region":  {
+"startLine":  370,
+"startColumn":  80,
+"endLine":  370,
+"endColumn":  89
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Testing\ConfigurableBootstrapper.cs",
+"region":  {
+"startLine":  523,
+"startColumn":  125,
+"endLine":  523,
+"endColumn":  152
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing-{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing-{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}-S927.json
@@ -2,7 +2,46 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'container' to 'existingContainer'.",
+"message":  "Rename parameter 'expected' to 'x' to match the interface declaration.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Testing\AssertEqualityComparer.cs",
+"region":  {
+"startLine":  13,
+"startColumn":  30,
+"endLine":  13,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'actual' to 'y' to match the interface declaration.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Testing\AssertEqualityComparer.cs",
+"region":  {
+"startLine":  13,
+"startColumn":  42,
+"endLine":  13,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'actual' to 'obj' to match the interface declaration.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Testing\AssertEqualityComparer.cs",
+"region":  {
+"startLine":  53,
+"startColumn":  34,
+"endLine":  53,
+"endColumn":  40
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'container' to 'existingContainer' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Testing\ConfigurableBootstrapper.cs",
 "region":  {
@@ -15,7 +54,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn'.",
+"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Testing\ConfigurableBootstrapper.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing.Tests-{8EB9E15A-4B65-4C80-B834-9A7773750666}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing.Tests-{8EB9E15A-4B65-4C80-B834-9A7773750666}-S927.json
@@ -1,0 +1,43 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'expected' to 'other' to match the interface declaration.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Testing.Tests\AssertEqualityComparerFixture.cs",
+"region":  {
+"startLine":  152,
+"startColumn":  47,
+"endLine":  152,
+"endColumn":  55
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'comparable' to 'other' to match the interface declaration.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Testing.Tests\AssertEqualityComparerFixture.cs",
+"region":  {
+"startLine":  175,
+"startColumn":  58,
+"endLine":  175,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'comparable' to 'obj' to match the interface declaration.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Testing.Tests\AssertEqualityComparerFixture.cs",
+"region":  {
+"startLine":  198,
+"startColumn":  41,
+"endLine":  198,
+"endColumn":  51
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests-{776D244D-BC4D-4BBB-A478-CAF2D04520E1}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests-{776D244D-BC4D-4BBB-A478-CAF2D04520E1}-S927.json
@@ -1,0 +1,56 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'existingContainer' to 'container'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Tests\Fakes\FakeDefaultNancyBootstrapper.cs",
+"region":  {
+"startLine":  74,
+"startColumn":  76,
+"endLine":  74,
+"endColumn":  93
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'existingContainer' to 'container'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Tests\Fakes\FakeDefaultNancyBootstrapper.cs",
+"region":  {
+"startLine":  97,
+"startColumn":  80,
+"endLine":  97,
+"endColumn":  97
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Tests\Unit\Bootstrapper\NancyBootstrapperBaseFixture.cs",
+"region":  {
+"startLine":  433,
+"startColumn":  122,
+"endLine":  433,
+"endColumn":  149
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Tests\Unit\Bootstrapper\NancyBootstrapperWithRequestContainerBaseFixture.cs",
+"region":  {
+"startLine":  345,
+"startColumn":  57,
+"endLine":  345,
+"endColumn":  84
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests-{776D244D-BC4D-4BBB-A478-CAF2D04520E1}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests-{776D244D-BC4D-4BBB-A478-CAF2D04520E1}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'existingContainer' to 'container'.",
+"message":  "Rename parameter 'existingContainer' to 'container' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Tests\Fakes\FakeDefaultNancyBootstrapper.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'existingContainer' to 'container'.",
+"message":  "Rename parameter 'existingContainer' to 'container' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Tests\Fakes\FakeDefaultNancyBootstrapper.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn'.",
+"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Tests\Unit\Bootstrapper\NancyBootstrapperBaseFixture.cs",
 "region":  {
@@ -41,7 +41,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn'.",
+"message":  "Rename parameter 'collectionTypeRegistrations' to 'collectionTypeRegistrationsn' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.Tests\Unit\Bootstrapper\NancyBootstrapperWithRequestContainerBaseFixture.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Validation.DataAnnotations-{701765DC-F4F2-4943-A37F-6ED253198158}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Validation.DataAnnotations-{701765DC-F4F2-4943-A37F-6ED253198158}-S927.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'context1' to 'context' to match the interface declaration.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Validation.DataAnnotations\DefaultValidatableObjectAdapter.cs",
+"region":  {
+"startLine":  18,
+"startColumn":  89,
+"endLine":  18,
+"endColumn":  97
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.DotLiquid-{B795886D-9D70-45B1-BFB5-AD54CBC9A447}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.DotLiquid-{B795886D-9D70-45B1-BFB5-AD54CBC9A447}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'propertyName' to 'method'.",
+"message":  "Rename parameter 'propertyName' to 'method' to match the base class declaration.",
 "location":  {
 "uri":  "Nancy\src\Nancy.ViewEngines.DotLiquid\DynamicDrop.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.DotLiquid-{B795886D-9D70-45B1-BFB5-AD54CBC9A447}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.DotLiquid-{B795886D-9D70-45B1-BFB5-AD54CBC9A447}-S927.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'propertyName' to 'method'.",
+"location":  {
+"uri":  "Nancy\src\Nancy.ViewEngines.DotLiquid\DynamicDrop.cs",
+"region":  {
+"startLine":  22,
+"startColumn":  52,
+"endLine":  22,
+"endColumn":  64
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S927.json
@@ -1,0 +1,95 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'channel' to 'classifier'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Event\EventStream.cs",
+"region":  {
+"startLine":  53,
+"startColumn":  67,
+"endLine":  53,
+"endColumn":  74
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'channel' to 'classifier'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Event\EventStream.cs",
+"region":  {
+"startLine":  73,
+"startColumn":  69,
+"endLine":  73,
+"endColumn":  76
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'm' to 'message'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\IO\TcpManager.cs",
+"region":  {
+"startLine":  62,
+"startColumn":  48,
+"endLine":  62,
+"endColumn":  49
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 's' to 'ds'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\IO\Udp.cs",
+"region":  {
+"startLine":  280,
+"startColumn":  64,
+"endLine":  280,
+"endColumn":  65
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'm' to 'message'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\IO\UdpConnectedManager.cs",
+"region":  {
+"startLine":  24,
+"startColumn":  48,
+"endLine":  24,
+"endColumn":  49
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'm' to 'message'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\IO\UdpManager.cs",
+"region":  {
+"startLine":  62,
+"startColumn":  48,
+"endLine":  62,
+"endColumn":  49
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'cause' to 'reason'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Routing\RouterActor.cs",
+"region":  {
+"startLine":  33,
+"startColumn":  54,
+"endLine":  33,
+"endColumn":  59
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S927.json
@@ -2,7 +2,98 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'channel' to 'classifier'.",
+"message":  "Rename parameter 'path' to 'actorPath' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\ActorCell.cs",
+"region":  {
+"startLine":  140,
+"startColumn":  53,
+"endLine":  140,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'path' to 'actorPath' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\ActorCell.cs",
+"region":  {
+"startLine":  145,
+"startColumn":  56,
+"endLine":  145,
+"endColumn":  60
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'path' to 'actorPath' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\ActorRefProvider.cs",
+"region":  {
+"startLine":  307,
+"startColumn":  52,
+"endLine":  307,
+"endColumn":  56
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'childRestartStats' to 'stats' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\ChildrenContainer\Internal\ChildrenContainerBase.cs",
+"region":  {
+"startLine":  63,
+"startColumn":  72,
+"endLine":  63,
+"endColumn":  89
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'childRestartStats' to 'stats' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\ChildrenContainer\Internal\EmptyChildrenContainer.cs",
+"region":  {
+"startLine":  45,
+"startColumn":  72,
+"endLine":  45,
+"endColumn":  89
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'actorRef' to 'target' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\Inbox.cs",
+"region":  {
+"startLine":  284,
+"startColumn":  36,
+"endLine":  284,
+"endColumn":  44
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'msg' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\Inbox.cs",
+"region":  {
+"startLine":  284,
+"startColumn":  53,
+"endLine":  284,
+"endColumn":  56
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'channel' to 'classifier' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka\Event\EventStream.cs",
 "region":  {
@@ -15,7 +106,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'channel' to 'classifier'.",
+"message":  "Rename parameter 'channel' to 'classifier' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka\Event\EventStream.cs",
 "region":  {
@@ -28,7 +119,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'm' to 'message'.",
+"message":  "Rename parameter 'm' to 'message' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka\IO\TcpManager.cs",
 "region":  {
@@ -41,7 +132,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 's' to 'ds'.",
+"message":  "Rename parameter 's' to 'ds' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka\IO\Udp.cs",
 "region":  {
@@ -54,7 +145,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'm' to 'message'.",
+"message":  "Rename parameter 'm' to 'message' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka\IO\UdpConnectedManager.cs",
 "region":  {
@@ -67,7 +158,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'm' to 'message'.",
+"message":  "Rename parameter 'm' to 'message' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka\IO\UdpManager.cs",
 "region":  {
@@ -80,7 +171,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'cause' to 'reason'.",
+"message":  "Rename parameter 'cause' to 'reason' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka\Routing\RouterActor.cs",
 "region":  {
@@ -88,6 +179,227 @@
 "startColumn":  54,
 "endLine":  33,
 "endColumn":  59
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'newTreeMap' to 'newMap' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\Internal\Collections\ImmutableAvlTreeMap.cs",
+"region":  {
+"startLine":  23,
+"startColumn":  99,
+"endLine":  23,
+"endColumn":  109
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'newSet' to 'newMap' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\Internal\Collections\ImmutableTreeSet.cs",
+"region":  {
+"startLine":  25,
+"startColumn":  77,
+"endLine":  25,
+"endColumn":  83
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  32,
+"startColumn":  30,
+"endLine":  32,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  45,
+"startColumn":  30,
+"endLine":  45,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  59,
+"startColumn":  30,
+"endLine":  59,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  75,
+"startColumn":  30,
+"endLine":  75,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  93,
+"startColumn":  30,
+"endLine":  93,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  113,
+"startColumn":  30,
+"endLine":  113,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  135,
+"startColumn":  30,
+"endLine":  135,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  159,
+"startColumn":  30,
+"endLine":  159,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  185,
+"startColumn":  30,
+"endLine":  185,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  213,
+"startColumn":  30,
+"endLine":  213,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  243,
+"startColumn":  30,
+"endLine":  243,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  275,
+"startColumn":  30,
+"endLine":  275,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  309,
+"startColumn":  30,
+"endLine":  309,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  345,
+"startColumn":  30,
+"endLine":  345,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'value' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs",
+"region":  {
+"startLine":  383,
+"startColumn":  30,
+"endLine":  383,
+"endColumn":  35
 }
 }
 }

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster-{6AB00F61-269A-4501-B06A-026707F000A7}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster-{6AB00F61-269A-4501-B06A-026707F000A7}-S927.json
@@ -1,0 +1,43 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'a' to 'x' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Cluster\Member.cs",
+"region":  {
+"startLine":  147,
+"startColumn":  39,
+"endLine":  147,
+"endColumn":  40
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'b' to 'y' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Cluster\Member.cs",
+"region":  {
+"startLine":  147,
+"startColumn":  49,
+"endLine":  147,
+"endColumn":  50
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'that' to 'other' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Cluster\Member.cs",
+"region":  {
+"startLine":  271,
+"startColumn":  44,
+"endLine":  271,
+"endColumn":  48
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster.Tools-{5CF8A8BE-B634-473F-BB01-EBA878746BD4}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster.Tools-{5CF8A8BE-B634-473F-BB01-EBA878746BD4}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'o' to 'obj'.",
+"message":  "Rename parameter 'o' to 'obj' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\contrib\cluster\Akka.Cluster.Tools\Client\Serialization\ClusterClientMessageSerializer.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'bytes' to 'binary'.",
+"message":  "Rename parameter 'bytes' to 'binary' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\contrib\cluster\Akka.Cluster.Tools\PublishSubscribe\Serialization\DistributedPubSubMessageSerializer.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'manifestString' to 'manifest'.",
+"message":  "Rename parameter 'manifestString' to 'manifest' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\contrib\cluster\Akka.Cluster.Tools\PublishSubscribe\Serialization\DistributedPubSubMessageSerializer.cs",
 "region":  {
@@ -41,7 +41,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'o' to 'obj'.",
+"message":  "Rename parameter 'o' to 'obj' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\contrib\cluster\Akka.Cluster.Tools\Singleton\Serialization\ClusterSingletonMessageSerializer.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster.Tools-{5CF8A8BE-B634-473F-BB01-EBA878746BD4}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster.Tools-{5CF8A8BE-B634-473F-BB01-EBA878746BD4}-S927.json
@@ -1,0 +1,56 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'o' to 'obj'.",
+"location":  {
+"uri":  "akka.net\src\contrib\cluster\Akka.Cluster.Tools\Client\Serialization\ClusterClientMessageSerializer.cs",
+"region":  {
+"startLine":  33,
+"startColumn":  48,
+"endLine":  33,
+"endColumn":  49
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'bytes' to 'binary'.",
+"location":  {
+"uri":  "akka.net\src\contrib\cluster\Akka.Cluster.Tools\PublishSubscribe\Serialization\DistributedPubSubMessageSerializer.cs",
+"region":  {
+"startLine":  67,
+"startColumn":  50,
+"endLine":  67,
+"endColumn":  55
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'manifestString' to 'manifest'.",
+"location":  {
+"uri":  "akka.net\src\contrib\cluster\Akka.Cluster.Tools\PublishSubscribe\Serialization\DistributedPubSubMessageSerializer.cs",
+"region":  {
+"startLine":  67,
+"startColumn":  64,
+"endLine":  67,
+"endColumn":  78
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'o' to 'obj'.",
+"location":  {
+"uri":  "akka.net\src\contrib\cluster\Akka.Cluster.Tools\Singleton\Serialization\ClusterSingletonMessageSerializer.cs",
+"region":  {
+"startLine":  39,
+"startColumn":  48,
+"endLine":  39,
+"endColumn":  49
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared-{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared-{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'logMessage' to 'logMessageFragment'.",
+"message":  "Rename parameter 'logMessage' to 'logMessageFragment' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\TestCoordinatorEnabledMessageSink.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared-{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared-{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}-S927.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'logMessage' to 'logMessageFragment'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\TestCoordinatorEnabledMessageSink.cs",
+"region":  {
+"startLine":  71,
+"startColumn":  85,
+"endLine":  71,
+"endColumn":  95
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.NodeTestRunner-{28520F30-2868-4BD3-9CAE-AC27226C24E3}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.NodeTestRunner-{28520F30-2868-4BD3-9CAE-AC27226C24E3}-S927.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'discovery' to 'testCaseDiscovered'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.NodeTestRunner\Discovery.cs",
+"region":  {
+"startLine":  30,
+"startColumn":  65,
+"endLine":  30,
+"endColumn":  74
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.NodeTestRunner-{28520F30-2868-4BD3-9CAE-AC27226C24E3}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.NodeTestRunner-{28520F30-2868-4BD3-9CAE-AC27226C24E3}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'discovery' to 'testCaseDiscovered'.",
+"message":  "Rename parameter 'discovery' to 'testCaseDiscovered' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka.NodeTestRunner\Discovery.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote-{EA4FF8FD-7C53-49C8-B9AA-02E458B3E6A7}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote-{EA4FF8FD-7C53-49C8-B9AA-02E458B3E6A7}-S927.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'payload' to 'data' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Remote\Transport\Helios\HeliosHelpers.cs",
+"region":  {
+"startLine":  139,
+"startColumn":  38,
+"endLine":  139,
+"endColumn":  45
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.TestKit-{0D3CBAD0-BBDB-43E5-AFC4-ED1D3ECDC224}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.TestKit-{0D3CBAD0-BBDB-43E5-AFC4-ED1D3ECDC224}-S927.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'path' to 's' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.TestKit\EventFilter\Internal\StringMatcher\EqualsStringAndPathMatcher.cs",
+"region":  {
+"startLine":  27,
+"startColumn":  36,
+"endLine":  27,
+"endColumn":  40
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.TestKit.Tests-{D2BED2D5-B152-48C1-9818-1097BECDDF98}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.TestKit.Tests-{D2BED2D5-B152-48C1-9818-1097BECDDF98}-S927.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'm' to 'logEvent'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.TestKit.Tests\TestEventListenerTests\ForwardAllEventsTestEventListener.cs",
+"region":  {
+"startLine":  18,
+"startColumn":  48,
+"endLine":  18,
+"endColumn":  49
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.TestKit.Tests-{D2BED2D5-B152-48C1-9818-1097BECDDF98}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.TestKit.Tests-{D2BED2D5-B152-48C1-9818-1097BECDDF98}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'm' to 'logEvent'.",
+"message":  "Rename parameter 'm' to 'logEvent' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka.TestKit.Tests\TestEventListenerTests\ForwardAllEventsTestEventListener.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Tests-{3F786C7D-70E3-4836-8B33-EC9A5AF72330}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Tests-{3F786C7D-70E3-4836-8B33-EC9A5AF72330}-S927.json
@@ -1,0 +1,95 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'cause' to 'reason'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Tests\Actor\ActorLifeCycleSpec.cs",
+"region":  {
+"startLine":  60,
+"startColumn":  58,
+"endLine":  60,
+"endColumn":  63
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'cause' to 'reason'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Tests\Actor\ActorLifeCycleSpec.cs",
+"region":  {
+"startLine":  65,
+"startColumn":  59,
+"endLine":  65,
+"endColumn":  64
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'cause' to 'reason'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Tests\Actor\ActorLifeCycleSpec.cs",
+"region":  {
+"startLine":  222,
+"startColumn":  58,
+"endLine":  222,
+"endColumn":  63
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'cause' to 'reason'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Tests\Actor\ActorLifeCycleSpec.cs",
+"region":  {
+"startLine":  227,
+"startColumn":  59,
+"endLine":  227,
+"endColumn":  64
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'evt' to 'event'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Tests\Event\EventBusSpec.cs",
+"region":  {
+"startLine":  29,
+"startColumn":  48,
+"endLine":  29,
+"endColumn":  51
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'evt' to 'event'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Tests\Event\EventBusSpec.cs",
+"region":  {
+"startLine":  34,
+"startColumn":  49,
+"endLine":  34,
+"endColumn":  52
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'cause' to 'reason'.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Tests\TestUtils\Supervisor.cs",
+"region":  {
+"startLine":  47,
+"startColumn":  54,
+"endLine":  47,
+"endColumn":  59
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Tests-{3F786C7D-70E3-4836-8B33-EC9A5AF72330}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Tests-{3F786C7D-70E3-4836-8B33-EC9A5AF72330}-S927.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'cause' to 'reason'.",
+"message":  "Rename parameter 'cause' to 'reason' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka.Tests\Actor\ActorLifeCycleSpec.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'cause' to 'reason'.",
+"message":  "Rename parameter 'cause' to 'reason' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka.Tests\Actor\ActorLifeCycleSpec.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'cause' to 'reason'.",
+"message":  "Rename parameter 'cause' to 'reason' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka.Tests\Actor\ActorLifeCycleSpec.cs",
 "region":  {
@@ -41,7 +41,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'cause' to 'reason'.",
+"message":  "Rename parameter 'cause' to 'reason' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka.Tests\Actor\ActorLifeCycleSpec.cs",
 "region":  {
@@ -54,7 +54,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'evt' to 'event'.",
+"message":  "Rename parameter 'evt' to 'event' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka.Tests\Event\EventBusSpec.cs",
 "region":  {
@@ -67,7 +67,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'evt' to 'event'.",
+"message":  "Rename parameter 'evt' to 'event' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka.Tests\Event\EventBusSpec.cs",
 "region":  {
@@ -80,7 +80,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'cause' to 'reason'.",
+"message":  "Rename parameter 'cause' to 'reason' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\core\Akka.Tests\TestUtils\Supervisor.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/its/expected/akka.net/SymbolLookup-{3007A692-A050-4F12-9187-4AE6C6106A66}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/SymbolLookup-{3007A692-A050-4F12-9187-4AE6C6106A66}-S927.json
@@ -1,0 +1,56 @@
+{
+"issues":  [
+{
+"id":  "S927",
+"message":  "Rename parameter 'cause' to 'reason'.",
+"location":  {
+"uri":  "akka.net\src\examples\Stocks\SymbolLookup\Actors\TickerActors.cs",
+"region":  {
+"startLine":  69,
+"startColumn":  54,
+"endLine":  69,
+"endColumn":  59
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'msg' to 'message'.",
+"location":  {
+"uri":  "akka.net\src\examples\Stocks\SymbolLookup\Actors\TickerActors.cs",
+"region":  {
+"startLine":  74,
+"startColumn":  50,
+"endLine":  74,
+"endColumn":  53
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'cause' to 'reason'.",
+"location":  {
+"uri":  "akka.net\src\examples\Stocks\SymbolLookup\Actors\TickerActors.cs",
+"region":  {
+"startLine":  97,
+"startColumn":  54,
+"endLine":  97,
+"endColumn":  59
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'msg' to 'message'.",
+"location":  {
+"uri":  "akka.net\src\examples\Stocks\SymbolLookup\Actors\TickerActors.cs",
+"region":  {
+"startLine":  102,
+"startColumn":  50,
+"endLine":  102,
+"endColumn":  53
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/SymbolLookup-{3007A692-A050-4F12-9187-4AE6C6106A66}-S927.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/SymbolLookup-{3007A692-A050-4F12-9187-4AE6C6106A66}-S927.json
@@ -2,7 +2,33 @@
 "issues":  [
 {
 "id":  "S927",
-"message":  "Rename parameter 'cause' to 'reason'.",
+"message":  "Rename parameter 'sd' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\examples\Stocks\SymbolLookup\Actors\DispatcherActor.cs",
+"region":  {
+"startLine":  45,
+"startColumn":  42,
+"endLine":  45,
+"endColumn":  44
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'fail' to 'message' to match the interface declaration.",
+"location":  {
+"uri":  "akka.net\src\examples\Stocks\SymbolLookup\Actors\DispatcherActor.cs",
+"region":  {
+"startLine":  52,
+"startColumn":  36,
+"endLine":  52,
+"endColumn":  40
+}
+}
+},
+{
+"id":  "S927",
+"message":  "Rename parameter 'cause' to 'reason' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\examples\Stocks\SymbolLookup\Actors\TickerActors.cs",
 "region":  {
@@ -15,7 +41,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'msg' to 'message'.",
+"message":  "Rename parameter 'msg' to 'message' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\examples\Stocks\SymbolLookup\Actors\TickerActors.cs",
 "region":  {
@@ -28,7 +54,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'cause' to 'reason'.",
+"message":  "Rename parameter 'cause' to 'reason' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\examples\Stocks\SymbolLookup\Actors\TickerActors.cs",
 "region":  {
@@ -41,7 +67,7 @@
 },
 {
 "id":  "S927",
-"message":  "Rename parameter 'msg' to 'message'.",
+"message":  "Rename parameter 'msg' to 'message' to match the base class declaration.",
 "location":  {
 "uri":  "akka.net\src\examples\Stocks\SymbolLookup\Actors\TickerActors.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/ParameterNamesInPartialMethod.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/ParameterNamesInPartialMethod.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -28,6 +29,41 @@ namespace Tests.Diagnostics
 //                                    ^^^^^^^^^
         {
 
+        }
+    }
+
+    public abstract class BaseClass
+    {
+        public virtual void DoSomethingVirtual(int x, int y)
+        {
+        }
+
+        public abstract void DoSomethingAbstract(int x, int y);
+    }
+
+    public class ChildClass : BaseClass
+    {
+        public override void DoSomethingAbstract(int x, int someParam) //Noncompliant {{Rename parameter 'someParam' to 'y'.}}
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DoSomethingVirtual(int x, int someParam) //Noncompliant {{Rename parameter 'someParam' to 'y'.}}
+        {
+            base.DoSomethingVirtual(x, y);
+        }
+    }
+
+    public abstract class ChildClassLevel2 : ChildClass
+    {
+        public override void DoSomethingAbstract(int x, int y) //Noncompliant {{Rename parameter 'y' to 'someParam'.}}
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DoSomethingVirtual(int x, int y) //Noncompliant {{Rename parameter 'y' to 'someParam'.}}
+        {
+            base.DoSomethingVirtual(x, y);
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/ParameterNamesInPartialMethod.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/ParameterNamesInPartialMethod.cs
@@ -14,7 +14,6 @@ namespace Tests.Diagnostics
 
         public void DoSomething4(int x, int y)
         {
-
         }
     }
 
@@ -25,11 +24,13 @@ namespace Tests.Diagnostics
 
         }
 
-        partial void DoSomething2(int someParam, int y) //Noncompliant {{Rename parameter 'someParam' to 'x'.}}
+        partial void DoSomething2(int someParam, int y) //Noncompliant {{Rename parameter 'someParam' to 'x' to match the partial class declaration.}}
 //                                    ^^^^^^^^^
         {
 
         }
+
+        partial void DoSomething3(int x, int y, int z);
     }
 
     public abstract class BaseClass
@@ -43,12 +44,12 @@ namespace Tests.Diagnostics
 
     public class ChildClass : BaseClass
     {
-        public override void DoSomethingAbstract(int x, int someParam) //Noncompliant {{Rename parameter 'someParam' to 'y'.}}
+        public override void DoSomethingAbstract(int x, int someParam) //Noncompliant {{Rename parameter 'someParam' to 'y' to match the base class declaration.}}
         {
             throw new NotImplementedException();
         }
 
-        public override void DoSomethingVirtual(int x, int someParam) //Noncompliant {{Rename parameter 'someParam' to 'y'.}}
+        public override void DoSomethingVirtual(int x, int someParam) //Noncompliant {{Rename parameter 'someParam' to 'y' to match the base class declaration.}}
         {
             base.DoSomethingVirtual(x, y);
         }
@@ -56,14 +57,22 @@ namespace Tests.Diagnostics
 
     public abstract class ChildClassLevel2 : ChildClass
     {
-        public override void DoSomethingAbstract(int x, int y) //Noncompliant {{Rename parameter 'y' to 'someParam'.}}
+        public override void DoSomethingAbstract(int x, int y) //Noncompliant {{Rename parameter 'y' to 'someParam' to match the base class declaration.}}
         {
             throw new NotImplementedException();
         }
 
-        public override void DoSomethingVirtual(int x, int y) //Noncompliant {{Rename parameter 'y' to 'someParam'.}}
+        public override void DoSomethingVirtual(int x, int y) //Noncompliant {{Rename parameter 'y' to 'someParam' to match the base class declaration.}}
         {
             base.DoSomethingVirtual(x, y);
+        }
+    }
+
+    public class InterfaceImplementation : IComparer<InterfaceImplementation>
+    {
+        public int Compare(InterfaceImplementation a, InterfaceImplementation y) //Noncompliant {{Rename parameter 'a' to 'x' to match the interface declaration.}}
+        {
+            return 0;
         }
     }
 }


### PR DESCRIPTION
Fix #516 