### PR TITLE
Fix S2325: 'Member should be static' throws NullReferenceException

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 return methodDeclaration.ExpressionBody.DescendantNodes();
             }
 
-            return methodDeclaration.Body.DescendantNodes();
+            return methodDeclaration.Body?.DescendantNodes();
         }
 
         private static void CheckIssue<TDeclarationSyntax>(SyntaxNodeAnalysisContext context,
@@ -104,8 +104,13 @@ namespace SonarAnalyzer.Rules.CSharp
                 IsNewMethod(symbol) ||
                 IsEmptyMethod(declaration) ||
                 IsNewProperty(symbol) ||
-                IsAutoProperty(symbol) ||
-                HasInstanceReferences(getDescendants(declaration), context.SemanticModel))
+                IsAutoProperty(symbol))
+            {
+                return;
+            }
+
+            var descendants = getDescendants(declaration);
+            if (descendants == null || HasInstanceReferences(descendants, context.SemanticModel))
             {
                 return;
             }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MemberShouldBeStatic.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MemberShouldBeStatic.cs
@@ -136,4 +136,15 @@ namespace Tests.Diagnostics
         [System.ObsoleteAttribute]
         public int Method2() => 0; // Compliant, any attribute disables this rule
     }
+
+    // Handle invalid code causing NullReferenceException: https://github.com/SonarSource/sonar-csharp/issues/819
+    public class Class7
+    {
+        public async Task<Result<T> Function<T>(Func<Task<Result<T>>> f)
+        {
+            Result<T> result;
+            result = await f();
+            return result;
+        }
+    }
 }


### PR DESCRIPTION
Fix #819 