### PR TITLE
SONAR-1010 TestClassShouldHaveTestMethod recognizes [DataTestMethod]

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TestClassShouldHaveTestMethod.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TestClassShouldHaveTestMethod.cs
@@ -47,6 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static readonly ISet<KnownType> HandledTestMethodAttributes = ImmutableHashSet.Create(
             KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_TestMethodAttribute,
+            KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_DataTestMethodAttribute,
             KnownType.NUnit_Framework_TestAttribute,
             KnownType.NUnit_Framework_TestCaseAttribute,
             KnownType.NUnit_Framework_TestCaseSourceAttribute,

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -34,6 +34,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_IgnoreAttribute = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.IgnoreAttribute");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestClassAttribute = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestMethodAttribute = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_DataTestMethodAttribute = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_WorkItemAttribute = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.WorkItemAttribute");
         internal static readonly KnownType NUnit_Framework_Assert = new KnownType("NUnit.Framework.Assert");
         internal static readonly KnownType NUnit_Framework_ExpectedExceptionAttribute = new KnownType("NUnit.Framework.ExpectedExceptionAttribute");

--- a/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/TestClassShouldHaveTestMethod.cs
+++ b/sonaranalyzer-dotnet/src/Tests/SonarAnalyzer.UnitTest/TestCases/TestClassShouldHaveTestMethod.cs
@@ -67,6 +67,14 @@ namespace Tests.Diagnostics
     }
 
     [TestClass]
+    class ClassTest12
+    {
+        [DataTestMethod]
+        [DataRow(1)]
+        public void Foo(int i) { }
+    }
+
+    [TestClass]
     public abstract class MyCommonCode1
     {
     }


### PR DESCRIPTION
add DataTestMethod to recognized test method attributes