### PR TITLE
Fix S3925: Should not raise on explicit implementation of ISerializable

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ImplementISerializableCorrectly.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ImplementISerializableCorrectly.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.Serialization;
 
 namespace Tests.Diagnostics
@@ -94,16 +94,26 @@ namespace Tests.Diagnostics
     }
 
     [Serializable]
-    public class Serializable_ExplicitImplementation : ISerializable
-//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant
+    public class Serializable_ExplicitImplementation : ISerializable // Compliant, False Negative - rule should be extended to ensure there is a virtual GetObjectData method that is called
     {
         public Serializable_ExplicitImplementation()
         { /*do something*/ }
         protected Serializable_ExplicitImplementation(SerializationInfo info, StreamingContext context)
         { /*do something*/ }
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
-//                         ^^^^^^^^^^^^^ Secondary {{Make 'GetObjectData' 'public' and 'virtual', or seal 'Serializable_ExplicitImplementation'.}}
         { /*do something*/ }
+    }
+
+    [Serializable]
+    public class Serializable_ExplicitImplementation : ISerializable
+    {
+        public Serializable_ExplicitImplementation()
+        { /*do something*/ }
+        protected Serializable_ExplicitImplementation(SerializationInfo info, StreamingContext context)
+        { /*do something*/ }
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        { GetObjectData(info, context); }
+        protected virtual GetObjectData(SerializationInfo info, StreamingContext context) { }
     }
 
     [Serializable]


### PR DESCRIPTION
Fix #1076 

Not perfect solution, but to make it right I have to rewrite half of the rule. Basically disabled the check for public/virtual GetObjectData on explicitly implemented interfaces. There is no check if the explicit implementation calls the virtual method, or if there is a virtual method at all.