### PR TITLE
Fix S3242: Rule throws ArgumentException when 2+ params of method hav…

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MethodsShouldUseBaseTypes.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MethodsShouldUseBaseTypes.cs
@@ -67,7 +67,8 @@ namespace SonarAnalyzer.Rules.CSharp
 
             var parametersToCheck = methodSymbol.Parameters
                 .Where(IsTrackedParameter)
-                .ToDictionary(p => p.Name, p => new ParameterData(p));
+                .GroupBy(p => p.Name)
+                .ToDictionary(p => p.Key, p => new ParameterData(p.First()));
 
             var parameterUsesInMethod = context
                 .Node

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MethodsShouldUseBaseTypes.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MethodsShouldUseBaseTypes.cs
@@ -65,6 +65,8 @@ namespace SonarAnalyzer.Rules.CSharp
                 return Enumerable.Empty<Diagnostic>();
             }
 
+            // The GroupBy is useless in most of the cases but safe-guard in case of 2+ parameters with same name (invalid code).
+            // In this case we analyze only the first parameter (a new analysis will be triggered after fixing the names).
             var parametersToCheck = methodSymbol.Parameters
                 .Where(IsTrackedParameter)
                 .GroupBy(p => p.Name)

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldUseBaseTypes.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldUseBaseTypes.cs
@@ -617,5 +617,10 @@ namespace Test_22
         {
             a.ToList();
         }
+
+        private void FooBar(IList<int> , IList<string>)
+        {
+            a.ToList();
+        }
     }
 }

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldUseBaseTypes.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldUseBaseTypes.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 // Test interface inheritance
 namespace Test_01
@@ -603,6 +604,18 @@ namespace Test_21
         public void MethodB(B b)
         {
             b.Foo();
+        }
+    }
+}
+
+namespace Test_22
+{
+    public class Foo
+    {
+        // New test case - code doesn't compile but was making analyzer crash
+        private void Foo(IList<int> a, IList<string> a)
+        {
+            a.ToList();
         }
     }
 }


### PR DESCRIPTION
…e the same name

Fix #834 