### PR TITLE
Fix S3263: Rule should not raise when constant field is used in initialization

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/StaticFieldInitializerOrder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/StaticFieldInitializerOrder.cs
@@ -110,6 +110,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         Identifier = identifier,
                         Field = field,
                         IsRelevant = field != null &&
+                            !field.IsConst &&
                             field.IsStatic &&
                             containingType.Equals(field.ContainingType) &&
                             enclosingSymbol is IFieldSymbol &&

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Rules/StaticFieldInitializerOrderTest.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/Rules/StaticFieldInitializerOrderTest.cs
@@ -30,7 +30,13 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void StaticFieldInitializerOrder()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\StaticFieldInitializerOrder.cs", new StaticFieldInitializerOrder());
+            Verifier.VerifyAnalyzer(
+                new []
+                {
+                    @"TestCases\StaticFieldInitializerOrder.cs",
+                    @"TestCases\StaticFieldInitializerOrder_PartialClass.cs"
+                }
+                , new StaticFieldInitializerOrder());
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/StaticFieldInitializerOrder.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/StaticFieldInitializerOrder.cs
@@ -8,6 +8,10 @@ namespace Tests.TestCases
 {
     public partial class StaticFieldInitializerOrder
     {
+        public static string s1 = new string('x', Const); // Compliant. Const do not suffer from initialization order fiasco.
+        public static string s2 = new string('x', Const2);
+        public static string s3 = new string('x', Y); // Noncompliant
+
         public static Action<int> A = (i) => { var x = i + StaticFieldInitializerOrder.Y; }; // Okay??? Might or might not. For no we don't report on it
         public static int X = Y; // Noncompliant; Y at this time is still assigned default(int), i.e. 0
 //                          ^^^
@@ -26,5 +30,7 @@ namespace Tests.TestCases
     public partial class StaticFieldInitializerOrder
     {
         public static int W = 2;
+
+        public const int Const2 = 5;
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/StaticFieldInitializerOrder.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/StaticFieldInitializerOrder.cs
@@ -26,11 +26,4 @@ namespace Tests.TestCases
 
         public static int M(int i) { return i; }
     }
-
-    public partial class StaticFieldInitializerOrder
-    {
-        public static int W = 2;
-
-        public const int Const2 = 5;
-    }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/StaticFieldInitializerOrder_PartialClass.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/StaticFieldInitializerOrder_PartialClass.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests.TestCases
+{
+    public partial class StaticFieldInitializerOrder
+    {
+        public static int W = 2;
+
+        public const int Const2 = 5;
+    }
+}


### PR DESCRIPTION
Fix #692 