### PR TITLE
SONARVB-269 Dotnet build fails when analyzers report location contain…

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Helpers
 {
     public static class AnalysisContextExtensions
     {
-        private static readonly Regex VbNetErrorPattern = new Regex(@"\s+error\s*:",
+        private static readonly Regex VbNetErrorPattern = new Regex(@"\s+error\s*",
             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         public static void ReportDiagnosticWhenActive(this SyntaxNodeAnalysisContext context, Diagnostic diagnostic)


### PR DESCRIPTION
…ing string "error"

It seems that the following change makes the build not to fail when using the "dotnet" command.