### PR TITLE
Rule S4261: Methods should be named according to their synchronicity

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S4261.json
@@ -1,0 +1,238 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\AfterPipeline.cs",
+"region":  {
+"startLine":  55,
+"startColumn":  27,
+"endLine":  55,
+"endColumn":  33
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\BeforePipeline.cs",
+"region":  {
+"startLine":  52,
+"startColumn":  37,
+"endLine":  52,
+"endColumn":  43
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Helpers\TaskHelpers.cs",
+"region":  {
+"startLine":  10,
+"startColumn":  31,
+"endLine":  10,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\INancyEngine.cs",
+"region":  {
+"startLine":  27,
+"startColumn":  28,
+"endLine":  27,
+"endColumn":  41
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\IO\RequestStream.cs",
+"region":  {
+"startLine":  89,
+"startColumn":  22,
+"endLine":  89,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\NancyEngine.cs",
+"region":  {
+"startLine":  235,
+"startColumn":  42,
+"endLine":  235,
+"endColumn":  64
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\NancyEngine.cs",
+"region":  {
+"startLine":  256,
+"startColumn":  39,
+"endLine":  256,
+"endColumn":  59
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\NancyEngine.cs",
+"region":  {
+"startLine":  261,
+"startColumn":  22,
+"endLine":  261,
+"endColumn":  43
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\NancyEngineExtensions.cs",
+"region":  {
+"startLine":  14,
+"startColumn":  42,
+"endLine":  14,
+"endColumn":  55
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Owin\NancyMiddleware.cs",
+"region":  {
+"startLine":  115,
+"startColumn":  29,
+"endLine":  115,
+"endColumn":  44
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Response.cs",
+"region":  {
+"startLine":  87,
+"startColumn":  29,
+"endLine":  87,
+"endColumn":  39
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Routing\DefaultRequestDispatcher.cs",
+"region":  {
+"startLine":  87,
+"startColumn":  28,
+"endLine":  87,
+"endColumn":  39
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Routing\DefaultRequestDispatcher.cs",
+"region":  {
+"startLine":  110,
+"startColumn":  39,
+"endLine":  110,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Routing\IRequestDispatcher.cs",
+"region":  {
+"startLine":  16,
+"startColumn":  24,
+"endLine":  16,
+"endColumn":  32
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Routing\IRouteInvoker.cs",
+"region":  {
+"startLine":  19,
+"startColumn":  24,
+"endLine":  19,
+"endColumn":  30
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Routing\MethodNotAllowedRoute.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  38,
+"endLine":  26,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Routing\OptionsRoute.cs",
+"region":  {
+"startLine":  18,
+"startColumn":  38,
+"endLine":  18,
+"endColumn":  65
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Routing\Route.cs",
+"region":  {
+"startLine":  73,
+"startColumn":  30,
+"endLine":  73,
+"endColumn":  36
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Authentication.Forms.TestingDemo-{948A8EF6-D50C-45EA-9AFD-7A4723ADAB0B}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Authentication.Forms.TestingDemo-{948A8EF6-D50C-45EA-9AFD-7A4723ADAB0B}-S4261.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Demo.Authentication.Forms.TestingDemo\LoginFixture.cs",
+"region":  {
+"startLine":  20,
+"startColumn":  27,
+"endLine":  20,
+"endColumn":  108
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Demo.Authentication.Forms.TestingDemo\LoginFixture.cs",
+"region":  {
+"startLine":  34,
+"startColumn":  27,
+"endLine":  34,
+"endColumn":  73
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Aspnet-{15B7F794-0BB2-4B66-AD78-4A951F1209B2}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Aspnet-{15B7F794-0BB2-4B66-AD78-4A951F1209B2}-S4261.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Hosting.Aspnet\NancyHandler.cs",
+"region":  {
+"startLine":  33,
+"startColumn":  27,
+"endLine":  33,
+"endColumn":  41
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Aspnet.Tests-{D0F1D7F4-0D48-49AE-9E33-005926B58B1D}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Aspnet.Tests-{D0F1D7F4-0D48-49AE-9E33-005926B58B1D}-S4261.json
@@ -1,0 +1,43 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Hosting.Aspnet.Tests\NancyHandlerFixture.cs",
+"region":  {
+"startLine":  47,
+"startColumn":  27,
+"endLine":  47,
+"endColumn":  69
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Hosting.Aspnet.Tests\NancyHandlerFixture.cs",
+"region":  {
+"startLine":  69,
+"startColumn":  27,
+"endLine":  69,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Hosting.Aspnet.Tests\NancyHandlerFixture.cs",
+"region":  {
+"startLine":  92,
+"startColumn":  27,
+"endLine":  92,
+"endColumn":  53
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Self-{AA7F66EB-EC2C-47DE-855F-30B3E6EF2134}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Hosting.Self-{AA7F66EB-EC2C-47DE-855F-30B3E6EF2134}-S4261.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Hosting.Self\NancyHost.cs",
+"region":  {
+"startLine":  410,
+"startColumn":  28,
+"endLine":  410,
+"endColumn":  35
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing-{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing-{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}-S4261.json
@@ -1,0 +1,212 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  55,
+"startColumn":  38,
+"endLine":  55,
+"endColumn":  44
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  66,
+"startColumn":  38,
+"endLine":  66,
+"endColumn":  44
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  77,
+"startColumn":  38,
+"endLine":  77,
+"endColumn":  41
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  88,
+"startColumn":  38,
+"endLine":  88,
+"endColumn":  41
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  99,
+"startColumn":  38,
+"endLine":  99,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  110,
+"startColumn":  38,
+"endLine":  110,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  121,
+"startColumn":  38,
+"endLine":  121,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  132,
+"startColumn":  38,
+"endLine":  132,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  143,
+"startColumn":  38,
+"endLine":  143,
+"endColumn":  43
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  154,
+"startColumn":  38,
+"endLine":  154,
+"endColumn":  43
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  165,
+"startColumn":  38,
+"endLine":  165,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  176,
+"startColumn":  38,
+"endLine":  176,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  187,
+"startColumn":  38,
+"endLine":  187,
+"endColumn":  41
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  198,
+"startColumn":  38,
+"endLine":  198,
+"endColumn":  41
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  211,
+"startColumn":  44,
+"endLine":  211,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\Browser.cs",
+"region":  {
+"startLine":  236,
+"startColumn":  38,
+"endLine":  236,
+"endColumn":  51
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing.Tests-{8EB9E15A-4B65-4C80-B834-9A7773750666}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing.Tests-{8EB9E15A-4B65-4C80-B834-9A7773750666}-S4261.json
@@ -1,0 +1,875 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  22,
+"startColumn":  27,
+"endLine":  22,
+"endColumn":  111
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  35,
+"startColumn":  27,
+"endLine":  35,
+"endColumn":  112
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  48,
+"startColumn":  27,
+"endLine":  48,
+"endColumn":  111
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  61,
+"startColumn":  27,
+"endLine":  61,
+"endColumn":  113
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  74,
+"startColumn":  27,
+"endLine":  74,
+"endColumn":  114
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  87,
+"startColumn":  27,
+"endLine":  87,
+"endColumn":  104
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  101,
+"startColumn":  27,
+"endLine":  101,
+"endColumn":  105
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  115,
+"startColumn":  27,
+"endLine":  115,
+"endColumn":  104
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  129,
+"startColumn":  27,
+"endLine":  129,
+"endColumn":  106
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  143,
+"startColumn":  27,
+"endLine":  143,
+"endColumn":  107
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserDefaultsFixture.cs",
+"region":  {
+"startLine":  157,
+"startColumn":  27,
+"endLine":  157,
+"endColumn":  89
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  38,
+"startColumn":  27,
+"endLine":  38,
+"endColumn":  64
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  55,
+"startColumn":  27,
+"endLine":  55,
+"endColumn":  66
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  72,
+"startColumn":  27,
+"endLine":  72,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  90,
+"startColumn":  27,
+"endLine":  90,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  108,
+"startColumn":  27,
+"endLine":  108,
+"endColumn":  60
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  126,
+"startColumn":  27,
+"endLine":  126,
+"endColumn":  64
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  147,
+"startColumn":  27,
+"endLine":  147,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  168,
+"startColumn":  27,
+"endLine":  168,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  189,
+"startColumn":  27,
+"endLine":  189,
+"endColumn":  100
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  261,
+"startColumn":  27,
+"endLine":  261,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  283,
+"startColumn":  27,
+"endLine":  283,
+"endColumn":  90
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  293,
+"startColumn":  27,
+"endLine":  293,
+"endColumn":  74
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  325,
+"startColumn":  27,
+"endLine":  325,
+"endColumn":  73
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  340,
+"startColumn":  27,
+"endLine":  340,
+"endColumn":  96
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  355,
+"startColumn":  27,
+"endLine":  355,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  365,
+"startColumn":  27,
+"endLine":  365,
+"endColumn":  49
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  375,
+"startColumn":  27,
+"endLine":  375,
+"endColumn":  83
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  393,
+"startColumn":  27,
+"endLine":  393,
+"endColumn":  49
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  403,
+"startColumn":  27,
+"endLine":  403,
+"endColumn":  99
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  413,
+"startColumn":  27,
+"endLine":  413,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  444,
+"startColumn":  27,
+"endLine":  444,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  466,
+"startColumn":  27,
+"endLine":  466,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  488,
+"startColumn":  27,
+"endLine":  488,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  502,
+"startColumn":  27,
+"endLine":  502,
+"endColumn":  52
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  516,
+"startColumn":  27,
+"endLine":  516,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  529,
+"startColumn":  27,
+"endLine":  529,
+"endColumn":  85
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  549,
+"startColumn":  27,
+"endLine":  549,
+"endColumn":  76
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\BrowserFixture.cs",
+"region":  {
+"startLine":  564,
+"startColumn":  27,
+"endLine":  564,
+"endColumn":  105
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\CaseSensitivityFixture.cs",
+"region":  {
+"startLine":  23,
+"startColumn":  27,
+"endLine":  23,
+"endColumn":  74
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\CaseSensitivityFixture.cs",
+"region":  {
+"startLine":  42,
+"startColumn":  27,
+"endLine":  42,
+"endColumn":  101
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\CaseSensitivityFixture.cs",
+"region":  {
+"startLine":  62,
+"startColumn":  27,
+"endLine":  62,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\CaseSensitivityFixture.cs",
+"region":  {
+"startLine":  80,
+"startColumn":  27,
+"endLine":  80,
+"endColumn":  95
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\CaseSensitivityFixture.cs",
+"region":  {
+"startLine":  94,
+"startColumn":  27,
+"endLine":  94,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\CaseSensitivityFixture.cs",
+"region":  {
+"startLine":  113,
+"startColumn":  27,
+"endLine":  113,
+"endColumn":  91
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\ConfigurableBootstrapperDependenciesTests.cs",
+"region":  {
+"startLine":  29,
+"startColumn":  27,
+"endLine":  29,
+"endColumn":  75
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\ConfigurableBootstrapperDependenciesTests.cs",
+"region":  {
+"startLine":  46,
+"startColumn":  27,
+"endLine":  46,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\ConfigurableBootstrapperDependenciesTests.cs",
+"region":  {
+"startLine":  63,
+"startColumn":  27,
+"endLine":  63,
+"endColumn":  74
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\ConfigurableBootstrapperDependenciesTests.cs",
+"region":  {
+"startLine":  80,
+"startColumn":  27,
+"endLine":  80,
+"endColumn":  70
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\ConfigurableBootstrapperDependenciesTests.cs",
+"region":  {
+"startLine":  124,
+"startColumn":  27,
+"endLine":  124,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\ConfigurableBootstrapperDependenciesTests.cs",
+"region":  {
+"startLine":  143,
+"startColumn":  27,
+"endLine":  143,
+"endColumn":  104
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\ConfigurableBootstrapperFixture.cs",
+"region":  {
+"startLine":  117,
+"startColumn":  27,
+"endLine":  117,
+"endColumn":  72
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\ConfigurableBootstrapperFixture.cs",
+"region":  {
+"startLine":  135,
+"startColumn":  27,
+"endLine":  135,
+"endColumn":  65
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\ConfigurableBootstrapperFixture.cs",
+"region":  {
+"startLine":  161,
+"startColumn":  27,
+"endLine":  161,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\ConfigurableBootstrapperFixture.cs",
+"region":  {
+"startLine":  225,
+"startColumn":  51,
+"endLine":  225,
+"endColumn":  60
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\TestingViewExtensions\GetModelExtententionsTests.cs",
+"region":  {
+"startLine":  20,
+"startColumn":  27,
+"endLine":  20,
+"endColumn":  67
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\TestingViewExtensions\GetModelExtententionsTests.cs",
+"region":  {
+"startLine":  27,
+"startColumn":  27,
+"endLine":  27,
+"endColumn":  67
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\TestingViewExtensions\GetModelExtententionsTests.cs",
+"region":  {
+"startLine":  34,
+"startColumn":  27,
+"endLine":  34,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\TestingViewExtensions\GetModelExtententionsTests.cs",
+"region":  {
+"startLine":  41,
+"startColumn":  27,
+"endLine":  41,
+"endColumn":  65
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\TestingViewExtensions\GetModelExtententionsTests.cs",
+"region":  {
+"startLine":  49,
+"startColumn":  27,
+"endLine":  49,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\TestingViewExtensions\GetModuleNameExtensionTests.cs",
+"region":  {
+"startLine":  20,
+"startColumn":  27,
+"endLine":  20,
+"endColumn":  59
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\TestingViewExtensions\GetModulePathExtensionMethodTests.cs",
+"region":  {
+"startLine":  9,
+"startColumn":  27,
+"endLine":  9,
+"endColumn":  82
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\TestingViewExtensions\GetModulePathExtensionMethodTests.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  27,
+"endLine":  26,
+"endColumn":  95
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\TestingViewExtensions\GetViewNameExtensionTests.cs",
+"region":  {
+"startLine":  20,
+"startColumn":  27,
+"endLine":  20,
+"endColumn":  78
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing.Tests\TestingViewExtensions\GetViewNameExtensionTests.cs",
+"region":  {
+"startLine":  27,
+"startColumn":  27,
+"endLine":  27,
+"endColumn":  77
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\xUnitExtensions\RecordAsync.cs",
+"region":  {
+"startLine":  9,
+"startColumn":  45,
+"endLine":  9,
+"endColumn":  54
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\xUnitExtensions\RecordAsync.cs",
+"region":  {
+"startLine":  25,
+"startColumn":  37,
+"endLine":  25,
+"endColumn":  43
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests-{776D244D-BC4D-4BBB-A478-CAF2D04520E1}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests-{776D244D-BC4D-4BBB-A478-CAF2D04520E1}-S4261.json
@@ -1,0 +1,1759 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\NoAppStartupsFixture.cs",
+"region":  {
+"startLine":  59,
+"startColumn":  27,
+"endLine":  59,
+"endColumn":  72
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\NoAppStartupsFixture.cs",
+"region":  {
+"startLine":  80,
+"startColumn":  27,
+"endLine":  80,
+"endColumn":  77
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\AfterPipelineFixture.cs",
+"region":  {
+"startLine":  50,
+"startColumn":  27,
+"endLine":  50,
+"endColumn":  76
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\AfterPipelineFixture.cs",
+"region":  {
+"startLine":  82,
+"startColumn":  27,
+"endLine":  82,
+"endColumn":  99
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\BeforePipelineFixture.cs",
+"region":  {
+"startLine":  30,
+"startColumn":  27,
+"endLine":  30,
+"endColumn":  101
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\BeforePipelineFixture.cs",
+"region":  {
+"startLine":  53,
+"startColumn":  27,
+"endLine":  53,
+"endColumn":  98
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\BeforePipelineFixture.cs",
+"region":  {
+"startLine":  72,
+"startColumn":  27,
+"endLine":  72,
+"endColumn":  85
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\BeforePipelineFixture.cs",
+"region":  {
+"startLine":  122,
+"startColumn":  27,
+"endLine":  122,
+"endColumn":  76
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\BeforePipelineFixture.cs",
+"region":  {
+"startLine":  161,
+"startColumn":  27,
+"endLine":  161,
+"endColumn":  85
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\BeforePipelineFixture.cs",
+"region":  {
+"startLine":  178,
+"startColumn":  27,
+"endLine":  178,
+"endColumn":  99
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Bootstrapper\NancyBootstrapperBaseFixture.cs",
+"region":  {
+"startLine":  238,
+"startColumn":  27,
+"endLine":  238,
+"endColumn":  69
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\DefaultNancyBootstrapperFixture.cs",
+"region":  {
+"startLine":  25,
+"startColumn":  27,
+"endLine":  25,
+"endColumn":  84
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\CustomInteractiveDiagnosticsFixture.cs",
+"region":  {
+"startLine":  117,
+"startColumn":  27,
+"endLine":  117,
+"endColumn":  73
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\DiagnosticsHookFixture.cs",
+"region":  {
+"startLine":  32,
+"startColumn":  27,
+"endLine":  32,
+"endColumn":  67
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\DiagnosticsHookFixture.cs",
+"region":  {
+"startLine":  58,
+"startColumn":  27,
+"endLine":  58,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\DiagnosticsHookFixture.cs",
+"region":  {
+"startLine":  85,
+"startColumn":  27,
+"endLine":  85,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\DiagnosticsHookFixture.cs",
+"region":  {
+"startLine":  111,
+"startColumn":  27,
+"endLine":  111,
+"endColumn":  73
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\DiagnosticsHookFixture.cs",
+"region":  {
+"startLine":  140,
+"startColumn":  27,
+"endLine":  140,
+"endColumn":  76
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\DiagnosticsHookFixture.cs",
+"region":  {
+"startLine":  169,
+"startColumn":  27,
+"endLine":  169,
+"endColumn":  92
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\DiagnosticsHookFixture.cs",
+"region":  {
+"startLine":  198,
+"startColumn":  27,
+"endLine":  198,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\DiagnosticsHookFixture.cs",
+"region":  {
+"startLine":  228,
+"startColumn":  27,
+"endLine":  228,
+"endColumn":  72
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\DiagnosticsHookFixture.cs",
+"region":  {
+"startLine":  258,
+"startColumn":  27,
+"endLine":  258,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Diagnostics\DiagnosticsHookFixture.cs",
+"region":  {
+"startLine":  290,
+"startColumn":  27,
+"endLine":  290,
+"endColumn":  59
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  106,
+"startColumn":  27,
+"endLine":  106,
+"endColumn":  101
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  132,
+"startColumn":  27,
+"endLine":  132,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  148,
+"startColumn":  27,
+"endLine":  148,
+"endColumn":  90
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  162,
+"startColumn":  27,
+"endLine":  162,
+"endColumn":  112
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  176,
+"startColumn":  27,
+"endLine":  176,
+"endColumn":  113
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  190,
+"startColumn":  27,
+"endLine":  190,
+"endColumn":  99
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  216,
+"startColumn":  27,
+"endLine":  216,
+"endColumn":  85
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  236,
+"startColumn":  27,
+"endLine":  236,
+"endColumn":  81
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  258,
+"startColumn":  27,
+"endLine":  258,
+"endColumn":  77
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  277,
+"startColumn":  27,
+"endLine":  277,
+"endColumn":  89
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  299,
+"startColumn":  27,
+"endLine":  299,
+"endColumn":  81
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  312,
+"startColumn":  27,
+"endLine":  312,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  325,
+"startColumn":  27,
+"endLine":  325,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  339,
+"startColumn":  27,
+"endLine":  339,
+"endColumn":  72
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  364,
+"startColumn":  27,
+"endLine":  364,
+"endColumn":  78
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  389,
+"startColumn":  27,
+"endLine":  389,
+"endColumn":  100
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  440,
+"startColumn":  27,
+"endLine":  440,
+"endColumn":  97
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  472,
+"startColumn":  27,
+"endLine":  472,
+"endColumn":  89
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  504,
+"startColumn":  27,
+"endLine":  504,
+"endColumn":  111
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  535,
+"startColumn":  27,
+"endLine":  535,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  556,
+"startColumn":  27,
+"endLine":  556,
+"endColumn":  87
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyEngineFixture.cs",
+"region":  {
+"startLine":  581,
+"startColumn":  27,
+"endLine":  581,
+"endColumn":  98
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyMiddlewareFixture.cs",
+"region":  {
+"startLine":  206,
+"startColumn":  27,
+"endLine":  206,
+"endColumn":  50
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\NancyMiddlewareFixture.cs",
+"region":  {
+"startLine":  224,
+"startColumn":  27,
+"endLine":  224,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  22,
+"startColumn":  27,
+"endLine":  22,
+"endColumn":  56
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  32,
+"startColumn":  27,
+"endLine":  32,
+"endColumn":  78
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  43,
+"startColumn":  27,
+"endLine":  43,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  53,
+"startColumn":  27,
+"endLine":  53,
+"endColumn":  60
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  63,
+"startColumn":  27,
+"endLine":  63,
+"endColumn":  60
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  73,
+"startColumn":  27,
+"endLine":  73,
+"endColumn":  64
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  83,
+"startColumn":  27,
+"endLine":  83,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  93,
+"startColumn":  27,
+"endLine":  93,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  103,
+"startColumn":  27,
+"endLine":  103,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  113,
+"startColumn":  27,
+"endLine":  113,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  123,
+"startColumn":  27,
+"endLine":  123,
+"endColumn":  58
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  133,
+"startColumn":  27,
+"endLine":  133,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  143,
+"startColumn":  27,
+"endLine":  143,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  155,
+"startColumn":  27,
+"endLine":  155,
+"endColumn":  65
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  165,
+"startColumn":  27,
+"endLine":  165,
+"endColumn":  56
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  175,
+"startColumn":  27,
+"endLine":  175,
+"endColumn":  60
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  185,
+"startColumn":  27,
+"endLine":  185,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  195,
+"startColumn":  27,
+"endLine":  195,
+"endColumn":  72
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  205,
+"startColumn":  27,
+"endLine":  205,
+"endColumn":  70
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  215,
+"startColumn":  27,
+"endLine":  215,
+"endColumn":  56
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  225,
+"startColumn":  27,
+"endLine":  225,
+"endColumn":  60
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  235,
+"startColumn":  27,
+"endLine":  235,
+"endColumn":  70
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  245,
+"startColumn":  27,
+"endLine":  245,
+"endColumn":  58
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  255,
+"startColumn":  27,
+"endLine":  255,
+"endColumn":  73
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  265,
+"startColumn":  27,
+"endLine":  265,
+"endColumn":  74
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  275,
+"startColumn":  27,
+"endLine":  275,
+"endColumn":  72
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  285,
+"startColumn":  27,
+"endLine":  285,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  295,
+"startColumn":  27,
+"endLine":  295,
+"endColumn":  66
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  305,
+"startColumn":  27,
+"endLine":  305,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  315,
+"startColumn":  27,
+"endLine":  315,
+"endColumn":  66
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  325,
+"startColumn":  27,
+"endLine":  325,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  335,
+"startColumn":  27,
+"endLine":  335,
+"endColumn":  83
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  345,
+"startColumn":  27,
+"endLine":  345,
+"endColumn":  59
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  355,
+"startColumn":  27,
+"endLine":  355,
+"endColumn":  74
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  365,
+"startColumn":  27,
+"endLine":  365,
+"endColumn":  75
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteResolverFixture.cs",
+"region":  {
+"startLine":  375,
+"startColumn":  27,
+"endLine":  375,
+"endColumn":  53
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteScoringFixture.cs",
+"region":  {
+"startLine":  18,
+"startColumn":  27,
+"endLine":  18,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\ConstraintNodeRouteScoringFixture.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  27,
+"endLine":  26,
+"endColumn":  94
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  57,
+"startColumn":  27,
+"endLine":  57,
+"endColumn":  116
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  108,
+"startColumn":  27,
+"endLine":  108,
+"endColumn":  134
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  154,
+"startColumn":  27,
+"endLine":  154,
+"endColumn":  87
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  188,
+"startColumn":  27,
+"endLine":  188,
+"endColumn":  76
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  226,
+"startColumn":  27,
+"endLine":  226,
+"endColumn":  95
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  257,
+"startColumn":  27,
+"endLine":  257,
+"endColumn":  78
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  287,
+"startColumn":  27,
+"endLine":  287,
+"endColumn":  84
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  317,
+"startColumn":  27,
+"endLine":  317,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  334,
+"startColumn":  27,
+"endLine":  334,
+"endColumn":  107
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  365,
+"startColumn":  27,
+"endLine":  365,
+"endColumn":  128
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  408,
+"startColumn":  27,
+"endLine":  408,
+"endColumn":  164
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  450,
+"startColumn":  27,
+"endLine":  450,
+"endColumn":  180
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  492,
+"startColumn":  27,
+"endLine":  492,
+"endColumn":  154
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  522,
+"startColumn":  27,
+"endLine":  522,
+"endColumn":  156
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  577,
+"startColumn":  27,
+"endLine":  577,
+"endColumn":  175
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  619,
+"startColumn":  27,
+"endLine":  619,
+"endColumn":  72
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  645,
+"startColumn":  27,
+"endLine":  645,
+"endColumn":  154
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  686,
+"startColumn":  27,
+"endLine":  686,
+"endColumn":  77
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  714,
+"startColumn":  27,
+"endLine":  714,
+"endColumn":  65
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  740,
+"startColumn":  27,
+"endLine":  740,
+"endColumn":  101
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  783,
+"startColumn":  27,
+"endLine":  783,
+"endColumn":  96
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  825,
+"startColumn":  27,
+"endLine":  825,
+"endColumn":  100
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  867,
+"startColumn":  27,
+"endLine":  867,
+"endColumn":  90
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  901,
+"startColumn":  27,
+"endLine":  901,
+"endColumn":  90
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  936,
+"startColumn":  27,
+"endLine":  936,
+"endColumn":  82
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  968,
+"startColumn":  38,
+"endLine":  968,
+"endColumn":  56
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRequestDispatcherFixture.cs",
+"region":  {
+"startLine":  978,
+"startColumn":  38,
+"endLine":  978,
+"endColumn":  50
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  12,
+"startColumn":  27,
+"endLine":  12,
+"endColumn":  46
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  23,
+"startColumn":  27,
+"endLine":  23,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  38,
+"startColumn":  27,
+"endLine":  38,
+"endColumn":  56
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  60,
+"startColumn":  27,
+"endLine":  60,
+"endColumn":  55
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  82,
+"startColumn":  27,
+"endLine":  82,
+"endColumn":  56
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  104,
+"startColumn":  27,
+"endLine":  104,
+"endColumn":  82
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  126,
+"startColumn":  27,
+"endLine":  126,
+"endColumn":  86
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  148,
+"startColumn":  27,
+"endLine":  148,
+"endColumn":  95
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  170,
+"startColumn":  27,
+"endLine":  170,
+"endColumn":  99
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  192,
+"startColumn":  27,
+"endLine":  192,
+"endColumn":  55
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  214,
+"startColumn":  27,
+"endLine":  214,
+"endColumn":  58
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  236,
+"startColumn":  27,
+"endLine":  236,
+"endColumn":  67
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  258,
+"startColumn":  27,
+"endLine":  258,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  280,
+"startColumn":  27,
+"endLine":  280,
+"endColumn":  59
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  302,
+"startColumn":  27,
+"endLine":  302,
+"endColumn":  47
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  320,
+"startColumn":  27,
+"endLine":  320,
+"endColumn":  54
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  332,
+"startColumn":  27,
+"endLine":  332,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  345,
+"startColumn":  27,
+"endLine":  345,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  358,
+"startColumn":  27,
+"endLine":  358,
+"endColumn":  123
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  372,
+"startColumn":  27,
+"endLine":  372,
+"endColumn":  123
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\Routing\DefaultRouteResolverFixture.cs",
+"region":  {
+"startLine":  386,
+"startColumn":  27,
+"endLine":  386,
+"endColumn":  83
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\xUnitExtensions\RecordAsync.cs",
+"region":  {
+"startLine":  9,
+"startColumn":  45,
+"endLine":  9,
+"endColumn":  54
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\xUnitExtensions\RecordAsync.cs",
+"region":  {
+"startLine":  25,
+"startColumn":  37,
+"endLine":  25,
+"endColumn":  43
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests.Functional-{BDA5E175-07D7-4E6F-B46F-C2CF7D63E231}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests.Functional-{BDA5E175-07D7-4E6F-B46F-C2CF7D63E231}-S4261.json
@@ -1,0 +1,1161 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\AbsoluteUrlTests.cs",
+"region":  {
+"startLine":  24,
+"startColumn":  27,
+"endLine":  24,
+"endColumn":  70
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\AbsoluteUrlTests.cs",
+"region":  {
+"startLine":  34,
+"startColumn":  27,
+"endLine":  34,
+"endColumn":  63
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\AbsoluteUrlTests.cs",
+"region":  {
+"startLine":  47,
+"startColumn":  27,
+"endLine":  47,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\AbsoluteUrlTests.cs",
+"region":  {
+"startLine":  57,
+"startColumn":  27,
+"endLine":  57,
+"endColumn":  73
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\AsyncExceptionTests.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  27,
+"endLine":  26,
+"endColumn":  58
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\AsyncExceptionTests.cs",
+"region":  {
+"startLine":  34,
+"startColumn":  27,
+"endLine":  34,
+"endColumn":  59
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  18,
+"startColumn":  27,
+"endLine":  18,
+"endColumn":  83
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  31,
+"startColumn":  27,
+"endLine":  31,
+"endColumn":  102
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  42,
+"startColumn":  27,
+"endLine":  42,
+"endColumn":  86
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  55,
+"startColumn":  27,
+"endLine":  55,
+"endColumn":  105
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  66,
+"startColumn":  27,
+"endLine":  66,
+"endColumn":  84
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  79,
+"startColumn":  27,
+"endLine":  79,
+"endColumn":  103
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  90,
+"startColumn":  27,
+"endLine":  90,
+"endColumn":  83
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  103,
+"startColumn":  27,
+"endLine":  103,
+"endColumn":  102
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  114,
+"startColumn":  27,
+"endLine":  114,
+"endColumn":  84
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  127,
+"startColumn":  27,
+"endLine":  127,
+"endColumn":  103
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\BasicRouteInvocationsFixture.cs",
+"region":  {
+"startLine":  184,
+"startColumn":  27,
+"endLine":  184,
+"endColumn":  81
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  21,
+"startColumn":  27,
+"endLine":  21,
+"endColumn":  107
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  42,
+"startColumn":  27,
+"endLine":  42,
+"endColumn":  106
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  63,
+"startColumn":  27,
+"endLine":  63,
+"endColumn":  114
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  84,
+"startColumn":  27,
+"endLine":  84,
+"endColumn":  91
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  117,
+"startColumn":  27,
+"endLine":  117,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  152,
+"startColumn":  27,
+"endLine":  152,
+"endColumn":  63
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  185,
+"startColumn":  27,
+"endLine":  185,
+"endColumn":  76
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  219,
+"startColumn":  27,
+"endLine":  219,
+"endColumn":  81
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  249,
+"startColumn":  27,
+"endLine":  249,
+"endColumn":  91
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  288,
+"startColumn":  27,
+"endLine":  288,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  324,
+"startColumn":  27,
+"endLine":  324,
+"endColumn":  115
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  351,
+"startColumn":  27,
+"endLine":  351,
+"endColumn":  102
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  368,
+"startColumn":  27,
+"endLine":  368,
+"endColumn":  116
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  396,
+"startColumn":  27,
+"endLine":  396,
+"endColumn":  81
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  425,
+"startColumn":  27,
+"endLine":  425,
+"endColumn":  56
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  447,
+"startColumn":  27,
+"endLine":  447,
+"endColumn":  82
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  470,
+"startColumn":  27,
+"endLine":  470,
+"endColumn":  92
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  497,
+"startColumn":  27,
+"endLine":  497,
+"endColumn":  99
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  524,
+"startColumn":  27,
+"endLine":  524,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  554,
+"startColumn":  27,
+"endLine":  554,
+"endColumn":  72
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  575,
+"startColumn":  27,
+"endLine":  575,
+"endColumn":  78
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  605,
+"startColumn":  27,
+"endLine":  605,
+"endColumn":  87
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  629,
+"startColumn":  27,
+"endLine":  629,
+"endColumn":  74
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  642,
+"startColumn":  27,
+"endLine":  642,
+"endColumn":  81
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  658,
+"startColumn":  27,
+"endLine":  658,
+"endColumn":  63
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  675,
+"startColumn":  27,
+"endLine":  675,
+"endColumn":  58
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  693,
+"startColumn":  27,
+"endLine":  693,
+"endColumn":  97
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  708,
+"startColumn":  27,
+"endLine":  708,
+"endColumn":  97
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ContentNegotiationFixture.cs",
+"region":  {
+"startLine":  723,
+"startColumn":  27,
+"endLine":  723,
+"endColumn":  96
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\CookieFixture.cs",
+"region":  {
+"startLine":  12,
+"startColumn":  27,
+"endLine":  12,
+"endColumn":  63
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\JsonpTests.cs",
+"region":  {
+"startLine":  29,
+"startColumn":  27,
+"endLine":  29,
+"endColumn":  82
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\JsonpTests.cs",
+"region":  {
+"startLine":  41,
+"startColumn":  27,
+"endLine":  41,
+"endColumn":  90
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\JsonpTests.cs",
+"region":  {
+"startLine":  50,
+"startColumn":  27,
+"endLine":  50,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\JsonpTests.cs",
+"region":  {
+"startLine":  63,
+"startColumn":  27,
+"endLine":  63,
+"endColumn":  101
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ManualStaticContentTests.cs",
+"region":  {
+"startLine":  29,
+"startColumn":  27,
+"endLine":  29,
+"endColumn":  60
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ManualStaticContentTests.cs",
+"region":  {
+"startLine":  42,
+"startColumn":  27,
+"endLine":  42,
+"endColumn":  65
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ManualStaticContentTests.cs",
+"region":  {
+"startLine":  55,
+"startColumn":  27,
+"endLine":  55,
+"endColumn":  53
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ManualStaticContentTests.cs",
+"region":  {
+"startLine":  68,
+"startColumn":  27,
+"endLine":  68,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ManualStaticContentTests.cs",
+"region":  {
+"startLine":  81,
+"startColumn":  27,
+"endLine":  81,
+"endColumn":  74
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\MethodRewriteFixture.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  27,
+"endLine":  26,
+"endColumn":  83
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\MethodRewriteFixture.cs",
+"region":  {
+"startLine":  40,
+"startColumn":  27,
+"endLine":  40,
+"endColumn":  99
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\MethodRewriteFixture.cs",
+"region":  {
+"startLine":  51,
+"startColumn":  27,
+"endLine":  51,
+"endColumn":  92
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\MethodRewriteFixture.cs",
+"region":  {
+"startLine":  62,
+"startColumn":  27,
+"endLine":  62,
+"endColumn":  135
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\MethodRewriteFixture.cs",
+"region":  {
+"startLine":  72,
+"startColumn":  27,
+"endLine":  72,
+"endColumn":  134
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\MethodRewriteFixture.cs",
+"region":  {
+"startLine":  82,
+"startColumn":  27,
+"endLine":  82,
+"endColumn":  137
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\MethodRewriteFixture.cs",
+"region":  {
+"startLine":  92,
+"startColumn":  27,
+"endLine":  92,
+"endColumn":  146
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ModelBindingTests.cs",
+"region":  {
+"startLine":  25,
+"startColumn":  27,
+"endLine":  25,
+"endColumn":  75
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ModelBindingTests.cs",
+"region":  {
+"startLine":  38,
+"startColumn":  27,
+"endLine":  38,
+"endColumn":  83
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\PartialViewTests.cs",
+"region":  {
+"startLine":  27,
+"startColumn":  27,
+"endLine":  27,
+"endColumn":  104
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\PartialViewTests.cs",
+"region":  {
+"startLine":  49,
+"startColumn":  27,
+"endLine":  49,
+"endColumn":  104
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\PerRouteAuthFixture.cs",
+"region":  {
+"startLine":  14,
+"startColumn":  27,
+"endLine":  14,
+"endColumn":  65
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\PerRouteAuthFixture.cs",
+"region":  {
+"startLine":  24,
+"startColumn":  27,
+"endLine":  24,
+"endColumn":  55
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\PerRouteAuthFixture.cs",
+"region":  {
+"startLine":  34,
+"startColumn":  27,
+"endLine":  34,
+"endColumn":  54
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\PerRouteAuthFixture.cs",
+"region":  {
+"startLine":  48,
+"startColumn":  27,
+"endLine":  48,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\PerRouteAuthFixture.cs",
+"region":  {
+"startLine":  62,
+"startColumn":  27,
+"endLine":  62,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\PerRouteAuthFixture.cs",
+"region":  {
+"startLine":  76,
+"startColumn":  27,
+"endLine":  76,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\RouteConstraintTests.cs",
+"region":  {
+"startLine":  31,
+"startColumn":  27,
+"endLine":  31,
+"endColumn":  85
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\RouteConstraintTests.cs",
+"region":  {
+"startLine":  43,
+"startColumn":  27,
+"endLine":  43,
+"endColumn":  124
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\RouteConstraintTests.cs",
+"region":  {
+"startLine":  55,
+"startColumn":  27,
+"endLine":  55,
+"endColumn":  93
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\RouteConstraintTests.cs",
+"region":  {
+"startLine":  67,
+"startColumn":  27,
+"endLine":  67,
+"endColumn":  99
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\SerializerTests.cs",
+"region":  {
+"startLine":  24,
+"startColumn":  27,
+"endLine":  24,
+"endColumn":  54
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\SerializerTests.cs",
+"region":  {
+"startLine":  40,
+"startColumn":  27,
+"endLine":  40,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\SerializerTests.cs",
+"region":  {
+"startLine":  60,
+"startColumn":  27,
+"endLine":  60,
+"endColumn":  69
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\SerializeTests.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  27,
+"endLine":  26,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\SerializeTests.cs",
+"region":  {
+"startLine":  48,
+"startColumn":  27,
+"endLine":  48,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\TracingSmokeTests.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  27,
+"endLine":  26,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ViewBagTests.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  27,
+"endLine":  26,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ViewBagTests.cs",
+"region":  {
+"startLine":  42,
+"startColumn":  27,
+"endLine":  42,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ViewBagTests.cs",
+"region":  {
+"startLine":  58,
+"startColumn":  27,
+"endLine":  58,
+"endColumn":  51
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests.Functional\Tests\ViewBagTests.cs",
+"region":  {
+"startLine":  77,
+"startColumn":  27,
+"endLine":  77,
+"endColumn":  52
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\xUnitExtensions\RecordAsync.cs",
+"region":  {
+"startLine":  9,
+"startColumn":  45,
+"endLine":  9,
+"endColumn":  54
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\xUnitExtensions\RecordAsync.cs",
+"region":  {
+"startLine":  25,
+"startColumn":  37,
+"endLine":  25,
+"endColumn":  43
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.DotLiquid.Tests-{A3BF6450-DE9A-4C11-8E3C-66D9A8EC93F5}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.DotLiquid.Tests-{A3BF6450-DE9A-4C11-8E3C-66D9A8EC93F5}-S4261.json
@@ -1,0 +1,43 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.DotLiquid.Tests\Functional\PartialRenderingFixture.cs",
+"region":  {
+"startLine":  24,
+"startColumn":  27,
+"endLine":  24,
+"endColumn":  67
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.DotLiquid.Tests\Functional\PartialRenderingFixture.cs",
+"region":  {
+"startLine":  36,
+"startColumn":  27,
+"endLine":  36,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.DotLiquid.Tests\Functional\PartialRenderingFixture.cs",
+"region":  {
+"startLine":  48,
+"startColumn":  27,
+"endLine":  48,
+"endColumn":  71
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S4261.json
@@ -1,0 +1,238 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\ActorSelection.cs",
+"region":  {
+"startLine":  103,
+"startColumn":  32,
+"endLine":  103,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\ActorSelection.cs",
+"region":  {
+"startLine":  108,
+"startColumn":  39,
+"endLine":  108,
+"endColumn":  54
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\Futures.cs",
+"region":  {
+"startLine":  27,
+"startColumn":  36,
+"endLine":  27,
+"endColumn":  39
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\Futures.cs",
+"region":  {
+"startLine":  32,
+"startColumn":  31,
+"endLine":  32,
+"endColumn":  34
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\Futures.cs",
+"region":  {
+"startLine":  64,
+"startColumn":  37,
+"endLine":  64,
+"endColumn":  40
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\GracefulStopSupport.cs",
+"region":  {
+"startLine":  37,
+"startColumn":  34,
+"endLine":  37,
+"endColumn":  46
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\GracefulStopSupport.cs",
+"region":  {
+"startLine":  42,
+"startColumn":  34,
+"endLine":  42,
+"endColumn":  46
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\PipeToSupport.cs",
+"region":  {
+"startLine":  24,
+"startColumn":  28,
+"endLine":  24,
+"endColumn":  34
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\PipeToSupport.cs",
+"region":  {
+"startLine":  44,
+"startColumn":  28,
+"endLine":  44,
+"endColumn":  34
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Pattern\CircuitBreaker.cs",
+"region":  {
+"startLine":  131,
+"startColumn":  30,
+"endLine":  131,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Pattern\CircuitBreaker.cs",
+"region":  {
+"startLine":  141,
+"startColumn":  27,
+"endLine":  141,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Routing\Router.cs",
+"region":  {
+"startLine":  36,
+"startColumn":  29,
+"endLine":  36,
+"endColumn":  32
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\AtomicState.cs",
+"region":  {
+"startLine":  50,
+"startColumn":  30,
+"endLine":  50,
+"endColumn":  55
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\AtomicState.cs",
+"region":  {
+"startLine":  79,
+"startColumn":  30,
+"endLine":  79,
+"endColumn":  41
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\AtomicState.cs",
+"region":  {
+"startLine":  118,
+"startColumn":  27,
+"endLine":  118,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\AtomicState.cs",
+"region":  {
+"startLine":  159,
+"startColumn":  30,
+"endLine":  159,
+"endColumn":  36
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\AtomicState.cs",
+"region":  {
+"startLine":  195,
+"startColumn":  17,
+"endLine":  195,
+"endColumn":  23
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\TaskExtensions.cs",
+"region":  {
+"startLine":  15,
+"startColumn":  37,
+"endLine":  15,
+"endColumn":  45
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster-{6AB00F61-269A-4501-B06A-026707F000A7}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster-{6AB00F61-269A-4501-B06A-026707F000A7}-S4261.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\Cluster.cs",
+"region":  {
+"startLine":  92,
+"startColumn":  39,
+"endLine":  92,
+"endColumn":  56
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster.Sharding-{A05C31E8-0246-46A1-B3BC-4D6FE7A9AA49}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster.Sharding-{A05C31E8-0246-46A1-B3BC-4D6FE7A9AA49}-S4261.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.Cluster.Sharding\ShardAllocationStrategy.cs",
+"region":  {
+"startLine":  39,
+"startColumn":  25,
+"endLine":  39,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.Cluster.Sharding\ShardAllocationStrategy.cs",
+"region":  {
+"startLine":  51,
+"startColumn":  38,
+"endLine":  51,
+"endColumn":  47
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster.Tests-{C8D6A95C-50BF-4416-A212-86B18B87220D}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster.Tests-{C8D6A95C-50BF-4416-A212-86B18B87220D}-S4261.json
@@ -1,0 +1,43 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster.Tests\Routing\ClusterRouterAsk1343BugFixSpec.cs",
+"region":  {
+"startLine":  73,
+"startColumn":  27,
+"endLine":  73,
+"endColumn":  85
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster.Tests\Routing\ClusterRouterAsk1343BugFixSpec.cs",
+"region":  {
+"startLine":  83,
+"startColumn":  27,
+"endLine":  83,
+"endColumn":  86
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster.Tests\Routing\ClusterRouterAsk1343BugFixSpec.cs",
+"region":  {
+"startLine":  94,
+"startColumn":  27,
+"endLine":  94,
+"endColumn":  92
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared-{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared-{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}-S4261.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunCoordinator.cs",
+"region":  {
+"startLine":  158,
+"startColumn":  28,
+"endLine":  158,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\IMessageSink.cs",
+"region":  {
+"startLine":  50,
+"startColumn":  20,
+"endLine":  50,
+"endColumn":  25
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Persistence-{FCA84DEA-C118-424B-9EB8-34375DFEF18A}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Persistence-{FCA84DEA-C118-424B-9EB8-34375DFEF18A}-S4261.json
@@ -1,0 +1,56 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Remove the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\Eventsourced.cs",
+"region":  {
+"startLine":  238,
+"startColumn":  21,
+"endLine":  238,
+"endColumn":  33
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Remove the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\Eventsourced.cs",
+"region":  {
+"startLine":  248,
+"startColumn":  21,
+"endLine":  248,
+"endColumn":  33
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\InternalExtensions.cs",
+"region":  {
+"startLine":  23,
+"startColumn":  28,
+"endLine":  23,
+"endColumn":  55
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\Snapshot\LocalSnapshotStore.cs",
+"region":  {
+"startLine":  221,
+"startColumn":  25,
+"endLine":  221,
+"endColumn":  48
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Persistence.Sql.Common-{3B9E6211-9488-4DB5-B714-24248693B38F}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Persistence.Sql.Common-{3B9E6211-9488-4DB5-B714-24248693B38F}-S4261.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\persistence\Akka.Persistence.Sql.Common\Journal\JournalDbEngine.cs",
+"region":  {
+"startLine":  128,
+"startColumn":  27,
+"endLine":  128,
+"endColumn":  37
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Persistence.Tests-{4492004A-A8D0-45B0-BACC-05BA2F38EC55}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Persistence.Tests-{4492004A-A8D0-45B0-BACC-05BA2F38EC55}-S4261.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Remove the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence.Tests\PersistentActorSpec.cs",
+"region":  {
+"startLine":  282,
+"startColumn":  21,
+"endLine":  282,
+"endColumn":  106
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote-{EA4FF8FD-7C53-49C8-B9AA-02E458B3E6A7}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote-{EA4FF8FD-7C53-49C8-B9AA-02E458B3E6A7}-S4261.json
@@ -1,0 +1,303 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\RemoteTransport.cs",
+"region":  {
+"startLine":  68,
+"startColumn":  30,
+"endLine":  68,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\RemoteTransport.cs",
+"region":  {
+"startLine":  81,
+"startColumn":  36,
+"endLine":  81,
+"endColumn":  53
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\AkkaProtocolTransport.cs",
+"region":  {
+"startLine":  119,
+"startColumn":  41,
+"endLine":  119,
+"endColumn":  50
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\AkkaProtocolTransport.cs",
+"region":  {
+"startLine":  898,
+"startColumn":  44,
+"endLine":  898,
+"endColumn":  65
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\AkkaProtocolTransport.cs",
+"region":  {
+"startLine":  909,
+"startColumn":  44,
+"endLine":  909,
+"endColumn":  64
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\Helios\HeliosTransport.cs",
+"region":  {
+"startLine":  339,
+"startColumn":  52,
+"endLine":  339,
+"endColumn":  69
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TestTransport.cs",
+"region":  {
+"startLine":  97,
+"startColumn":  86,
+"endLine":  97,
+"endColumn":  99
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TestTransport.cs",
+"region":  {
+"startLine":  114,
+"startColumn":  47,
+"endLine":  114,
+"endColumn":  63
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TestTransport.cs",
+"region":  {
+"startLine":  164,
+"startColumn":  21,
+"endLine":  164,
+"endColumn":  33
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TestTransport.cs",
+"region":  {
+"startLine":  169,
+"startColumn":  27,
+"endLine":  169,
+"endColumn":  46
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TestTransport.cs",
+"region":  {
+"startLine":  190,
+"startColumn":  28,
+"endLine":  190,
+"endColumn":  43
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TestTransport.cs",
+"region":  {
+"startLine":  199,
+"startColumn":  27,
+"endLine":  199,
+"endColumn":  32
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TestTransport.cs",
+"region":  {
+"startLine":  204,
+"startColumn":  28,
+"endLine":  204,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TestTransport.cs",
+"region":  {
+"startLine":  387,
+"startColumn":  27,
+"endLine":  387,
+"endColumn":  32
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\ThrottleTransportAdapter.cs",
+"region":  {
+"startLine":  386,
+"startColumn":  38,
+"endLine":  386,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\ThrottleTransportAdapter.cs",
+"region":  {
+"startLine":  396,
+"startColumn":  38,
+"endLine":  396,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\ThrottleTransportAdapter.cs",
+"region":  {
+"startLine":  409,
+"startColumn":  38,
+"endLine":  409,
+"endColumn":  64
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\Transport.cs",
+"region":  {
+"startLine":  25,
+"startColumn":  95,
+"endLine":  25,
+"endColumn":  101
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\Transport.cs",
+"region":  {
+"startLine":  39,
+"startColumn":  49,
+"endLine":  39,
+"endColumn":  58
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\Transport.cs",
+"region":  {
+"startLine":  48,
+"startColumn":  36,
+"endLine":  48,
+"endColumn":  44
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\Transport.cs",
+"region":  {
+"startLine":  56,
+"startColumn":  35,
+"endLine":  56,
+"endColumn":  52
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TransportAdapters.cs",
+"region":  {
+"startLine":  158,
+"startColumn":  60,
+"endLine":  158,
+"endColumn":  75
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TransportAdapters.cs",
+"region":  {
+"startLine":  313,
+"startColumn":  33,
+"endLine":  313,
+"endColumn":  48
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote.TestKit-{E5957C3E-2B1E-469F-A680-7953B4DEA31B}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote.TestKit-{E5957C3E-2B1E-469F-A680-7953B4DEA31B}-S4261.json
@@ -1,0 +1,173 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  64,
+"startColumn":  34,
+"endLine":  64,
+"endColumn":  49
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  75,
+"startColumn":  28,
+"endLine":  75,
+"endColumn":  36
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  102,
+"startColumn":  27,
+"endLine":  102,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  123,
+"startColumn":  27,
+"endLine":  123,
+"endColumn":  36
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  148,
+"startColumn":  27,
+"endLine":  148,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  161,
+"startColumn":  27,
+"endLine":  161,
+"endColumn":  37
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  174,
+"startColumn":  27,
+"endLine":  174,
+"endColumn":  32
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  186,
+"startColumn":  27,
+"endLine":  186,
+"endColumn":  31
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  208,
+"startColumn":  27,
+"endLine":  208,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  225,
+"startColumn":  44,
+"endLine":  225,
+"endColumn":  52
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Conductor.cs",
+"region":  {
+"startLine":  238,
+"startColumn":  27,
+"endLine":  238,
+"endColumn":  37
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Player.cs",
+"region":  {
+"startLine":  51,
+"startColumn":  27,
+"endLine":  51,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.TestKit\Player.cs",
+"region":  {
+"startLine":  146,
+"startColumn":  30,
+"endLine":  146,
+"endColumn":  43
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote.Tests-{95E921AB-1F5A-4AF9-B7FE-284E317A97F4}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote.Tests-{95E921AB-1F5A-4AF9-B7FE-284E317A97F4}-S4261.json
@@ -1,0 +1,43 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.Tests\RemotingSpec.cs",
+"region":  {
+"startLine":  159,
+"startColumn":  27,
+"endLine":  159,
+"endColumn":  52
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.Tests\RemotingSpec.cs",
+"region":  {
+"startLine":  203,
+"startColumn":  27,
+"endLine":  203,
+"endColumn":  72
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.Tests\RemotingSpec.cs",
+"region":  {
+"startLine":  217,
+"startColumn":  27,
+"endLine":  217,
+"endColumn":  81
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Tests-{3F786C7D-70E3-4836-8B33-EC9A5AF72330}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Tests-{3F786C7D-70E3-4836-8B33-EC9A5AF72330}-S4261.json
@@ -1,0 +1,225 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Actor\ActorSelectionSpec.cs",
+"region":  {
+"startLine":  87,
+"startColumn":  27,
+"endLine":  87,
+"endColumn":  40
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Actor\ActorSelectionSpec.cs",
+"region":  {
+"startLine":  95,
+"startColumn":  27,
+"endLine":  95,
+"endColumn":  54
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Actor\AskTimeoutSpec.cs",
+"region":  {
+"startLine":  39,
+"startColumn":  27,
+"endLine":  39,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Actor\PatternSpec.cs",
+"region":  {
+"startLine":  35,
+"startColumn":  27,
+"endLine":  35,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Dispatch\AsyncAwaitSpec.cs",
+"region":  {
+"startLine":  260,
+"startColumn":  27,
+"endLine":  260,
+"endColumn":  87
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Dispatch\AsyncAwaitSpec.cs",
+"region":  {
+"startLine":  271,
+"startColumn":  27,
+"endLine":  271,
+"endColumn":  79
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Dispatch\AsyncAwaitSpec.cs",
+"region":  {
+"startLine":  281,
+"startColumn":  27,
+"endLine":  281,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Dispatch\AsyncAwaitSpec.cs",
+"region":  {
+"startLine":  292,
+"startColumn":  27,
+"endLine":  292,
+"endColumn":  74
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Dispatch\AsyncAwaitSpec.cs",
+"region":  {
+"startLine":  303,
+"startColumn":  27,
+"endLine":  303,
+"endColumn":  79
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Dispatch\AsyncAwaitSpec.cs",
+"region":  {
+"startLine":  320,
+"startColumn":  27,
+"endLine":  320,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Dispatch\AsyncAwaitSpec.cs",
+"region":  {
+"startLine":  337,
+"startColumn":  27,
+"endLine":  337,
+"endColumn":  70
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Dispatch\AsyncAwaitSpec.cs",
+"region":  {
+"startLine":  345,
+"startColumn":  27,
+"endLine":  345,
+"endColumn":  65
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Dispatch\AsyncAwaitSpec.cs",
+"region":  {
+"startLine":  394,
+"startColumn":  27,
+"endLine":  394,
+"endColumn":  75
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Dispatch\XUnitAsyncTestsSanityCheck.cs",
+"region":  {
+"startLine":  23,
+"startColumn":  21,
+"endLine":  23,
+"endColumn":  58
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Pattern\CircuitBreakerSpec.cs",
+"region":  {
+"startLine":  253,
+"startColumn":  21,
+"endLine":  253,
+"endColumn":  26
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Routing\ConsistentHashingRouterSpec.cs",
+"region":  {
+"startLine":  112,
+"startColumn":  27,
+"endLine":  112,
+"endColumn":  84
+}
+}
+},
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests\Routing\ConsistentHashingRouterSpec.cs",
+"region":  {
+"startLine":  170,
+"startColumn":  27,
+"endLine":  170,
+"endColumn":  89
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/PingPong-{956F7D26-4505-4A26-86D0-73135BD35A93}-S4261.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/PingPong-{956F7D26-4505-4A26-86D0-73135BD35A93}-S4261.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S4261",
+"message":  "Add the 'Async' suffix to the name of this method.",
+"location":  {
+"uri":  "sources\akka.net\src\benchmark\PingPong\Program.cs",
+"region":  {
+"startLine":  162,
+"startColumn":  59,
+"endLine":  162,
+"endColumn":  68
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/rspec/cs/S4261_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S4261_c#.html
@@ -1,0 +1,41 @@
+<p>According to the Task-based Asynchronous Pattern (TAP), methods returning either a <code>System.Threading.Tasks.Task</code> or a
+<code>System.Threading.Tasks.Task&lt;TResult&gt;</code> are considered "asynchronous". Such methods should use the "Async" suffix. Conversely methods
+which do not return such <code>Task</code>s should not have an "Async" suffix in their names.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+using System;
+using  System.Threading.Tasks;
+
+namespace myLibrary
+{
+
+  public class Foo
+  {
+    public Task Read(byte [] buffer, int offset, int count, // Noncompliant
+                                CancellationToken cancellationToken)
+  }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System;
+using  System.Threading.Tasks;
+
+namespace myLibrary
+{
+
+  public class Foo
+  {
+    public Task ReadAsync(byte [] buffer, int offset, int count,
+                                          CancellationToken cancellationToken)
+  }
+}
+</pre>
+<h2>Exceptions</h2>
+<p>This rule doesn't raise an issue when the method is an override or part of the implementation of an interface since it can not be renamed.</p>
+<h2>See</h2>
+<ul>
+  <li> <a href="https://docs.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap">Task-based
+  Asynchronous Pattern</a> </li>
+</ul>
+

--- a/sonaranalyzer-dotnet/rspec/cs/S4261_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S4261_c#.json
@@ -1,0 +1,17 @@
+{
+  "title": "Methods should be named according to their synchronicities",
+  "type": "BUG",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "convention",
+    "async-await",
+    "confusing"
+  ],
+  "defaultSeverity": "Minor",
+  "ruleSpecification": "RSPEC-4261",
+  "sqKey": "S4261"
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -8544,6 +8544,33 @@
   <data name="S4260_Type" xml:space="preserve">
     <value>BUG</value>
   </data>
+  <data name="S4261_Category" xml:space="preserve">
+    <value>Minor Bug</value>
+  </data>
+  <data name="S4261_Description" xml:space="preserve">
+    <value>According to the Task-based Asynchronous Pattern (TAP), methods returning either a System.Threading.Tasks.Task or a System.Threading.Tasks.Task&lt;TResult&gt; are considered "asynchronous". Such methods should use the "Async" suffix. Conversely methods which do not return such Tasks should not have an "Async" suffix in their names.</value>
+  </data>
+  <data name="S4261_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S4261_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S4261_RemediationCost" xml:space="preserve">
+    <value>5min</value>
+  </data>
+  <data name="S4261_Severity" xml:space="preserve">
+    <value>Minor</value>
+  </data>
+  <data name="S4261_Tags" xml:space="preserve">
+    <value>convention,async-await,confusing</value>
+  </data>
+  <data name="S4261_Title" xml:space="preserve">
+    <value>Methods should be named according to their synchronicities</value>
+  </data>
+  <data name="S4261_Type" xml:space="preserve">
+    <value>BUG</value>
+  </data>
   <data name="S4277_Category" xml:space="preserve">
     <value>Critical Bug</value>
   </data>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNameAccordingToSynchronicity.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNameAccordingToSynchronicity.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(DiagnosticId)]
+    public sealed class MethodShouldBeNameAccordingToSynchronicity : SonarDiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "S4261";
+        private const string MessageFormat = "{0}";
+        private const string AddAsyncSuffixMessage = "Add the 'Async' suffix to the name of this method.";
+        private const string RemoveAsyncSuffixMessage = "Remove the 'Async' suffix to the name of this method.";
+
+        private static readonly DiagnosticDescriptor rule =
+            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+
+        private static ISet<KnownType> TaskTypes = new HashSet<KnownType>
+        {
+            KnownType.System_Threading_Tasks_Task,
+            KnownType.System_Threading_Tasks_Task_T
+        };
+
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionInNonGenerated(
+                c =>
+                {
+                    var methodDeclaration = (MethodDeclarationSyntax)c.Node;
+                    if (methodDeclaration.Identifier.IsMissing)
+                    {
+                        return;
+                    }
+
+                    var methodSymbol = c.SemanticModel.GetDeclaredSymbol(methodDeclaration);
+                    if (methodSymbol == null ||
+                        methodSymbol.GetInterfaceMember() != null ||
+                        methodSymbol.GetOverriddenMember() != null)
+                    {
+                        return;
+                    }
+
+                    var isTaskReturnType = methodSymbol.ReturnType.DerivesFromAny(TaskTypes);
+                    var hasAsyncSuffix = "async".Equals(methodDeclaration.Identifier.ValueText.SplitCamelCaseToWords().LastOrDefault());
+
+                    if (hasAsyncSuffix && !isTaskReturnType)
+                    {
+                        c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, methodDeclaration.Identifier.GetLocation(), RemoveAsyncSuffixMessage));
+                    }
+                    else if (!hasAsyncSuffix && isTaskReturnType)
+                    {
+                        c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, methodDeclaration.Identifier.GetLocation(), AddAsyncSuffixMessage));
+                    }
+                    else
+                    {
+                        // do nothing
+                    }
+                },
+                SyntaxKind.MethodDeclaration);
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNameAccordingToSynchronicity.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNameAccordingToSynchronicity.cs
@@ -46,7 +46,8 @@ namespace SonarAnalyzer.Rules.CSharp
         private static ISet<KnownType> TaskTypes = new HashSet<KnownType>
         {
             KnownType.System_Threading_Tasks_Task,
-            KnownType.System_Threading_Tasks_Task_T
+            KnownType.System_Threading_Tasks_Task_T,
+            KnownType.System_Threading_Tasks_ValueTask_TResult
         };
 
         protected override void Initialize(SonarAnalysisContext context)
@@ -68,8 +69,8 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    var isTaskReturnType = methodSymbol.ReturnType.DerivesFromAny(TaskTypes);
-                    var hasAsyncSuffix = "async".Equals(methodDeclaration.Identifier.ValueText.SplitCamelCaseToWords().LastOrDefault());
+                    var isTaskReturnType = (methodSymbol.ReturnType as INamedTypeSymbol)?.ConstructedFrom.DerivesFromAny(TaskTypes) ?? false;
+                    var hasAsyncSuffix = methodDeclaration.Identifier.ValueText.SplitCamelCaseToWords().LastOrDefault() == "async";
 
                     if (hasAsyncSuffix && !isTaskReturnType)
                     {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Helpers
 {
     internal sealed class KnownType
     {
-        #region Known types
+        #region Known types        
 
         internal static readonly KnownType Microsoft_AspNetCore_Mvc_Controller = new KnownType("Microsoft.AspNetCore.Mvc.Controller");
         internal static readonly KnownType Microsoft_VisualBasic_Interaction = new KnownType("Microsoft.VisualBasic.Interaction");
@@ -237,6 +237,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_Text_StringBuilder = new KnownType("System.Text.StringBuilder");
         internal static readonly KnownType System_Threading_Tasks_Task = new KnownType("System.Threading.Tasks.Task");
         internal static readonly KnownType System_Threading_Tasks_Task_T = new KnownType("System.Threading.Tasks.Task<TResult>");
+        internal static readonly KnownType System_Threading_Tasks_ValueTask_TResult = new KnownType("System.Threading.Tasks.ValueTask<TResult>");
         internal static readonly KnownType System_Threading_Thread = new KnownType("System.Threading.Thread");
         internal static readonly KnownType System_ThreadStaticAttribute = new KnownType("System.ThreadStaticAttribute");
         internal static readonly KnownType System_Type = new KnownType("System.Type");

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S4261.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S4261.html
@@ -1,0 +1,41 @@
+<p>According to the Task-based Asynchronous Pattern (TAP), methods returning either a <code>System.Threading.Tasks.Task</code> or a
+<code>System.Threading.Tasks.Task&lt;TResult&gt;</code> are considered "asynchronous". Such methods should use the "Async" suffix. Conversely methods
+which do not return such <code>Task</code>s should not have an "Async" suffix in their names.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+using System;
+using  System.Threading.Tasks;
+
+namespace myLibrary
+{
+
+  public class Foo
+  {
+    public Task Read(byte [] buffer, int offset, int count, // Noncompliant
+                                CancellationToken cancellationToken)
+  }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System;
+using  System.Threading.Tasks;
+
+namespace myLibrary
+{
+
+  public class Foo
+  {
+    public Task ReadAsync(byte [] buffer, int offset, int count,
+                                          CancellationToken cancellationToken)
+  }
+}
+</pre>
+<h2>Exceptions</h2>
+<p>This rule doesn't raise an issue when the method is an override or part of the implementation of an interface since it can not be renamed.</p>
+<h2>See</h2>
+<ul>
+  <li> <a href="https://docs.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap">Task-based
+  Asynchronous Pattern</a> </li>
+</ul>
+

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/PackagingTests/CsRuleTypeMapping.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/PackagingTests/CsRuleTypeMapping.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2018 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -4258,7 +4258,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
             //["4258"],
             //["4259"],
             ["4260"] = "BUG",
-            //["4261"],
+            ["4261"] = "BUG",
             //["4262"],
             //["4263"],
             //["4264"],

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodShouldBeNameAccordingToSynchronicityTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodShouldBeNameAccordingToSynchronicityTest.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void MethodShouldBeNameAccordingToSynchronicity()
         {
             Verifier.VerifyAnalyzer(@"TestCases\MethodShouldBeNameAccordingToSynchronicity.cs",
-                new MethodShouldBeNameAccordingToSynchronicity());
+                new MethodShouldBeNameAccordingToSynchronicity(), null, Verifier.SystemThreadingTasksExtensionsAssembly);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodShouldBeNameAccordingToSynchronicityTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodShouldBeNameAccordingToSynchronicityTest.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+extern alias csharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using csharp::SonarAnalyzer.Rules.CSharp;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class MethodShouldBeNameAccordingToSynchronicityTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void MethodShouldBeNameAccordingToSynchronicity()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\MethodShouldBeNameAccordingToSynchronicity.cs",
+                new MethodShouldBeNameAccordingToSynchronicity());
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodShouldBeNameAccordingToSynchronicity.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodShouldBeNameAccordingToSynchronicity.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Tests.Diagnostics
+{
+    public class NonCompliantCases
+    {
+        public Task FooTask() // Noncompliant {{Add the 'Async' suffix to the name of this method.}}
+//                  ^^^^^^^
+        {
+            return Task.Delay(0);
+        }
+
+        public Task<int> FooTaskInt() // Noncompliant
+        {
+            return Task.FromResult(1);
+        }
+
+        public Task<T> FooTaskT<T>() // Noncompliant
+//                     ^^^^^^^^
+        {
+            return Task.FromResult(default(T));
+        }
+
+        public void BarVoidAsync() // Noncompliant {{Remove the 'Async' suffix to the name of this method.}}
+//                  ^^^^^^^^^^^^
+        {
+        }
+
+        public int BarIntAsync() // Noncompliant
+        {
+            return 1;
+        }
+
+        public object BarObjectAsync() // Noncompliant
+        {
+            return null;
+        }
+    }
+
+    public interface IFoo
+    {
+        Task Do(); // Noncompliant
+    }
+
+    public class BaseClass : IFoo
+    {
+        public virtual Task<string> MyMethod()// Noncompliant
+        {
+            return Task.FromResult("foo");
+        }
+
+        public Task Do() // Compliant - comes from interface so not possible to change
+        {
+        }
+    }
+
+    public class CompliantCases : BaseClass
+    {
+        public Task FooTaskAsync() 
+        {
+            return Task.Delay(0);
+        }
+
+        public Task<int> FooTaskIntAsync()
+        {
+            return Task.FromResult(1);
+        }
+
+        public Task<T> FooTaskTAsync<T>()
+        {
+            return Task.FromResult(default(T));
+        }
+
+        public void BarVoid()
+        {
+        }
+
+        public int BarInt()
+        {
+            return 1;
+        }
+
+        public object BarObject()
+        {
+            return null;
+        }
+
+        public override Task<string> MyMethod()
+        {
+            return Task.FromResult("foo");
+        }
+    }
+
+    public class InvalidCode
+    {
+        public Task ()
+        {
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodShouldBeNameAccordingToSynchronicity.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodShouldBeNameAccordingToSynchronicity.cs
@@ -5,6 +5,10 @@ namespace Tests.Diagnostics
 {
     public class NonCompliantCases
     {
+        public ValueTask<T> FooValueTaskT<T>() // Noncompliant
+        {
+        }
+
         public Task FooTask() // Noncompliant {{Add the 'Async' suffix to the name of this method.}}
 //                  ^^^^^^^
         {
@@ -35,6 +39,23 @@ namespace Tests.Diagnostics
         public object BarObjectAsync() // Noncompliant
         {
             return null;
+        }
+
+        public Task MyMethodAsync()
+        {
+            if (true)
+            {
+                return OtherSubMethod();
+            }
+
+            return SubMethod();
+
+            Task SubMethod() => Task.Delay(0); // Compliant - should not be but requires C# 7 syntax
+
+            Task OtherSubMethod()// Compliant - should not be but requires C# 7 syntax
+            {
+                return Task.Delay(0);
+            }
         }
     }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Verifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Verifier.cs
@@ -74,6 +74,8 @@ namespace SonarAnalyzer.UnitTest
             MetadataReference.CreateFromFile(PackagesFolderRelativePath + @"xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll");
         internal static readonly MetadataReference NUnitFrameworkAssembly =
             MetadataReference.CreateFromFile(PackagesFolderRelativePath + @"NUnit.2.6.4\lib\nunit.framework.dll");
+        internal static readonly MetadataReference SystemThreadingTasksExtensionsAssembly =
+           MetadataReference.CreateFromFile(PackagesFolderRelativePath + @"System.Threading.Tasks.Extensions.4.3.0\lib\netstandard1.0\System.Threading.Tasks.Extensions.dll");
         internal static readonly MetadataReference FluentAssertionsAssembly =
             MetadataReference.CreateFromFile(typeof(AssertionExtensions).Assembly.Location);
         internal static readonly MetadataReference FluentAssertionsCoreAssembly =

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/packages.SonarAnalyzer.UnitTest.config
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/packages.SonarAnalyzer.UnitTest.config
@@ -61,6 +61,7 @@
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />


### PR DESCRIPTION
FIx #780 