### PR TITLE
Do not enforce var everywhere

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -67,10 +67,8 @@ dotnet_style_explicit_tuple_names = true:suggestion
 
 # CSharp code style settings:
 [*.cs]
-# Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:suggestion
+# Prefer "var" when type is apparent
 csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none


### PR DESCRIPTION
As you know, "var everywhere" is a bit controversial in our team. With current rules, VS even to even do `for (var i = 0; i<XXX; i++)`, which I see a step too far. Let's soften it a bit to the part everybody is happy with.