### PR TITLE
Allow metadata computing metrics to be ignored during its

### DIFF
--- a/sonaranalyzer-dotnet/its/SingleRule.ruleset.template
+++ b/sonaranalyzer-dotnet/its/SingleRule.ruleset.template
@@ -20019,6 +20019,7 @@
 
     <Rule Id="S9999-cpd" Action="None" />
     <Rule Id="S9999-encoding" Action="None" />
+    <Rule Id="S9999-metadata" Action="None" />
     <Rule Id="S9999-metrics" Action="None" />
     <Rule Id="S9999-token-type" Action="None" />
     <Rule Id="S9999-symbolRef" Action="None" />


### PR DESCRIPTION
This speeds up its for a single rule by 10s