### PR TITLE
Rule S4212: Serialization constructors should be secured

### DIFF
--- a/sonaranalyzer-dotnet/rspec/cs/S4212_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S4212_c#.html
@@ -1,0 +1,79 @@
+<p>Because serialization constructors allocate and initialize objects, security checks that are present on regular constructors must also be present
+on a serialization constructor. Failure to do so would allow callers that could not otherwise create an instance to use the serialization constructor
+to do this.</p>
+<p>This rule raises an issue when a type implements the <code>System.Runtime.Serialization.ISerializable</code> interface, is not a delegate or
+interface, is declared in an assembly that allows partially trusted callers and has a constructor that takes a
+<code>System.Runtime.Serialization.SerializationInfo</code> object and a <code>System.Runtime.Serialization.StreamingContext</code> object which is
+not secured by a security check, but one or more of the regular constructors in the type is secured.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security;
+using System.Security.Permissions;
+
+[assembly: AllowPartiallyTrustedCallersAttribute()]
+namespace MyLibrary
+{
+    [Serializable]
+    public class Foo : ISerializable
+    {
+        private int n;
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        public Foo()
+        {
+           n = -1;
+        }
+
+        protected Foo(SerializationInfo info, StreamingContext context) // Noncompliant
+        {
+           n = (int)info.GetValue("n", typeof(int));
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+           info.AddValue("n", n);
+        }
+    }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security;
+using System.Security.Permissions;
+
+[assembly: AllowPartiallyTrustedCallersAttribute()]
+namespace MyLibrary
+{
+    [Serializable]
+    public class Foo : ISerializable
+    {
+        private int n;
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        public Foo()
+        {
+           n = -1;
+        }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        protected Foo(SerializationInfo info, StreamingContext context)
+        {
+           n = (int)info.GetValue("n", typeof(int));
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+           info.AddValue("n", n);
+        }
+    }
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/rspec/cs/S4212_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S4212_c#.json
@@ -1,0 +1,15 @@
+{
+  "title": "Serialization constructors should be secured",
+  "type": "VULNERABILITY",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "security"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-4212",
+  "sqKey": "S4212"
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -8300,6 +8300,33 @@
   </data>
   <data name="S4210_Type" xml:space="preserve">
     <value>BUG</value>
+  </data>
+  <data name="S4212_Category" xml:space="preserve">
+    <value>Critical Vulnerability</value>
+  </data>
+  <data name="S4212_Description" xml:space="preserve">
+    <value>Because serialization constructors allocate and initialize objects, security checks that are present on regular constructors must also be present on a serialization constructor. Failure to do so would allow callers that could not otherwise create an instance to use the serialization constructor to do this.</value>
+  </data>
+  <data name="S4212_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S4212_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S4212_RemediationCost" xml:space="preserve">
+    <value>5min</value>
+  </data>
+  <data name="S4212_Severity" xml:space="preserve">
+    <value>Critical</value>
+  </data>
+  <data name="S4212_Tags" xml:space="preserve">
+    <value>security</value>
+  </data>
+  <data name="S4212_Title" xml:space="preserve">
+    <value>Serialization constructors should be secured</value>
+  </data>
+  <data name="S4212_Type" xml:space="preserve">
+    <value>VULNERABILITY</value>
   </data>
   <data name="S4214_Category" xml:space="preserve">
     <value>Major Code Smell</value>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
@@ -1,0 +1,139 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(DiagnosticId)]
+    public sealed class SerializationConstructorsShouldBeSecured : SonarDiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "S4212";
+        private const string MessageFormat = "Secure that serialization constructor.";
+
+        private static readonly DiagnosticDescriptor rule =
+            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+
+        private static readonly AttributeComparer attributeComparer = new AttributeComparer();
+
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionInNonGenerated(FindPossibleViolations,
+                SyntaxKind.ConstructorDeclaration);
+        }
+
+        private void FindPossibleViolations(SyntaxNodeAnalysisContext c)
+        {
+            var constructorSyntax = (ConstructorDeclarationSyntax)c.Node;
+            var reportLocation = constructorSyntax?.Identifier.GetLocation();
+            if (reportLocation == null)
+            {
+                return;
+            }
+
+            var serializationConstructor = c.SemanticModel.GetDeclaredSymbol(constructorSyntax);
+            if (!serializationConstructor.IsSerializationConstructor())
+            {
+                return;
+            }
+
+            var classSymbol = serializationConstructor.ContainingType;
+            if (!classSymbol.Implements(KnownType.System_Runtime_Serialization_ISerializable))
+            {
+                return;
+            }
+
+            var isAssemblyIsPartiallyTrusted = c.SemanticModel.Compilation.Assembly
+                    .GetAttributes()
+                    .Any(a => a.AttributeClass.Is(KnownType.System_Security_AllowPartiallyTrustedCallersAttribute));
+            if (!isAssemblyIsPartiallyTrusted)
+            {
+                return;
+            }
+
+            var serializationConstructorAttributes = GetCasAttributes(serializationConstructor);
+
+            bool isConstructorMissingAttributes = classSymbol.Constructors
+                .SelectMany(m => GetCasAttributes(m))
+                .Any(attr => !serializationConstructorAttributes.Contains(attr, attributeComparer));
+
+            if (isConstructorMissingAttributes)
+            {
+                c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, reportLocation));
+            }
+        }
+
+        private static IEnumerable<AttributeData> GetCasAttributes(IMethodSymbol methodSymbol)
+        {
+            return methodSymbol.GetAttributes().Where(IsCasAttribute);
+
+            bool IsCasAttribute(AttributeData data) =>
+                data?.AttributeClass.DerivesFrom(KnownType.System_Security_Permissions_CodeAccessSecurityAttribute)
+                    ?? false;
+        }
+
+        private class AttributeComparer : IEqualityComparer<AttributeData>
+        {
+            public bool Equals(AttributeData x, AttributeData y)
+            {
+                return Equals(x.AttributeConstructor, y.AttributeConstructor) &&
+                    Enumerable.SequenceEqual(x.ConstructorArguments, y.ConstructorArguments) &&
+                    AreNamedArgumentsEqual(x.NamedArguments, y.NamedArguments);
+            }
+
+            private bool AreNamedArgumentsEqual(
+                ImmutableArray<KeyValuePair<string, TypedConstant>> argumentsX,
+                ImmutableArray<KeyValuePair<string, TypedConstant>> argumentsY)
+            {
+                var dictX = argumentsX.ToDictionary(p => p.Key, p => p.Value);
+                var dictY = argumentsY.ToDictionary(p => p.Key, p => p.Value);
+
+                if (dictX.Count != dictY.Count)
+                {
+                    return false;
+                }
+
+                foreach (var key in dictX.Keys)
+                {
+                    if (!dictX.TryGetValue(key, out TypedConstant itemX) ||
+                        !dictY.TryGetValue(key, out TypedConstant itemY) ||
+                        !Equals(itemX, itemY))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public int GetHashCode(AttributeData obj) => 1;
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -209,6 +209,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_Runtime_Serialization_SerializationInfo = new KnownType("System.Runtime.Serialization.SerializationInfo");
         internal static readonly KnownType System_Runtime_Serialization_StreamingContext = new KnownType("System.Runtime.Serialization.StreamingContext");
         internal static readonly KnownType System_SByte = new KnownType(SpecialType.System_SByte, "sbyte");
+        internal static readonly KnownType System_Security_AllowPartiallyTrustedCallersAttribute = new KnownType("System.Security.AllowPartiallyTrustedCallersAttribute");
         internal static readonly KnownType System_Security_Cryptography_DES = new KnownType("System.Security.Cryptography.DES");
         internal static readonly KnownType System_Security_Cryptography_DSA = new KnownType("System.Security.Cryptography.DSA");
         internal static readonly KnownType System_Security_Cryptography_HashAlgorithm = new KnownType("System.Security.Cryptography.HashAlgorithm");
@@ -220,6 +221,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_Security_Cryptography_RIPEMD160 = new KnownType("System.Security.Cryptography.RIPEMD160");
         internal static readonly KnownType System_Security_Cryptography_SHA1 = new KnownType("System.Security.Cryptography.SHA1");
         internal static readonly KnownType System_Security_Cryptography_TripleDES = new KnownType("System.Security.Cryptography.TripleDES");
+        internal static readonly KnownType System_Security_Permissions_CodeAccessSecurityAttribute = new KnownType("System.Security.Permissions.CodeAccessSecurityAttribute");
         internal static readonly KnownType System_Security_PermissionSet = new KnownType("System.Security.PermissionSet");
         internal static readonly KnownType System_SerializableAttribute = new KnownType("System.SerializableAttribute");
         internal static readonly KnownType System_ServiceModel_OperationContractAttribute = new KnownType("System.ServiceModel.OperationContractAttribute");

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S4212.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S4212.html
@@ -1,0 +1,79 @@
+<p>Because serialization constructors allocate and initialize objects, security checks that are present on regular constructors must also be present
+on a serialization constructor. Failure to do so would allow callers that could not otherwise create an instance to use the serialization constructor
+to do this.</p>
+<p>This rule raises an issue when a type implements the <code>System.Runtime.Serialization.ISerializable</code> interface, is not a delegate or
+interface, is declared in an assembly that allows partially trusted callers and has a constructor that takes a
+<code>System.Runtime.Serialization.SerializationInfo</code> object and a <code>System.Runtime.Serialization.StreamingContext</code> object which is
+not secured by a security check, but one or more of the regular constructors in the type is secured.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security;
+using System.Security.Permissions;
+
+[assembly: AllowPartiallyTrustedCallersAttribute()]
+namespace MyLibrary
+{
+    [Serializable]
+    public class Foo : ISerializable
+    {
+        private int n;
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        public Foo()
+        {
+           n = -1;
+        }
+
+        protected Foo(SerializationInfo info, StreamingContext context) // Noncompliant
+        {
+           n = (int)info.GetValue("n", typeof(int));
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+           info.AddValue("n", n);
+        }
+    }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security;
+using System.Security.Permissions;
+
+[assembly: AllowPartiallyTrustedCallersAttribute()]
+namespace MyLibrary
+{
+    [Serializable]
+    public class Foo : ISerializable
+    {
+        private int n;
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        public Foo()
+        {
+           n = -1;
+        }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        protected Foo(SerializationInfo info, StreamingContext context)
+        {
+           n = (int)info.GetValue("n", typeof(int));
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+           info.AddValue("n", n);
+        }
+    }
+}
+</pre>
+

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/PackagingTests/CsRuleTypeMapping.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/PackagingTests/CsRuleTypeMapping.cs
@@ -4209,7 +4209,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
             //["4209"],
             ["4210"] = "BUG",
             //["4211"],
-            //["4212"],
+            ["4212"] = "VULNERABILITY",
             //["4213"],
             ["4214"] = "CODE_SMELL",
             //["4215"],

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SerializationConstructorsShouldBeSecuredTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SerializationConstructorsShouldBeSecuredTest.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+extern alias csharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using csharp::SonarAnalyzer.Rules.CSharp;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class SerializationConstructorsShouldBeSecuredTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void SerializationConstructorsShouldBeSecured()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\SerializationConstructorsShouldBeSecured.cs",
+                new SerializationConstructorsShouldBeSecured());
+        }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void SerializationConstructorsShouldBeSecured_NoAssemblyAttribute()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\SerializationConstructorsShouldBeSecured_NoAssemblyAttribute.cs",
+                new SerializationConstructorsShouldBeSecured());
+        }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void SerializationConstructorsShouldBeSecured_PartialClasses()
+        {
+            Verifier.VerifyAnalyzer(new[]
+            {
+                @"TestCases\SerializationConstructorsShouldBeSecured_Part1.cs",
+                @"TestCases\SerializationConstructorsShouldBeSecured_Part2.cs",
+            },
+            new SerializationConstructorsShouldBeSecured());
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/SerializationConstructorsShouldBeSecured.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/SerializationConstructorsShouldBeSecured.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security;
+using System.Security.Permissions;
+
+[assembly: System.Security.AllowPartiallyTrustedCallers()]
+namespace MyLibrary
+{
+    [Serializable]
+    public class Foo : ISerializable
+    {
+        private int n;
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        public Foo()
+        {
+            n = -1;
+        }
+
+        protected Foo(SerializationInfo info, StreamingContext context) // Noncompliant {{Secure that serialization constructor.}}
+//                ^^^
+        {
+            n = (int)info.GetValue("n", typeof(int));
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("n", n);
+        }
+    }
+
+    [Serializable]
+    public class Foo_ok : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        public Foo_ok() { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        protected Foo_ok(SerializationInfo info, StreamingContext context) { } // Compliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+    [Serializable]
+    public class Foo2 : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public Foo2() { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        protected Foo2(SerializationInfo info, StreamingContext context) { } // Noncompliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+
+    [Serializable]
+    public class Foo2_ok : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public Foo2_ok() { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        protected Foo2_ok(SerializationInfo info, StreamingContext context) { } // Compliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+    [Serializable]
+    public class Foo3 : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public Foo3() { }
+
+        [GacIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public Foo3(int i) { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        protected Foo3(SerializationInfo info, StreamingContext context) { } // Noncompliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+    [Serializable]
+    public class Foo3_ok : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public Foo3_ok() { }
+
+        [GacIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public Foo3_ok(int i) { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        [GacIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        protected Foo3_ok(SerializationInfo info, StreamingContext context) { } // Compliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+
+    public class Foo4 : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.InheritanceDemand)]
+        public Foo4() { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand)]
+        protected Foo4(SerializationInfo info, StreamingContext context) { } // Noncompliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+    public class Foo4_ok : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.InheritanceDemand)]
+        public Foo4_ok() { }
+
+        [FileIOPermissionAttribute(SecurityAction.InheritanceDemand)]
+        protected Foo4_ok(SerializationInfo info, StreamingContext context) { } // Compliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+
+    public class Foo5 : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = false)]
+        public Foo5() { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        protected Foo5(SerializationInfo info, StreamingContext context) { } // Noncompliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+    public class Foo5_ok : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand)]
+        public Foo5_ok() { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand)]
+        protected Foo5_ok(SerializationInfo info, StreamingContext context) { } // Compliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+
+    public class Foo6 : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        public Foo6() { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand)]
+        protected Foo6(SerializationInfo info, StreamingContext context) { } // Noncompliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+    public class Foo6_ok : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        public Foo6_ok() { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        protected Foo6_ok(SerializationInfo info, StreamingContext context) { } // Compliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+    [Serializable]
+    public partial class InvalidCode : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public InvalidCode() { }
+
+        protected (SerializationInfo info, StreamingContext context) { }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/SerializationConstructorsShouldBeSecured.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/SerializationConstructorsShouldBeSecured.cs
@@ -19,7 +19,7 @@ namespace MyLibrary
             n = -1;
         }
 
-        protected Foo(SerializationInfo info, StreamingContext context) // Noncompliant {{Secure that serialization constructor.}}
+        protected Foo(SerializationInfo info, StreamingContext context) // Noncompliant {{Secure this serialization constructor.}}
 //                ^^^
         {
             n = (int)info.GetValue("n", typeof(int));
@@ -176,6 +176,17 @@ namespace MyLibrary
     }
 
     [Serializable]
+    public partial class MalformedAttributes : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Whatever_Mate)]
+        public MalformedAttributes() { }
+
+        protected MalformedAttributes(SerializationInfo info, StreamingContext context) { } // Noncompliant
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+[Serializable]
     public partial class InvalidCode : ISerializable
     {
         [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/SerializationConstructorsShouldBeSecured_NoAssemblyAttribute.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/SerializationConstructorsShouldBeSecured_NoAssemblyAttribute.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security;
+
+namespace MyLibrary
+{
+    [Serializable]
+    public class Foo : ISerializable
+    {
+        private int n;
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        public Foo()
+        {
+            n = -1;
+        }
+
+        protected Foo(SerializationInfo info, StreamingContext context) // Compliant (no partial trust assembly attribute)
+        {
+            n = (int)info.GetValue("n", typeof(int));
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("n", n);
+        }
+    }
+
+    [Serializable]
+    public class Foo_ok : ISerializable
+    {
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        public Foo_ok() { }
+
+        [FileIOPermissionAttribute(SecurityAction.Demand, Unrestricted = true)]
+        protected Foo_ok(SerializationInfo info, StreamingContext context) { } // Compliant
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/SerializationConstructorsShouldBeSecured_Part1.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/SerializationConstructorsShouldBeSecured_Part1.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+
+[assembly: System.Security.AllowPartiallyTrustedCallers()]
+namespace MyLibrary
+{
+
+
+
+    // Noncompliant (in *part2.cs)
+
+    [Serializable]
+    public partial class PartialFoo : ISerializable
+    {
+        [FileIOPermission(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public PartialFoo() { }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+    [Serializable]
+    public partial class PartialFoo_ok : ISerializable
+    {
+        [FileIOPermission(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public PartialFoo_ok() { }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+
+    [Serializable]
+    public partial class PartialFoo2 : ISerializable
+    {
+        [FileIOPermission(SecurityAction.Demand, Unrestricted = true)]
+        protected PartialFoo2(SerializationInfo info, StreamingContext context) { } // Noncompliant
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+
+    [Serializable]
+    public partial class PartialFoo2_ok : ISerializable
+    {
+        [FileIOPermission(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        protected PartialFoo2_ok(SerializationInfo info, StreamingContext context) { }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) { }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/SerializationConstructorsShouldBeSecured_Part2.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/SerializationConstructorsShouldBeSecured_Part2.cs
@@ -1,0 +1,35 @@
+﻿using System.Runtime.Serialization;
+using System.Security.Permissions;
+
+
+[assembly: System.Security.AllowPartiallyTrustedCallers()]
+namespace MyLibrary
+{
+    public partial class PartialFoo
+    {
+        [FileIOPermission(SecurityAction.Demand, Unrestricted = true)]
+        protected PartialFoo(SerializationInfo info, StreamingContext context) { }
+    }
+
+    public partial class PartialFoo_ok : ISerializable
+    {
+        [FileIOPermission(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        protected PartialFoo_ok(SerializationInfo info, StreamingContext context) { }
+    }
+
+
+    public partial class PartialFoo2 : ISerializable
+    {
+        [FileIOPermission(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public PartialFoo2() { }
+    }
+
+    public partial class PartialFoo2_ok : ISerializable
+    {
+        [FileIOPermission(SecurityAction.Demand, Unrestricted = true)]
+        [ZoneIdentityPermission(SecurityAction.Demand, Unrestricted = true)]
+        public PartialFoo2_ok() { }
+    }
+}


### PR DESCRIPTION
Fix #1070 