### PR TITLE
Improved error reporting in powershell script

### DIFF
--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -46,14 +46,23 @@ function Write-Header([string]$text) {
 function Get-ExecutablePath([string]$name, [string]$directory, [string]$envVar) {
     $path = [environment]::GetEnvironmentVariable($envVar, "Process")
 
-    if (!$path) {
-        if (!$directory) {
-            $path = Exec { & where.exe $name } | Select-Object -First 1
-        }
-        else {
-            $path = Exec { & where.exe /R $directory $name } | Select-Object -First 1
+    try
+    {
+        if (!$path) {
+            if (!$directory) {
+                $path = Exec { & where.exe $name } | Select-Object -First 1
+            }
+            else {
+                $path = Exec { & where.exe /R $directory $name } | Select-Object -First 1
+            }
         }
     }
+    catch
+    {
+        Write-Error "Failed to locate executable '${name}' on the path"
+        exit 1
+    }
+
 
     if (Test-Path $path) {
         Write-Host "Found '${name}' at '${path}'"

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -46,8 +46,7 @@ function Write-Header([string]$text) {
 function Get-ExecutablePath([string]$name, [string]$directory, [string]$envVar) {
     $path = [environment]::GetEnvironmentVariable($envVar, "Process")
 
-    try
-    {
+    try{
         if (!$path) {
             if (!$directory) {
                 $path = Exec { & where.exe $name } | Select-Object -First 1
@@ -59,8 +58,7 @@ function Get-ExecutablePath([string]$name, [string]$directory, [string]$envVar) 
     }
     catch
     {
-        Write-Error "Failed to locate executable '${name}' on the path"
-        exit 1
+        throw "Failed to locate executable '${name}' on the path"
     }
 
 
@@ -70,8 +68,7 @@ function Get-ExecutablePath([string]$name, [string]$directory, [string]$envVar) 
         return $path
     }
 
-    Write-Host "Cannot find '${name}'"
-    exit 1
+    throw "Cannot find '${name}'"
 }
 
 function Expand-ZIPFile($source, $destination) {


### PR DESCRIPTION
If the executable couldn't be found then the script would fail with an unhelpful error about _where.exe_.
Added a try-catch with a more useful output message.