### PR TITLE
Update SonarC#: Unit Tests total and skipped numbers are not consistent

### DIFF
--- a/its/projects/UnitTestResultsTest/reports/vstest.trx
+++ b/its/projects/UnitTestResultsTest/reports/vstest.trx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TestRun id="db9562ec-872e-4714-a0bc-e9e96f702955" name="vagrant@WIN7PRO64 2014-06-12 10:10:41" runUser="WIN7PRO64\vagrant" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
   <ResultSummary outcome="Completed">
-    <Counters total="42" executed="42" passed="21" error="1" failed="2" timeout="3" aborted="5" inconclusive="7" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <Counters total="42" executed="40" passed="21" error="1" failed="2" timeout="3" aborted="5" inconclusive="7" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
   </ResultSummary>
 </TestRun>

--- a/its/src/test/java/com/sonar/it/csharp/UnitTestResultsTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/UnitTestResultsTest.java
@@ -68,10 +68,10 @@ public class UnitTestResultsTest {
     BuildResult buildResult = analyzeTestProject("sonar.cs.vstest.reportsPaths", "reports/vstest.trx");
 
     assertThat(buildResult.getLogs()).contains("C# Unit Test Results Import");
-    assertThat(getMeasureAsInt("UnitTestResultsTest", "tests")).isEqualTo(32);
+    assertThat(getMeasureAsInt("UnitTestResultsTest", "tests")).isEqualTo(40);
     assertThat(getMeasureAsInt("UnitTestResultsTest", "test_errors")).isEqualTo(1);
     assertThat(getMeasureAsInt("UnitTestResultsTest", "test_failures")).isEqualTo(10);
-    assertThat(getMeasureAsInt("UnitTestResultsTest", "skipped_tests")).isEqualTo(7);
+    assertThat(getMeasureAsInt("UnitTestResultsTest", "skipped_tests")).isEqualTo(2);
   }
 
   @Test
@@ -79,17 +79,17 @@ public class UnitTestResultsTest {
     BuildResult buildResult = analyzeTestProject("sonar.cs.nunit.reportsPaths", "reports/nunit.xml");
 
     assertThat(buildResult.getLogs()).contains("C# Unit Test Results Import");
-    assertThat(getMeasureAsInt("UnitTestResultsTest", "tests")).isEqualTo(196);
+    assertThat(getMeasureAsInt("UnitTestResultsTest", "tests")).isEqualTo(191);
     assertThat(getMeasureAsInt("UnitTestResultsTest", "test_errors")).isEqualTo(30);
     assertThat(getMeasureAsInt("UnitTestResultsTest", "test_failures")).isEqualTo(20);
-    assertThat(getMeasureAsInt("UnitTestResultsTest", "skipped_tests")).isEqualTo(7);
+    assertThat(getMeasureAsInt("UnitTestResultsTest", "skipped_tests")).isEqualTo(9);
   }
 
   @Test
   public void should_support_wildcard_patterns() throws Exception {
     analyzeTestProject("sonar.cs.vstest.reportsPaths", "reports/*.trx");
 
-    assertThat(getMeasureAsInt("UnitTestResultsTest", "tests")).isEqualTo(32);
+    assertThat(getMeasureAsInt("UnitTestResultsTest", "tests")).isEqualTo(42);
   }
 
   private BuildResult analyzeTestProject(String... keyValues) throws IOException {

--- a/its/src/test/java/com/sonar/it/csharp/UnitTestResultsTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/UnitTestResultsTest.java
@@ -68,7 +68,7 @@ public class UnitTestResultsTest {
     BuildResult buildResult = analyzeTestProject("sonar.cs.vstest.reportsPaths", "reports/vstest.trx");
 
     assertThat(buildResult.getLogs()).contains("C# Unit Test Results Import");
-    assertThat(getMeasureAsInt("UnitTestResultsTest", "tests")).isEqualTo(40);
+    assertThat(getMeasureAsInt("UnitTestResultsTest", "tests")).isEqualTo(42);
     assertThat(getMeasureAsInt("UnitTestResultsTest", "test_errors")).isEqualTo(1);
     assertThat(getMeasureAsInt("UnitTestResultsTest", "test_failures")).isEqualTo(10);
     assertThat(getMeasureAsInt("UnitTestResultsTest", "skipped_tests")).isEqualTo(2);
@@ -79,7 +79,7 @@ public class UnitTestResultsTest {
     BuildResult buildResult = analyzeTestProject("sonar.cs.nunit.reportsPaths", "reports/nunit.xml");
 
     assertThat(buildResult.getLogs()).contains("C# Unit Test Results Import");
-    assertThat(getMeasureAsInt("UnitTestResultsTest", "tests")).isEqualTo(191);
+    assertThat(getMeasureAsInt("UnitTestResultsTest", "tests")).isEqualTo(200);
     assertThat(getMeasureAsInt("UnitTestResultsTest", "test_errors")).isEqualTo(30);
     assertThat(getMeasureAsInt("UnitTestResultsTest", "test_failures")).isEqualTo(20);
     assertThat(getMeasureAsInt("UnitTestResultsTest", "skipped_tests")).isEqualTo(9);

--- a/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParser.java
+++ b/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParser.java
@@ -71,15 +71,12 @@ public class NUnitTestResultsFileParser implements UnitTestResultsParser {
       int skipped = xmlParserHelper.getRequiredIntAttribute("skipped");
 
       int totalSkipped = skipped + inconclusive + ignored;
-      // Surprisingly the Unit Tests measure count in SonarQube is not the total number of tests but the total of
-      // not-skipped tests. To actually get the total you need to add this metric with the skipped one.
-      int tests = total - totalSkipped;
-      int passed = tests - errors - failures;
+      int passed = total - errors - failures;
 
       Double duration = readExecutionTimeFromDirectlyNestedTestSuiteTags(xmlParserHelper);
       Long executionTime = duration != null ? (long) duration.doubleValue() : null;
 
-      unitTestResults.add(tests, passed, totalSkipped, failures, errors, executionTime);
+      unitTestResults.add(total, passed, totalSkipped, failures, errors, executionTime);
     }
 
     private void handleTestRunTag(XmlParserHelper xmlParserHelper) {
@@ -90,16 +87,13 @@ public class NUnitTestResultsFileParser implements UnitTestResultsParser {
       int skipped = xmlParserHelper.getRequiredIntAttribute("skipped");
 
       int totalSkipped = skipped + inconclusive;
-      // Surprisingly the Unit Tests measure count in SonarQube is not the total number of tests but the total of
-      // not-skipped tests. To actually get the total you need to add this metric with the skipped one.
-      int tests = total - totalSkipped;
 
       Double duration = xmlParserHelper.getDoubleAttribute("duration");
       Long executionTime = duration != null ? (long) (duration * 1000) : null;
 
       int errors = readErrorCountFromNestedTestCaseTags(xmlParserHelper);
 
-      unitTestResults.add(tests, passed, totalSkipped, failures, errors, executionTime);
+      unitTestResults.add(total, passed, totalSkipped, failures, errors, executionTime);
     }
 
     @CheckForNull

--- a/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParser.java
+++ b/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParser.java
@@ -80,16 +80,21 @@ public class VisualStudioTestResultsFileParser implements UnitTestResultsParser 
     private void handleCountersTag(XmlParserHelper xmlParserHelper) {
       foundCounters = true;
 
+      int total = xmlParserHelper.getIntAttributeOrZero("total");
       int passed = xmlParserHelper.getIntAttributeOrZero("passed");
       int failed = xmlParserHelper.getIntAttributeOrZero("failed");
       int errors = xmlParserHelper.getIntAttributeOrZero("error");
       int timeout = xmlParserHelper.getIntAttributeOrZero("timeout");
       int aborted = xmlParserHelper.getIntAttributeOrZero("aborted");
+      int executed = xmlParserHelper.getIntAttributeOrZero("executed");
 
-      int inconclusive = xmlParserHelper.getIntAttributeOrZero("inconclusive");
-
-      int tests = passed + failed + errors + timeout + aborted;
-      int skipped = inconclusive;
+      // IgnoreAttribute and Assert.Inconclusive do not appear in the trx (xml attributes are always 0).
+      // There is no official documentation but it seems like the only way to get skipped tests is to do the following
+      // maths.
+      int skipped = total - executed;
+      // Surprisingly the Unit Tests measure count in SonarQube is not the total number of tests but the total of
+      // not-skipped tests. To actually get the total you need to add this metric with the skipped one.
+      int tests = total - skipped;
       int failures = timeout + failed + aborted;
 
       unitTestResults.add(tests, passed, skipped, failures, errors, null);

--- a/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParser.java
+++ b/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParser.java
@@ -92,12 +92,9 @@ public class VisualStudioTestResultsFileParser implements UnitTestResultsParser 
       // There is no official documentation but it seems like the only way to get skipped tests is to do the following
       // maths.
       int skipped = total - executed;
-      // Surprisingly the Unit Tests measure count in SonarQube is not the total number of tests but the total of
-      // not-skipped tests. To actually get the total you need to add this metric with the skipped one.
-      int tests = total - skipped;
       int failures = timeout + failed + aborted;
 
-      unitTestResults.add(tests, passed, skipped, failures, errors, null);
+      unitTestResults.add(total, passed, skipped, failures, errors, null);
     }
 
     private void handleTimesTag(XmlParserHelper xmlParserHelper) {

--- a/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
+++ b/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
@@ -75,12 +75,10 @@ public class XUnitTestResultsFileParser implements UnitTestResultsParser {
       int skipped = xmlParserHelper.getRequiredIntAttribute("skipped");
       int errors = xmlParserHelper.getIntAttributeOrZero("errors");
 
-      int tests = total - skipped;
-
       Double time = xmlParserHelper.getDoubleAttribute("time");
       Long executionTime = time != null ? (long) (time * 1000) : null;
 
-      unitTestResults.add(tests, passed, skipped, failed, errors, executionTime);
+      unitTestResults.add(total, passed, skipped, failed, errors, executionTime);
     }
 
   }

--- a/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
+++ b/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
@@ -74,12 +74,13 @@ public class XUnitTestResultsFileParser implements UnitTestResultsParser {
       int failed = xmlParserHelper.getRequiredIntAttribute("failed");
       int skipped = xmlParserHelper.getRequiredIntAttribute("skipped");
       int errors = xmlParserHelper.getIntAttributeOrZero("errors");
-      Double executionTime = xmlParserHelper.getDoubleAttribute("time");
-      if (executionTime != null) {
-        executionTime *= 1000;
-      }
 
-      unitTestResults.add(total, passed, skipped, failed, errors, executionTime != null ? (long) executionTime.doubleValue() : null);
+      int tests = total - skipped;
+
+      Double time = xmlParserHelper.getDoubleAttribute("time");
+      Long executionTime = time != null ? (long) (time * 1000) : null;
+
+      unitTestResults.add(tests, passed, skipped, failed, errors, executionTime);
     }
 
   }

--- a/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParserTest.java
+++ b/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParserTest.java
@@ -54,11 +54,11 @@ public class NUnitTestResultsFileParserTest {
     UnitTestResults results = new UnitTestResults();
     new NUnitTestResultsFileParser().accept(new File("src/test/resources/nunit/valid.xml"), results);
 
-    assertThat(results.tests()).isEqualTo(196);
-    assertThat(results.passedPercentage()).isEqualTo(146 * 100.0 / 196);
-    assertThat(results.skipped()).isEqualTo(7);
-    assertThat(results.failures()).isEqualTo(20);
     assertThat(results.errors()).isEqualTo(30);
+    assertThat(results.failures()).isEqualTo(20);
+    assertThat(results.skipped()).isEqualTo(9); // 4 + 3 + 2
+    assertThat(results.tests()).isEqualTo(191); // 200 - 9
+    assertThat(results.passedPercentage()).isEqualTo(141 * 100.0 / 191); // 191 - 30 - 20
     assertThat(results.executionTime()).isEqualTo(51);
   }
 
@@ -75,11 +75,11 @@ public class NUnitTestResultsFileParserTest {
     UnitTestResults results = new UnitTestResults();
     new NUnitTestResultsFileParser().accept(new File("src/test/resources/nunit/valid_no_execution_time.xml"), results);
 
-    assertThat(results.tests()).isEqualTo(196);
-    assertThat(results.passedPercentage()).isEqualTo(146 * 100.0 / 196);
-    assertThat(results.skipped()).isEqualTo(7);
     assertThat(results.failures()).isEqualTo(20);
     assertThat(results.errors()).isEqualTo(30);
+    assertThat(results.skipped()).isEqualTo(9); // 4 + 3 + 2
+    assertThat(results.tests()).isEqualTo(191); // 200 - 9
+    assertThat(results.passedPercentage()).isEqualTo(141 * 100.0 / 191); // 191 - 30 - 20
     assertThat(results.executionTime()).isNull();
   }
 
@@ -88,11 +88,11 @@ public class NUnitTestResultsFileParserTest {
     UnitTestResults results = new UnitTestResults();
     new NUnitTestResultsFileParser().accept(new File("src/test/resources/nunit/nunit3_sample.xml"), results);
 
-    assertThat(results.tests()).isEqualTo(18);
-    assertThat(results.passedPercentage()).isEqualTo(12 * 100.0 / 18);
-    assertThat(results.skipped()).isEqualTo(4);
     assertThat(results.failures()).isEqualTo(2);
     assertThat(results.errors()).isEqualTo(1);
+    assertThat(results.skipped()).isEqualTo(4); // 1 + 3
+    assertThat(results.tests()).isEqualTo(14); // 18 - 4
+    assertThat(results.passedPercentage()).isEqualTo(12 * 100.0 / 14); // 16 - 2 - 1
     assertThat(results.executionTime()).isEqualTo(154);
   }
 

--- a/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParserTest.java
+++ b/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParserTest.java
@@ -56,9 +56,9 @@ public class NUnitTestResultsFileParserTest {
 
     assertThat(results.errors()).isEqualTo(30);
     assertThat(results.failures()).isEqualTo(20);
+    assertThat(results.tests()).isEqualTo(200);
+    assertThat(results.passedPercentage()).isEqualTo(150 * 100.0 / 200); // 200 - 30 - 20
     assertThat(results.skipped()).isEqualTo(9); // 4 + 3 + 2
-    assertThat(results.tests()).isEqualTo(191); // 200 - 9
-    assertThat(results.passedPercentage()).isEqualTo(141 * 100.0 / 191); // 191 - 30 - 20
     assertThat(results.executionTime()).isEqualTo(51);
   }
 
@@ -77,9 +77,9 @@ public class NUnitTestResultsFileParserTest {
 
     assertThat(results.failures()).isEqualTo(20);
     assertThat(results.errors()).isEqualTo(30);
+    assertThat(results.tests()).isEqualTo(200);
+    assertThat(results.passedPercentage()).isEqualTo(150 * 100.0 / 200); // 200 - 30 - 20
     assertThat(results.skipped()).isEqualTo(9); // 4 + 3 + 2
-    assertThat(results.tests()).isEqualTo(191); // 200 - 9
-    assertThat(results.passedPercentage()).isEqualTo(141 * 100.0 / 191); // 191 - 30 - 20
     assertThat(results.executionTime()).isNull();
   }
 
@@ -90,9 +90,9 @@ public class NUnitTestResultsFileParserTest {
 
     assertThat(results.failures()).isEqualTo(2);
     assertThat(results.errors()).isEqualTo(1);
+    assertThat(results.tests()).isEqualTo(18);
+    assertThat(results.passedPercentage()).isEqualTo(12 * 100.0 / 18);
     assertThat(results.skipped()).isEqualTo(4); // 1 + 3
-    assertThat(results.tests()).isEqualTo(14); // 18 - 4
-    assertThat(results.passedPercentage()).isEqualTo(12 * 100.0 / 14); // 16 - 2 - 1
     assertThat(results.executionTime()).isEqualTo(154);
   }
 

--- a/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParserTest.java
+++ b/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParserTest.java
@@ -56,9 +56,9 @@ public class VisualStudioTestResultsFileParserTest {
 
     assertThat(results.failures()).isEqualTo(14);
     assertThat(results.errors()).isEqualTo(3);
+    assertThat(results.tests()).isEqualTo(43);
+    assertThat(results.passedPercentage()).isEqualTo(14 * 100.0 / 43);
     assertThat(results.skipped()).isEqualTo(12); // 43 - 31
-    assertThat(results.tests()).isEqualTo(31); // 43 - 12
-    assertThat(results.passedPercentage()).isEqualTo(14 * 100.0 / 31);
     assertThat(results.executionTime()).isEqualTo(816l);
   }
 

--- a/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParserTest.java
+++ b/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParserTest.java
@@ -54,11 +54,11 @@ public class VisualStudioTestResultsFileParserTest {
     UnitTestResults results = new UnitTestResults();
     new VisualStudioTestResultsFileParser().accept(new File("src/test/resources/visualstudio_test_results/valid.trx"), results);
 
-    assertThat(results.tests()).isEqualTo(31);
-    assertThat(results.passedPercentage()).isEqualTo(14 * 100.0 / 31);
-    assertThat(results.skipped()).isEqualTo(11);
     assertThat(results.failures()).isEqualTo(14);
     assertThat(results.errors()).isEqualTo(3);
+    assertThat(results.skipped()).isEqualTo(12); // 43 - 31
+    assertThat(results.tests()).isEqualTo(31); // 43 - 12
+    assertThat(results.passedPercentage()).isEqualTo(14 * 100.0 / 31);
     assertThat(results.executionTime()).isEqualTo(816l);
   }
 

--- a/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParserTest.java
+++ b/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParserTest.java
@@ -69,9 +69,9 @@ public class XUnitTestResultsFileParserTest {
 
     assertThat(results.failures()).isEqualTo(3);
     assertThat(results.errors()).isEqualTo(5);
+    assertThat(results.tests()).isEqualTo(17);
+    assertThat(results.passedPercentage()).isEqualTo(5 * 100.0 / 17);
     assertThat(results.skipped()).isEqualTo(4);
-    assertThat(results.tests()).isEqualTo(13); // 17 - 4
-    assertThat(results.passedPercentage()).isEqualTo(5 * 100.0 / 13);
     assertThat(results.executionTime()).isEqualTo(227 + 228);
   }
 
@@ -83,8 +83,8 @@ public class XUnitTestResultsFileParserTest {
     assertThat(results.failures()).isEqualTo(1);
     assertThat(results.errors()).isEqualTo(0);
     assertThat(results.skipped()).isEqualTo(2);
-    assertThat(results.tests()).isEqualTo(4);
-    assertThat(results.passedPercentage()).isEqualTo(3 * 100.0 / 4);
+    assertThat(results.tests()).isEqualTo(6);
+    assertThat(results.passedPercentage()).isEqualTo(3 * 100.0 / 6);
   }
 
   @Test
@@ -94,9 +94,9 @@ public class XUnitTestResultsFileParserTest {
 
     assertThat(results.failures()).isEqualTo(3);
     assertThat(results.errors()).isEqualTo(5);
+    assertThat(results.tests()).isEqualTo(17);
+    assertThat(results.passedPercentage()).isEqualTo(5 * 100.0 / 17);
     assertThat(results.skipped()).isEqualTo(4);
-    assertThat(results.tests()).isEqualTo(13); // 17 - 4
-    assertThat(results.passedPercentage()).isEqualTo(5 * 100.0 / 13);
     assertThat(results.executionTime()).isNull();
   }
 

--- a/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParserTest.java
+++ b/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParserTest.java
@@ -67,11 +67,11 @@ public class XUnitTestResultsFileParserTest {
     UnitTestResults results = new UnitTestResults();
     new XUnitTestResultsFileParser().accept(new File("src/test/resources/xunit/valid.xml"), results);
 
-    assertThat(results.tests()).isEqualTo(17);
-    assertThat(results.passedPercentage()).isEqualTo(5 * 100.0 / 17);
-    assertThat(results.skipped()).isEqualTo(4);
     assertThat(results.failures()).isEqualTo(3);
     assertThat(results.errors()).isEqualTo(5);
+    assertThat(results.skipped()).isEqualTo(4);
+    assertThat(results.tests()).isEqualTo(13); // 17 - 4
+    assertThat(results.passedPercentage()).isEqualTo(5 * 100.0 / 13);
     assertThat(results.executionTime()).isEqualTo(227 + 228);
   }
 
@@ -80,11 +80,11 @@ public class XUnitTestResultsFileParserTest {
     UnitTestResults results = new UnitTestResults();
     new XUnitTestResultsFileParser().accept(new File("src/test/resources/xunit/valid_xunit-1.9.2.xml"), results);
 
-    assertThat(results.tests()).isEqualTo(6);
-    assertThat(results.passedPercentage()).isEqualTo(3 * 100.0 / 6);
-    assertThat(results.skipped()).isEqualTo(2);
     assertThat(results.failures()).isEqualTo(1);
     assertThat(results.errors()).isEqualTo(0);
+    assertThat(results.skipped()).isEqualTo(2);
+    assertThat(results.tests()).isEqualTo(4);
+    assertThat(results.passedPercentage()).isEqualTo(3 * 100.0 / 4);
   }
 
   @Test
@@ -92,11 +92,11 @@ public class XUnitTestResultsFileParserTest {
     UnitTestResults results = new UnitTestResults();
     new XUnitTestResultsFileParser().accept(new File("src/test/resources/xunit/no_execution_time.xml"), results);
 
-    assertThat(results.tests()).isEqualTo(17);
-    assertThat(results.passedPercentage()).isEqualTo(5 * 100.0 / 17);
-    assertThat(results.skipped()).isEqualTo(4);
     assertThat(results.failures()).isEqualTo(3);
     assertThat(results.errors()).isEqualTo(5);
+    assertThat(results.skipped()).isEqualTo(4);
+    assertThat(results.tests()).isEqualTo(13); // 17 - 4
+    assertThat(results.passedPercentage()).isEqualTo(5 * 100.0 / 13);
     assertThat(results.executionTime()).isNull();
   }
 

--- a/sonar-dotnet-tests-library/src/test/resources/visualstudio_test_results/valid.trx
+++ b/sonar-dotnet-tests-library/src/test/resources/visualstudio_test_results/valid.trx
@@ -2,6 +2,6 @@
 <TestRun id="0ecff956-7215-452f-9ce6-2b6d45870188" name="vagrant@WIN7PRO64 2014-06-11 15:48:58" runUser="WIN7PRO64\vagrant" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
   <Times creation="2016-03-14T17:04:31.0752743+01:00" queuing="2016-03-14T17:04:31.4447480+01:00" start="2016-03-14T17:04:31.1+01:00" finish="2016-03-14T17:04:31.9162137+01:00" />
   <ResultSummary outcome="Failed">
-    <Counters total="43" executed="42" passed="14" failed="2" error="3" timeout="5" aborted="7" inconclusive="11" passedButRunAborted="0" notRunnable="0" notExecuted="1" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <Counters total="43" executed="31" passed="14" failed="2" error="3" timeout="5" aborted="7" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
   </ResultSummary>
 </TestRun>


### PR DESCRIPTION
Fix #973 