### PR TITLE
Fix S4220 : Rule should not throw StackOverflowException

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EventHandlerDelegateShouldHaveProperArguments.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EventHandlerDelegateShouldHaveProperArguments.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2018 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -118,6 +118,13 @@ namespace SonarAnalyzer.Rules.CSharp
             if (expression is MemberBindingExpressionSyntax)
             {
                 var conditionalExpression = expression.FirstAncestorOrSelf<ConditionalAccessExpressionSyntax>();
+                var isSelf = expression == conditionalExpression?.Expression;
+
+                if (isSelf)
+                {
+                    return null;
+                }
+
                 return GetEventSymbol(conditionalExpression?.Expression, model);
             }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EventHandlerDelegateShouldHaveProperArguments.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EventHandlerDelegateShouldHaveProperArguments.cs
@@ -1,7 +1,12 @@
-using System;
+﻿using System;
 
 namespace Tests.Diagnostics
 {
+    class Foo
+    {
+        public EventHandler Bar { get; }
+    }
+
     class Program
     {
         public event EventHandler SomeEvent;
@@ -44,6 +49,13 @@ namespace Tests.Diagnostics
         {
             SomeEvent(); // Invalid syntax
             SomeEvent(null, null, null); // Invalid syntax
+        }
+
+        protected void OnEvent()
+        {
+            Foo foo = new Foo();
+
+            foo?.Bar?.Invoke(this, EventArgs.Empty); // Should not cause a StackOverflow
         }
     }
 }


### PR DESCRIPTION
Hi,

We encountered a StackOverflow in one of our projects during the build when using the sonar c# analyser.

After a divide and conquer strategy, I was able to isolate the code and deduce the faulty rule.

It's a very specific combination of criteria :
- An encapsuled EventHandler without event keyword
- A nested conditionnal access and invoke of the handler
In this case the method GetEventSymbol get called in infinite loop.

Here, the reproduction case and the fix.

There may be better way to handle this case, I don't know well the roselyn api.
