### PR TITLE
Update S3440: 'Variables should not be checked before assignment' should not raise on properties

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
@@ -19,6 +19,7 @@
  */
 
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -48,7 +49,8 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var ifStatement = (IfStatementSyntax)c.Node;
                     if (ifStatement.Else != null ||
-                        ifStatement.Parent is ElseClauseSyntax)
+                        ifStatement.Parent is ElseClauseSyntax ||
+                        ifStatement.Ancestors().OfType<PropertyDeclarationSyntax>().Any())
                     {
                         return;
                     }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var ifStatement = (IfStatementSyntax)c.Node;
                     if (ifStatement.Else != null ||
                         ifStatement.Parent is ElseClauseSyntax ||
-                        ifStatement.Ancestors().OfType<PropertyDeclarationSyntax>().Any())
+                        ifStatement.FirstAncestorOrSelf<PropertyDeclarationSyntax>() is PropertyDeclarationSyntax)
                     {
                         return;
                     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantConditionalAroundAssignment.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantConditionalAroundAssignment.Fixed.cs
@@ -47,5 +47,24 @@ namespace Tests.Diagnostics
                 y += 2;
             }
         }
+
+        // Properties are not checked
+        public static void Property
+        {
+            get
+            {
+                if (x != null)
+                {
+                    x = null;
+                }
+            }
+            set
+            {
+                if (x != null)
+                {
+                    x = null;
+                }
+            }
+        }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantConditionalAroundAssignment.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantConditionalAroundAssignment.cs
@@ -60,5 +60,24 @@ namespace Tests.Diagnostics
                 y += 2;
             }
         }
+
+        // Properties are not checked
+        public static void Property
+        {
+            get
+            {
+                if (x != null)
+                {
+                    x = null;
+                }
+            }
+            set
+            {
+                if (x != null)
+                {
+                    x = null;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #1000 