### PR TITLE
Rule S3956: "Generic.List" instances should not be part of public APIs

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Ember-MM/Ember.Plugins-{9496C697-5AFD-4813-AEDC-AF33FACEADF0}-S3956.json
+++ b/sonaranalyzer-dotnet/its/expected/Ember-MM/Ember.Plugins-{9496C697-5AFD-4813-AEDC-AF33FACEADF0}-S3956.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3956",
+"message":  "Refactor this property to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "Ember-MM\Ember.Plugins\PluginManager.cs",
+"region":  {
+"startLine":  41,
+"startColumn":  16,
+"endLine":  41,
+"endColumn":  47
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S3956.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S3956.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S3956",
+"message":  "Refactor this field to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "Nancy\src\Nancy\AsyncNamedPipelineBase.cs",
+"region":  {
+"startLine":  12,
+"startColumn":  28,
+"endLine":  12,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S3956",
+"message":  "Refactor this field to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "Nancy\src\Nancy\NamedPipelineBase.cs",
+"region":  {
+"startLine":  12,
+"startColumn":  28,
+"endLine":  12,
+"endColumn":  57
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.ModelBinding-{1258BFCD-3BAD-4373-B786-4D698EC3C157}-S3956.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.ModelBinding-{1258BFCD-3BAD-4373-B786-4D698EC3C157}-S3956.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S3956",
+"message":  "Refactor this property to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Demo.ModelBinding\Database\DB.cs",
+"region":  {
+"startLine":  9,
+"startColumn":  23,
+"endLine":  9,
+"endColumn":  34
+}
+}
+},
+{
+"id":  "S3956",
+"message":  "Refactor this property to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Demo.ModelBinding\Database\DB.cs",
+"region":  {
+"startLine":  11,
+"startColumn":  23,
+"endLine":  11,
+"endColumn":  37
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Validation-{F417B81C-B914-4BFD-8299-6BBD11072B01}-S3956.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Validation-{F417B81C-B914-4BFD-8299-6BBD11072B01}-S3956.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3956",
+"message":  "Refactor this property to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "Nancy\src\Nancy.Demo.Validation\Database\DB.cs",
+"region":  {
+"startLine":  9,
+"startColumn":  23,
+"endLine":  9,
+"endColumn":  37
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.Spark-{4B7E35DF-1569-4346-B180-A09615723095}-S3956.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.Spark-{4B7E35DF-1569-4346-B180-A09615723095}-S3956.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3956",
+"message":  "Refactor this constructor to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "Nancy\src\Nancy.ViewEngines.Spark\SparkViewEngineResult.cs",
+"region":  {
+"startLine":  14,
+"startColumn":  38,
+"endLine":  14,
+"endColumn":  50
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S3956.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S3956.json
@@ -1,0 +1,82 @@
+{
+"issues":  [
+{
+"id":  "S3956",
+"message":  "Refactor this constructor to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\FSM.cs",
+"region":  {
+"startLine":  236,
+"startColumn":  106,
+"endLine":  236,
+"endColumn":  118
+}
+}
+},
+{
+"id":  "S3956",
+"message":  "Refactor this property to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\FSM.cs",
+"region":  {
+"startLine":  253,
+"startColumn":  20,
+"endLine":  253,
+"endColumn":  32
+}
+}
+},
+{
+"id":  "S3956",
+"message":  "Refactor this method to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\FSM.cs",
+"region":  {
+"startLine":  255,
+"startColumn":  84,
+"endLine":  255,
+"endColumn":  96
+}
+}
+},
+{
+"id":  "S3956",
+"message":  "Refactor this property to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Actor\SupervisorStrategy.cs",
+"region":  {
+"startLine":  575,
+"startColumn":  16,
+"endLine":  575,
+"endColumn":  29
+}
+}
+},
+{
+"id":  "S3956",
+"message":  "Refactor this property to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Configuration\Hocon\HoconValue.cs",
+"region":  {
+"startLine":  53,
+"startColumn":  16,
+"endLine":  53,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S3956",
+"message":  "Refactor this property to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "akka.net\src\core\Akka\Util\MatchHandler\TypeHandler.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  16,
+"endLine":  26,
+"endColumn":  41
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Persistence-{FCA84DEA-C118-424B-9EB8-34375DFEF18A}-S3956.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Persistence-{FCA84DEA-C118-424B-9EB8-34375DFEF18A}-S3956.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S3956",
+"message":  "Refactor this constructor to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Persistence\Fsm\PersistentFSMBase.cs",
+"region":  {
+"startLine":  719,
+"startColumn":  17,
+"endLine":  719,
+"endColumn":  29
+}
+}
+},
+{
+"id":  "S3956",
+"message":  "Refactor this method to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "akka.net\src\core\Akka.Persistence\Fsm\PersistentFSMBase.cs",
+"region":  {
+"startLine":  775,
+"startColumn":  17,
+"endLine":  775,
+"endColumn":  29
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/PersistenceExample-{4022147A-4F95-4A04-BE09-01B7952BBDD9}-S3956.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/PersistenceExample-{4022147A-4F95-4A04-BE09-01B7952BBDD9}-S3956.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3956",
+"message":  "Refactor this constructor to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "akka.net\src\examples\PersistenceExample\ExamplePersistentActor.cs",
+"region":  {
+"startLine":  47,
+"startColumn":  29,
+"endLine":  47,
+"endColumn":  41
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Samples.Cluster.Transformation-{E5EB3DF5-D017-4B50-B5AA-2B0440DB773D}-S3956.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Samples.Cluster.Transformation-{E5EB3DF5-D017-4B50-B5AA-2B0440DB773D}-S3956.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3956",
+"message":  "Refactor this field to use a generic collection designed for inheritance.",
+"location":  {
+"uri":  "akka.net\src\examples\Cluster\Roles\Samples.Cluster.Transformation\TransformationFrontend.cs",
+"region":  {
+"startLine":  15,
+"startColumn":  19,
+"endLine":  15,
+"endColumn":  34
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/rspec/cs/S3956_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S3956_c#.html
@@ -1,0 +1,46 @@
+<p><code>System.Collections.Generic.List&lt;T&gt;</code> is a generic collection that is designed for performance and not inheritance. For example, it
+does not contain virtual members that make it easier to change the behavior of an inherited class. That means that future attempts to expand the
+behavior will be spoiled because the extension points simply aren't there. Instead, one of the following generic collections should be used:</p>
+<ul>
+  <li> <code>System.Collections.Generic.IEnumerable&lt;T&gt;</code> </li>
+  <li> <code>System.Collections.Generic.IReadOnlyCollection&lt;T&gt;</code> </li>
+  <li> <code>System.Collections.Generic.ICollection&lt;TKey&gt;</code> </li>
+  <li> <code>System.Collections.Generic.IReadOnlyList&lt;T&gt;</code> </li>
+  <li> <code>System.Collections.Generic.IList&lt;TKey&gt;</code> </li>
+  <li> <code>System.Collections.ObjectModel.Collection&lt;T&gt;</code> </li>
+  <li> <code>System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</code> </li>
+  <li> <code>System.Collections.ObjectModel.KeyedCollection&lt;TKey, Titem&gt;</code> </li>
+</ul>
+<p>This rule raises an issue every time a <code>System.Collections.Generic.List&lt;T&gt;</code> is exposed:</p>
+<ul>
+  <li> As an externally visible member. </li>
+  <li> As the return type of an externally visible method. </li>
+  <li> As a parameter type of an an externally visible method. </li>
+</ul>
+<h2>Noncompliant Code Example</h2>
+<pre>
+namespace Foo
+{
+   public class Bar
+   {
+      public List&lt;T&gt; Method1(T arg) // Noncompliant
+      {
+           //...
+      }
+   }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+namespace Foo
+{
+   public class Bar
+   {
+      public Collection&lt;T&gt; Method1(T arg)
+      {
+           //...
+      }
+   }
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/rspec/cs/S3956_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S3956_c#.json
@@ -1,0 +1,13 @@
+{
+  "title": "\"Generic.List\" instances should not be part of public APIs",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "10min"
+  },
+  "tags": [
+    "api-design"
+  ],
+  "defaultSeverity": "Major"
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.Designer.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.Designer.cs
@@ -3670,7 +3670,7 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sonar Bug.
+        ///   Looks up a localized string similar to Sonar Code Smell.
         /// </summary>
         internal static string S1449_Category {
             get {
@@ -3742,7 +3742,7 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to BUG.
+        ///   Looks up a localized string similar to CODE_SMELL.
         /// </summary>
         internal static string S1449_Type {
             get {
@@ -5533,7 +5533,7 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sonar Bug.
+        ///   Looks up a localized string similar to Sonar Code Smell.
         /// </summary>
         internal static string S1944_Category {
             get {
@@ -5587,7 +5587,7 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to cwe,misra,cert,pitfall.
+        ///   Looks up a localized string similar to cwe,misra,cert,suspicious.
         /// </summary>
         internal static string S1944_Tags {
             get {
@@ -5605,7 +5605,7 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to BUG.
+        ///   Looks up a localized string similar to CODE_SMELL.
         /// </summary>
         internal static string S1944_Type {
             get {
@@ -6406,7 +6406,7 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Return values should not be ignored when function calls don&apos;t have any side effects.
+        ///   Looks up a localized string similar to Return values from functions without side effects should not be ignored.
         /// </summary>
         internal static string S2201_Title {
             get {
@@ -18583,7 +18583,7 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Code is clearest when each statement has its own line. Nonetheless, it is not uncommon to combine on the same line an if and it&apos;s resulting then statement. However, when an if is appended to the line with a previous if&apos;s closing } it is either an error - else is missing - or the prelude to a future error as maintainers fail to understand that the two statements are unconnected..
+        ///   Looks up a localized string similar to Code is clearest when each statement has its own line. Nonetheless, it is a common pattern to combine on the same line an if and it&apos;s resulting then statement. However, when an if is placed on the same line as the closing } from a preceding else or else if, it is either an error - else is missing - or the invitation to a future error as maintainers fail to understand that the two statements are unconnected..
         /// </summary>
         internal static string S3972_Description {
             get {
@@ -20752,7 +20752,7 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certain characters, once normalized to lowercase, cannot make a round trip, meaning that they can not be converted from one locale to another and then accurately restored to their original characters..
+        ///   Looks up a localized string similar to Certain characters, once normalized to lowercase, cannot make a round trip. That is, they can not be converted from one locale to another and then accurately restored to their original characters..
         /// </summary>
         internal static string S4040_Description {
             get {
@@ -20988,6 +20988,87 @@ namespace SonarAnalyzer {
         /// <summary>
         ///   Looks up a localized string similar to Sonar Code Smell.
         /// </summary>
+        internal static string S4049_Category {
+            get {
+                return ResourceManager.GetString("S4049_Category", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Properties are accessed like fields which makes them easier to use..
+        /// </summary>
+        internal static string S4049_Description {
+            get {
+                return ResourceManager.GetString("S4049_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to False.
+        /// </summary>
+        internal static string S4049_IsActivatedByDefault {
+            get {
+                return ResourceManager.GetString("S4049_IsActivatedByDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Constant/Issue.
+        /// </summary>
+        internal static string S4049_Remediation {
+            get {
+                return ResourceManager.GetString("S4049_Remediation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 5min.
+        /// </summary>
+        internal static string S4049_RemediationCost {
+            get {
+                return ResourceManager.GetString("S4049_RemediationCost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minor.
+        /// </summary>
+        internal static string S4049_Severity {
+            get {
+                return ResourceManager.GetString("S4049_Severity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to convention.
+        /// </summary>
+        internal static string S4049_Tags {
+            get {
+                return ResourceManager.GetString("S4049_Tags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Properties should be preferred.
+        /// </summary>
+        internal static string S4049_Title {
+            get {
+                return ResourceManager.GetString("S4049_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CODE_SMELL.
+        /// </summary>
+        internal static string S4049_Type {
+            get {
+                return ResourceManager.GetString("S4049_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sonar Code Smell.
+        /// </summary>
         internal static string S4050_Category {
             get {
                 return ResourceManager.GetString("S4050_Category", resourceCulture);
@@ -21150,162 +21231,81 @@ namespace SonarAnalyzer {
         /// <summary>
         ///   Looks up a localized string similar to Sonar Code Smell.
         /// </summary>
-        internal static string S4058_Category {
+        internal static string S4056_Category {
             get {
-                return ResourceManager.GetString("S4058_Category", resourceCulture);
+                return ResourceManager.GetString("S4056_Category", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Many string operations, the Compare and Equals methods in particular, provide an overload that accepts a StringComparison enumeration value as a parameter. Calling these overloads and explicitly providing this parameter makes your code clearer and easier to maintain..
+        ///   Looks up a localized string similar to When a System.Globalization.CultureInfo or IFormatProvider object is not supplied, the default value that is supplied by the overloaded member might not have the effect that you want in all locales..
         /// </summary>
-        internal static string S4058_Description {
+        internal static string S4056_Description {
             get {
-                return ResourceManager.GetString("S4058_Description", resourceCulture);
+                return ResourceManager.GetString("S4056_Description", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to False.
         /// </summary>
-        internal static string S4058_IsActivatedByDefault {
+        internal static string S4056_IsActivatedByDefault {
             get {
-                return ResourceManager.GetString("S4058_IsActivatedByDefault", resourceCulture);
+                return ResourceManager.GetString("S4056_IsActivatedByDefault", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Constant/Issue.
         /// </summary>
-        internal static string S4058_Remediation {
+        internal static string S4056_Remediation {
             get {
-                return ResourceManager.GetString("S4058_Remediation", resourceCulture);
+                return ResourceManager.GetString("S4056_Remediation", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 2min.
+        ///   Looks up a localized string similar to 5min.
         /// </summary>
-        internal static string S4058_RemediationCost {
+        internal static string S4056_RemediationCost {
             get {
-                return ResourceManager.GetString("S4058_RemediationCost", resourceCulture);
+                return ResourceManager.GetString("S4056_RemediationCost", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Minor.
         /// </summary>
-        internal static string S4058_Severity {
+        internal static string S4056_Severity {
             get {
-                return ResourceManager.GetString("S4058_Severity", resourceCulture);
+                return ResourceManager.GetString("S4056_Severity", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to localisation,pitfall.
         /// </summary>
-        internal static string S4058_Tags {
+        internal static string S4056_Tags {
             get {
-                return ResourceManager.GetString("S4058_Tags", resourceCulture);
+                return ResourceManager.GetString("S4056_Tags", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Overloads with a &quot;StringComparison&quot; parameter should be used.
+        ///   Looks up a localized string similar to Overloads with a &quot;CultureInfo&quot; or an &quot;IFormatProvider&quot; parameter should be used.
         /// </summary>
-        internal static string S4058_Title {
+        internal static string S4056_Title {
             get {
-                return ResourceManager.GetString("S4058_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to CODE_SMELL.
-        /// </summary>
-        internal static string S4058_Type {
-            get {
-                return ResourceManager.GetString("S4058_Type", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Sonar Code Smell.
-        /// </summary>
-        internal static string S4059_Category {
-            get {
-                return ResourceManager.GetString("S4059_Category", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Properties and Get method should have names that makes them clearly distinguishable..
-        /// </summary>
-        internal static string S4059_Description {
-            get {
-                return ResourceManager.GetString("S4059_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to False.
-        /// </summary>
-        internal static string S4059_IsActivatedByDefault {
-            get {
-                return ResourceManager.GetString("S4059_IsActivatedByDefault", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Constant/Issue.
-        /// </summary>
-        internal static string S4059_Remediation {
-            get {
-                return ResourceManager.GetString("S4059_Remediation", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to 2min.
-        /// </summary>
-        internal static string S4059_RemediationCost {
-            get {
-                return ResourceManager.GetString("S4059_RemediationCost", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Major.
-        /// </summary>
-        internal static string S4059_Severity {
-            get {
-                return ResourceManager.GetString("S4059_Severity", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to confusing.
-        /// </summary>
-        internal static string S4059_Tags {
-            get {
-                return ResourceManager.GetString("S4059_Tags", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Property names should not match get methods.
-        /// </summary>
-        internal static string S4059_Title {
-            get {
-                return ResourceManager.GetString("S4059_Title", resourceCulture);
+                return ResourceManager.GetString("S4056_Title", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to CODE_SMELL.
         /// </summary>
-        internal static string S4059_Type {
+        internal static string S4056_Type {
             get {
-                return ResourceManager.GetString("S4059_Type", resourceCulture);
+                return ResourceManager.GetString("S4056_Type", resourceCulture);
             }
         }
         
@@ -21636,162 +21636,81 @@ namespace SonarAnalyzer {
         /// <summary>
         ///   Looks up a localized string similar to Sonar Code Smell.
         /// </summary>
-        internal static string S4070_Category {
+        internal static string S4069_Category {
             get {
-                return ResourceManager.GetString("S4070_Category", resourceCulture);
+                return ResourceManager.GetString("S4069_Category", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This rule raises an issue when an externally visible enumeration is marked with FlagsAttribute and one, or more, of its values is not a power of 2 or a combination of the other defined values..
+        ///   Looks up a localized string similar to Operator overloading is convenient but unfortunately not portable across languages. To be able to access the same functionality from another language you need to provide an alternate named method following the convention:.
         /// </summary>
-        internal static string S4070_Description {
+        internal static string S4069_Description {
             get {
-                return ResourceManager.GetString("S4070_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to False.
-        /// </summary>
-        internal static string S4070_IsActivatedByDefault {
-            get {
-                return ResourceManager.GetString("S4070_IsActivatedByDefault", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Constant/Issue.
-        /// </summary>
-        internal static string S4070_Remediation {
-            get {
-                return ResourceManager.GetString("S4070_Remediation", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to 2min.
-        /// </summary>
-        internal static string S4070_RemediationCost {
-            get {
-                return ResourceManager.GetString("S4070_RemediationCost", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Major.
-        /// </summary>
-        internal static string S4070_Severity {
-            get {
-                return ResourceManager.GetString("S4070_Severity", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to .
-        /// </summary>
-        internal static string S4070_Tags {
-            get {
-                return ResourceManager.GetString("S4070_Tags", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Non-flags enums should not be marked with &quot;FlagsAttribute&quot;.
-        /// </summary>
-        internal static string S4070_Title {
-            get {
-                return ResourceManager.GetString("S4070_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to CODE_SMELL.
-        /// </summary>
-        internal static string S4070_Type {
-            get {
-                return ResourceManager.GetString("S4070_Type", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Sonar Code Smell.
-        /// </summary>
-        internal static string S4061_Category {
-            get {
-                return ResourceManager.GetString("S4061_Category", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A method using the VarArgs calling convention is not Common Language Specification (CLS) compliant and might not be accessible across programming languages, while the params keyword works the same way and is CLS compliant..
-        /// </summary>
-        internal static string S4061_Description {
-            get {
-                return ResourceManager.GetString("S4061_Description", resourceCulture);
+                return ResourceManager.GetString("S4069_Description", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to False.
         /// </summary>
-        internal static string S4061_IsActivatedByDefault {
+        internal static string S4069_IsActivatedByDefault {
             get {
-                return ResourceManager.GetString("S4061_IsActivatedByDefault", resourceCulture);
+                return ResourceManager.GetString("S4069_IsActivatedByDefault", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Constant/Issue.
         /// </summary>
-        internal static string S4061_Remediation {
+        internal static string S4069_Remediation {
             get {
-                return ResourceManager.GetString("S4061_Remediation", resourceCulture);
+                return ResourceManager.GetString("S4069_Remediation", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to 5min.
         /// </summary>
-        internal static string S4061_RemediationCost {
+        internal static string S4069_RemediationCost {
             get {
-                return ResourceManager.GetString("S4061_RemediationCost", resourceCulture);
+                return ResourceManager.GetString("S4069_RemediationCost", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Minor.
         /// </summary>
-        internal static string S4061_Severity {
+        internal static string S4069_Severity {
             get {
-                return ResourceManager.GetString("S4061_Severity", resourceCulture);
+                return ResourceManager.GetString("S4069_Severity", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to convention.
         /// </summary>
-        internal static string S4061_Tags {
+        internal static string S4069_Tags {
             get {
-                return ResourceManager.GetString("S4061_Tags", resourceCulture);
+                return ResourceManager.GetString("S4069_Tags", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &quot;params&quot; should be use instead of &quot;varargs&quot;.
+        ///   Looks up a localized string similar to Operator overloads should have named alternatives.
         /// </summary>
-        internal static string S4061_Title {
+        internal static string S4069_Title {
             get {
-                return ResourceManager.GetString("S4061_Title", resourceCulture);
+                return ResourceManager.GetString("S4069_Title", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to CODE_SMELL.
         /// </summary>
-        internal static string S4061_Type {
+        internal static string S4069_Type {
             get {
-                return ResourceManager.GetString("S4061_Type", resourceCulture);
+                return ResourceManager.GetString("S4069_Type", resourceCulture);
             }
         }
         
@@ -22048,7 +21967,7 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to When the parameters to the implementation of a partial method don&apos;t match those in the signature declaration, then confusion is almost guaranteed. Either the implementer was confused when he renamed, swapped or mangled the parameter names in the implementation, or callers will be confused..
+        ///   Looks up a localized string similar to The name of a parameter in an externally visible method override does not match the name of the parameter in the base declaration of the method, or the name of the parameter in the interface declaration of the method or the name of any other partial definition..
         /// </summary>
         internal static string S927_Description {
             get {
@@ -22102,7 +22021,7 @@ namespace SonarAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &quot;partial&quot; method parameter names should match.
+        ///   Looks up a localized string similar to parameter names should match base declaration and other partial definitions.
         /// </summary>
         internal static string S927_Title {
             get {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.Designer.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.Designer.cs
@@ -18171,6 +18171,87 @@ namespace SonarAnalyzer {
         /// <summary>
         ///   Looks up a localized string similar to Sonar Code Smell.
         /// </summary>
+        internal static string S3956_Category {
+            get {
+                return ResourceManager.GetString("S3956_Category", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to System.Collections.Generic.List&lt;T&gt; is a generic collection that is designed for performance and not inheritance. For example, it does not contain virtual members that make it easier to change the behavior of an inherited class. That means that future attempts to expand the behavior will be spoiled because the extension points simply aren&apos;t there. Instead, one of the following generic collections should be used:.
+        /// </summary>
+        internal static string S3956_Description {
+            get {
+                return ResourceManager.GetString("S3956_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to False.
+        /// </summary>
+        internal static string S3956_IsActivatedByDefault {
+            get {
+                return ResourceManager.GetString("S3956_IsActivatedByDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Constant/Issue.
+        /// </summary>
+        internal static string S3956_Remediation {
+            get {
+                return ResourceManager.GetString("S3956_Remediation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 10min.
+        /// </summary>
+        internal static string S3956_RemediationCost {
+            get {
+                return ResourceManager.GetString("S3956_RemediationCost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Major.
+        /// </summary>
+        internal static string S3956_Severity {
+            get {
+                return ResourceManager.GetString("S3956_Severity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to api-design.
+        /// </summary>
+        internal static string S3956_Tags {
+            get {
+                return ResourceManager.GetString("S3956_Tags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;Generic.List&quot; instances should not be part of public APIs.
+        /// </summary>
+        internal static string S3956_Title {
+            get {
+                return ResourceManager.GetString("S3956_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CODE_SMELL.
+        /// </summary>
+        internal static string S3956_Type {
+            get {
+                return ResourceManager.GetString("S3956_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sonar Code Smell.
+        /// </summary>
         internal static string S3962_Category {
             get {
                 return ResourceManager.GetString("S3962_Category", resourceCulture);
@@ -21231,6 +21312,168 @@ namespace SonarAnalyzer {
         /// <summary>
         ///   Looks up a localized string similar to Sonar Code Smell.
         /// </summary>
+        internal static string S4058_Category {
+            get {
+                return ResourceManager.GetString("S4058_Category", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Many string operations, the Compare and Equals methods in particular, provide an overload that accepts a StringComparison enumeration value as a parameter. Calling these overloads and explicitly providing this parameter makes your code clearer and easier to maintain..
+        /// </summary>
+        internal static string S4058_Description {
+            get {
+                return ResourceManager.GetString("S4058_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to False.
+        /// </summary>
+        internal static string S4058_IsActivatedByDefault {
+            get {
+                return ResourceManager.GetString("S4058_IsActivatedByDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Constant/Issue.
+        /// </summary>
+        internal static string S4058_Remediation {
+            get {
+                return ResourceManager.GetString("S4058_Remediation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 2min.
+        /// </summary>
+        internal static string S4058_RemediationCost {
+            get {
+                return ResourceManager.GetString("S4058_RemediationCost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minor.
+        /// </summary>
+        internal static string S4058_Severity {
+            get {
+                return ResourceManager.GetString("S4058_Severity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string S4058_Tags {
+            get {
+                return ResourceManager.GetString("S4058_Tags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Overloads with a &quot;StringComparison&quot; parameter should be used.
+        /// </summary>
+        internal static string S4058_Title {
+            get {
+                return ResourceManager.GetString("S4058_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CODE_SMELL.
+        /// </summary>
+        internal static string S4058_Type {
+            get {
+                return ResourceManager.GetString("S4058_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sonar Code Smell.
+        /// </summary>
+        internal static string S4059_Category {
+            get {
+                return ResourceManager.GetString("S4059_Category", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Properties and Get method should have names that makes them clearly distinguishable..
+        /// </summary>
+        internal static string S4059_Description {
+            get {
+                return ResourceManager.GetString("S4059_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to False.
+        /// </summary>
+        internal static string S4059_IsActivatedByDefault {
+            get {
+                return ResourceManager.GetString("S4059_IsActivatedByDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Constant/Issue.
+        /// </summary>
+        internal static string S4059_Remediation {
+            get {
+                return ResourceManager.GetString("S4059_Remediation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 2min.
+        /// </summary>
+        internal static string S4059_RemediationCost {
+            get {
+                return ResourceManager.GetString("S4059_RemediationCost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Major.
+        /// </summary>
+        internal static string S4059_Severity {
+            get {
+                return ResourceManager.GetString("S4059_Severity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to confusing.
+        /// </summary>
+        internal static string S4059_Tags {
+            get {
+                return ResourceManager.GetString("S4059_Tags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Property names should not match get methods.
+        /// </summary>
+        internal static string S4059_Title {
+            get {
+                return ResourceManager.GetString("S4059_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CODE_SMELL.
+        /// </summary>
+        internal static string S4059_Type {
+            get {
+                return ResourceManager.GetString("S4059_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sonar Code Smell.
+        /// </summary>
         internal static string S4060_Category {
             get {
                 return ResourceManager.GetString("S4060_Category", resourceCulture);
@@ -21306,6 +21549,168 @@ namespace SonarAnalyzer {
         internal static string S4060_Type {
             get {
                 return ResourceManager.GetString("S4060_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sonar Code Smell.
+        /// </summary>
+        internal static string S4061_Category {
+            get {
+                return ResourceManager.GetString("S4061_Category", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A method using the VarArgs calling convention is not Common Language Specification (CLS) compliant and might not be accessible across programming languages, while the params keyword works the same way and is CLS compliant..
+        /// </summary>
+        internal static string S4061_Description {
+            get {
+                return ResourceManager.GetString("S4061_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to False.
+        /// </summary>
+        internal static string S4061_IsActivatedByDefault {
+            get {
+                return ResourceManager.GetString("S4061_IsActivatedByDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Constant/Issue.
+        /// </summary>
+        internal static string S4061_Remediation {
+            get {
+                return ResourceManager.GetString("S4061_Remediation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 5min.
+        /// </summary>
+        internal static string S4061_RemediationCost {
+            get {
+                return ResourceManager.GetString("S4061_RemediationCost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minor.
+        /// </summary>
+        internal static string S4061_Severity {
+            get {
+                return ResourceManager.GetString("S4061_Severity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string S4061_Tags {
+            get {
+                return ResourceManager.GetString("S4061_Tags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;params&quot; should be use instead of &quot;varargs&quot;.
+        /// </summary>
+        internal static string S4061_Title {
+            get {
+                return ResourceManager.GetString("S4061_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CODE_SMELL.
+        /// </summary>
+        internal static string S4061_Type {
+            get {
+                return ResourceManager.GetString("S4061_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sonar Code Smell.
+        /// </summary>
+        internal static string S4070_Category {
+            get {
+                return ResourceManager.GetString("S4070_Category", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This rule raises an issue when an externally visible enumeration is marked with FlagsAttribute and one, or more, of its values is not a power of 2 or a combination of the other defined values..
+        /// </summary>
+        internal static string S4070_Description {
+            get {
+                return ResourceManager.GetString("S4070_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to False.
+        /// </summary>
+        internal static string S4070_IsActivatedByDefault {
+            get {
+                return ResourceManager.GetString("S4070_IsActivatedByDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Constant/Issue.
+        /// </summary>
+        internal static string S4070_Remediation {
+            get {
+                return ResourceManager.GetString("S4070_Remediation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 2min.
+        /// </summary>
+        internal static string S4070_RemediationCost {
+            get {
+                return ResourceManager.GetString("S4070_RemediationCost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Major.
+        /// </summary>
+        internal static string S4070_Severity {
+            get {
+                return ResourceManager.GetString("S4070_Severity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string S4070_Tags {
+            get {
+                return ResourceManager.GetString("S4070_Tags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Non-flags enums should not be marked with &quot;FlagsAttribute&quot;.
+        /// </summary>
+        internal static string S4070_Title {
+            get {
+                return ResourceManager.GetString("S4070_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CODE_SMELL.
+        /// </summary>
+        internal static string S4070_Type {
+            get {
+                return ResourceManager.GetString("S4070_Type", resourceCulture);
             }
         }
         

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -6153,6 +6153,33 @@
   <data name="S3928_Type" xml:space="preserve">
     <value>CODE_SMELL</value>
   </data>
+  <data name="S3956_Category" xml:space="preserve">
+    <value>Sonar Code Smell</value>
+  </data>
+  <data name="S3956_Description" xml:space="preserve">
+    <value>System.Collections.Generic.List&lt;T&gt; is a generic collection that is designed for performance and not inheritance. For example, it does not contain virtual members that make it easier to change the behavior of an inherited class. That means that future attempts to expand the behavior will be spoiled because the extension points simply aren't there. Instead, one of the following generic collections should be used:</value>
+  </data>
+  <data name="S3956_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S3956_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S3956_RemediationCost" xml:space="preserve">
+    <value>10min</value>
+  </data>
+  <data name="S3956_Severity" xml:space="preserve">
+    <value>Major</value>
+  </data>
+  <data name="S3956_Tags" xml:space="preserve">
+    <value>api-design</value>
+  </data>
+  <data name="S3956_Title" xml:space="preserve">
+    <value>"Generic.List" instances should not be part of public APIs</value>
+  </data>
+  <data name="S3956_Type" xml:space="preserve">
+    <value>CODE_SMELL</value>
+  </data>
   <data name="S3962_Category" xml:space="preserve">
     <value>Sonar Code Smell</value>
   </data>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
@@ -1,0 +1,150 @@
+/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2017 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(DiagnosticId)]
+    public sealed class DoNotExposeListT : SonarDiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "S3956";
+        private const string MessageFormat = "Refactor this {0} to use a generic collection designed for inheritance.";
+
+        private static readonly DiagnosticDescriptor rule =
+            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionInNonGenerated(c =>
+            {
+                if (c.IsTest())
+                {
+                    return;
+                }
+
+                var baseMethodDeclaration = (BaseMethodDeclarationSyntax)c.Node;
+                var methodSymbol = c.SemanticModel.GetDeclaredSymbol(baseMethodDeclaration);
+
+                if (methodSymbol == null ||
+                    !IsPubliclyAccessible(methodSymbol) ||
+                    methodSymbol.IsOverride ||
+                    IsPropertyGetOrSet(methodSymbol))
+                {
+                    return;
+                }
+
+                string methodType = methodSymbol.IsConstructor() ? "constructor" : "method";
+
+                var methodDeclaration = baseMethodDeclaration as MethodDeclarationSyntax;
+                if (methodDeclaration != null)
+                {
+                    ReportIfListT(methodDeclaration.ReturnType, c, methodType);
+                }
+
+                baseMethodDeclaration
+                    .ParameterList?
+                    .Parameters
+                    .ToList()
+                    .ForEach(p => ReportIfListT(p.Type, c, methodType));
+            },
+            SyntaxKind.MethodDeclaration,
+            SyntaxKind.ConstructorDeclaration);
+
+            context.RegisterSyntaxNodeActionInNonGenerated(c =>
+            {
+                if (c.IsTest())
+                {
+                    return;
+                }
+
+                var propertyDeclaration = (PropertyDeclarationSyntax)c.Node;
+                var propertySymbol = c.SemanticModel.GetDeclaredSymbol(propertyDeclaration);
+
+                if (propertySymbol != null &&
+                    IsPubliclyAccessible(propertySymbol) &&
+                    !propertySymbol.IsOverride)
+                {
+                    ReportIfListT(propertyDeclaration.Type, c, "property");
+                }
+            },
+            SyntaxKind.PropertyDeclaration);
+
+            context.RegisterSyntaxNodeActionInNonGenerated(c =>
+            {
+                if (c.IsTest())
+                {
+                    return;
+                }
+
+                var fieldDeclaration = (FieldDeclarationSyntax)c.Node;
+
+                var variableDeclaration = fieldDeclaration.Declaration?.Variables.FirstOrDefault();
+                if (variableDeclaration == null)
+                {
+                    return;
+                }
+
+                var fieldSymbol = c.SemanticModel.GetDeclaredSymbol(variableDeclaration);
+
+                if (fieldSymbol != null &&
+                    IsPubliclyAccessible(fieldSymbol) &&
+                    !fieldSymbol.IsOverride)
+                {
+                    ReportIfListT(fieldDeclaration.Declaration.Type, c, "field");
+                }
+            },
+            SyntaxKind.FieldDeclaration);
+        }
+
+        private static void ReportIfListT(TypeSyntax typeSyntax, SyntaxNodeAnalysisContext context, string memberType)
+        {
+            if (typeSyntax != null && typeSyntax.IsKnownType(KnownType.System_Collections_Generic_List_T, context.SemanticModel))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(rule, typeSyntax.GetLocation(),
+                    messageArgs: memberType));
+            }
+        }
+
+        private static bool IsPropertyGetOrSet(IMethodSymbol method)
+        {
+            return method.MethodKind == MethodKind.PropertyGet ||
+                   method.MethodKind == MethodKind.PropertySet;
+        }
+
+        private static bool IsPubliclyAccessible(ISymbol symbol)
+        {
+            var access = symbol.GetEffectiveAccessibility();
+
+            return access == Accessibility.Public ||
+                   access == Accessibility.Protected ||
+                   access == Accessibility.ProtectedOrInternal;
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
@@ -272,7 +272,8 @@ namespace SonarAnalyzer.Helpers
         internal static bool IsKnownType(this SyntaxNode syntaxNode, KnownType knownType, SemanticModel semanticModel)
         {
             var symbolType = semanticModel.GetSymbolInfo(syntaxNode).Symbol.GetSymbolType();
-            return symbolType.Is(knownType);
+
+            return symbolType.Is(knownType) || symbolType?.OriginalDefinition?.Is(knownType) == true;
         }
 
         internal static bool IsDeclarationKnownType(this SyntaxNode syntaxNode, KnownType knownType, SemanticModel semanticModel)

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S3956.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S3956.html
@@ -1,0 +1,46 @@
+<p><code>System.Collections.Generic.List&lt;T&gt;</code> is a generic collection that is designed for performance and not inheritance. For example, it
+does not contain virtual members that make it easier to change the behavior of an inherited class. That means that future attempts to expand the
+behavior will be spoiled because the extension points simply aren't there. Instead, one of the following generic collections should be used:</p>
+<ul>
+  <li> <code>System.Collections.Generic.IEnumerable&lt;T&gt;</code> </li>
+  <li> <code>System.Collections.Generic.IReadOnlyCollection&lt;T&gt;</code> </li>
+  <li> <code>System.Collections.Generic.ICollection&lt;TKey&gt;</code> </li>
+  <li> <code>System.Collections.Generic.IReadOnlyList&lt;T&gt;</code> </li>
+  <li> <code>System.Collections.Generic.IList&lt;TKey&gt;</code> </li>
+  <li> <code>System.Collections.ObjectModel.Collection&lt;T&gt;</code> </li>
+  <li> <code>System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</code> </li>
+  <li> <code>System.Collections.ObjectModel.KeyedCollection&lt;TKey, Titem&gt;</code> </li>
+</ul>
+<p>This rule raises an issue every time a <code>System.Collections.Generic.List&lt;T&gt;</code> is exposed:</p>
+<ul>
+  <li> As an externally visible member. </li>
+  <li> As the return type of an externally visible method. </li>
+  <li> As a parameter type of an an externally visible method. </li>
+</ul>
+<h2>Noncompliant Code Example</h2>
+<pre>
+namespace Foo
+{
+   public class Bar
+   {
+      public List&lt;T&gt; Method1(T arg) // Noncompliant
+      {
+           //...
+      }
+   }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+namespace Foo
+{
+   public class Bar
+   {
+      public Collection&lt;T&gt; Method1(T arg)
+      {
+           //...
+      }
+   }
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Helpers/SymbolHelperTest.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Helpers/SymbolHelperTest.cs
@@ -33,6 +33,8 @@ namespace SonarAnalyzer.UnitTest.Helpers
         internal const string TestInput = @"
 namespace NS
 {
+  using System.Collections.Generic;
+
   public class Base
   {
     public class Nested
@@ -64,6 +66,7 @@ namespace NS
   {
     int Property2 { get; set; }
     void Method3();
+    void Method4<T, V>(List<T> param1, List<int> param2, List<V> param3, IList<int> param4);
   }
 }
 ";
@@ -269,6 +272,39 @@ namespace NS
             var typeSymbol = semanticModel.GetDeclaredSymbol(baseClassDeclaration) as INamedTypeSymbol;
             var typeSymbols = typeSymbol.GetAllNamedTypes();
             typeSymbols.Should().HaveCount(3);
+        }
+
+        [TestMethod]
+        public void Symbol_IsKnownType()
+        {
+            var method4 = interfaceDeclaration
+                .DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .First(m => m.Identifier.ValueText == "Method4");
+
+            method4.ParameterList
+                .Parameters[0]
+                .Type
+                .IsKnownType(KnownType.System_Collections_Generic_List_T, semanticModel)
+                .Should().BeTrue();
+
+            method4.ParameterList
+                .Parameters[1]
+                .Type
+                .IsKnownType(KnownType.System_Collections_Generic_List_T, semanticModel)
+                .Should().BeTrue();
+
+            method4.ParameterList
+                .Parameters[2]
+                .Type
+                .IsKnownType(KnownType.System_Collections_Generic_List_T, semanticModel)
+                .Should().BeTrue();
+
+            method4.ParameterList
+                .Parameters[3]
+                .Type
+                .IsKnownType(KnownType.System_Collections_Generic_List_T, semanticModel)
+                .Should().BeFalse();
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTests.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTests.cs
@@ -3953,7 +3953,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
             //["3953"],
             //["3954"],
             //["3955"],
-            //["3956"],
+            ["3956"] = "CODE_SMELL",
             //["3957"],
             //["3958"],
             //["3959"],

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Rules/DoNotExposeListTTest.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Rules/DoNotExposeListTTest.cs
@@ -1,0 +1,37 @@
+/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2017 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Rules.CSharp;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class DoNotExposeListTTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void DoNotExposeListT()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\DoNotExposeListT.cs",
+                new DoNotExposeListT());
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/DoNotExposeListT.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/DoNotExposeListT.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tests.Diagnostics
+{
+    public class Bar
+    {
+        public List<T> Method1<T>(T arg) => null;
+//             ^^^^^^^ Noncompliant {{Refactor this method to use a generic collection designed for inheritance.}}
+
+        private List<T> Method2<T>(T arg) => null;
+
+        private void Method3(int arg) => null;
+
+        public List<int> Method4(List<string> someParam) => null;
+//             ^^^^^^^^^ Noncompliant
+//                               ^^^^^^^^^^^^ Noncompliant@-1
+
+        public IList<int> Method5(ICollection<string> someParam) => null;
+
+        public List<T> field, field2;
+//             ^^^^^^^ Noncompliant {{Refactor this field to use a generic collection designed for inheritance.}}
+
+        public List<int> Property { get; set; }
+//             ^^^^^^^^^ Noncompliant {{Refactor this property to use a generic collection designed for inheritance.}}
+
+        public Bar(List<Bar> bars) { } // Noncompliant  {{Refactor this constructor to use a generic collection designed for inheritance.}}
+    }
+
+    public class InvalidCode
+    {
+        public List<int> () => null;
+
+        public List<T> { get; set; }
+
+        public List<InvalidType> Method() => null;
+
+        public InvalidType Method2() => null;
+    }
+}

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/DoNotExposeListT.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/DoNotExposeListT.cs
@@ -25,6 +25,12 @@ namespace Tests.Diagnostics
 //             ^^^^^^^^^ Noncompliant {{Refactor this property to use a generic collection designed for inheritance.}}
 
         public Bar(List<Bar> bars) { } // Noncompliant  {{Refactor this constructor to use a generic collection designed for inheritance.}}
+
+        protected List<int> ProtectedMethod() => null; // Noncompliant
+
+        protected internal List<int> ProtectedInternalMethod() => null; // Noncompliant
+
+        internal List<int> InternalMethod() => null;
     }
 
     public class InvalidCode


### PR DESCRIPTION
Fix #506 

I'm surprised by how few violations this rule reports. Expected way more.