### PR TITLE
Fix S2259: Rule should not fire on nameof(a.P) when a is null

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
@@ -966,7 +966,12 @@ namespace SonarAnalyzer.SymbolicExecution.ControlFlowGraph
         {
             currentBlock.ReversedInstructions.Add(parent);
 
-            return children == null
+            // The nameof arguments are not evaluated at runtime and should not be added
+            // to the block as instructions
+            var isNameof = parent is InvocationExpressionSyntax invocation
+                && invocation.IsNameof(semanticModel);
+
+            return children == null || isNameof
                 ? currentBlock
                 : BuildExpressions(children, currentBlock);
         }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/InvocationVisitor.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/InvocationVisitor.cs
@@ -74,7 +74,7 @@ namespace SonarAnalyzer.SymbolicExecution
 
             if (invocation.IsNameof(semanticModel))
             {
-                return HandleNameofExpression(invocationArgsCount);
+                return HandleNameofExpression();
             }
 
             return programState
@@ -82,16 +82,11 @@ namespace SonarAnalyzer.SymbolicExecution
                 .PushValue(new SymbolicValue());
         }
 
-        private ProgramState HandleNameofExpression(int argumentsCount)
+        private ProgramState HandleNameofExpression()
         {
-            // We want to handle the correct nameof(a) but also malformed ones likes nameof(), nameof(a, b)...
-            // So we pop number of arguments + the nameof itself
-            var newProgramState = programState
-                .PopValues(argumentsCount)
-                .PopValue();
-
+            // The nameof arguments are not on the stack, we just push the nameof result
             var nameof = new SymbolicValue();
-            newProgramState = newProgramState.PushValue(nameof);
+            var newProgramState = programState.PushValue(nameof);
             return newProgramState.SetConstraint(nameof, ObjectConstraint.NotNull);
         }
 

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
@@ -524,6 +524,12 @@ namespace Tests.Diagnostics
             _foo1.ToString(); // Noncompliant
         }
 
+        void DereferenceInNameOfShouldNotRaise()
+        {
+            object o = null;
+            var name = nameof(o.ToString);
+        }
+
         void DoSomething() { }
 
         void TestNameOf()


### PR DESCRIPTION
Fix #923 