### PR TITLE
Fix S3264: FP when using add/remove syntax

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public class UninvokedEventDeclaration : SonarDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S3264";
-        private const string MessageFormat = "Remove this unused event or invoke it.";
+        private const string MessageFormat = "Remove the unused event '{0}' or invoke it.";
 
         private static readonly Accessibility maxAccessibility = Accessibility.Public;
 
@@ -43,6 +43,11 @@ namespace SonarAnalyzer.Rules.CSharp
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+
+        private static readonly ISet<SyntaxKind> eventSyntax = new HashSet<SyntaxKind>
+        {
+            SyntaxKind.EventFieldDeclaration,
+        };
 
         protected sealed override void Initialize(SonarAnalysisContext context)
         {
@@ -60,41 +65,41 @@ namespace SonarAnalyzer.Rules.CSharp
 
             var removableDeclarationCollector = new RemovableDeclarationCollector(namedType, context.Compilation);
 
-            var removableEvents = removableDeclarationCollector.GetRemovableDeclarations(
-                new HashSet<SyntaxKind> { SyntaxKind.EventDeclaration }, maxAccessibility);
-            var removableEventFields = removableDeclarationCollector.GetRemovableFieldLikeDeclarations(
-                new HashSet<SyntaxKind> { SyntaxKind.EventFieldDeclaration }, maxAccessibility);
+            var removableEventFields = removableDeclarationCollector
+                .GetRemovableFieldLikeDeclarations(eventSyntax, maxAccessibility)
+                .ToList();
 
-            var allRemovableEvents = removableEvents.Concat(removableEventFields).ToList();
-            if (!allRemovableEvents.Any())
+            if (!removableEventFields.Any())
             {
                 return;
             }
 
-            var symbolNames = allRemovableEvents.Select(t => t.Symbol.Name).ToHashSet();
+            var symbolNames = removableEventFields.Select(t => t.Symbol.Name).ToHashSet();
             var usedSymbols = GetReferencedSymbolsWithMatchingNames(removableDeclarationCollector, symbolNames);
             var invokedSymbols = GetInvokedEventSymbols(removableDeclarationCollector);
             var possiblyCopiedSymbols = GetPossiblyCopiedSymbols(removableDeclarationCollector);
 
-            foreach (var removableEvent in allRemovableEvents)
-            {
-                if (!usedSymbols.Contains(removableEvent.Symbol))
-                {
-                    /// reported by <see cref="UnusedPrivateMember"/>
-                    continue;
-                }
+            removableEventFields
+                .Where(IsUsed) /// Unused are reported by <see cref="UnusedPrivateMember"/>
+                .Where(IsNotInvoked)
+                .Where(IsNotCopied)
+                .ToList()
+                .ForEach(x => context.ReportDiagnosticIfNonGenerated(
+                    Diagnostic.Create(rule, GetLocation(x.SyntaxNode), x.Symbol.Name)));
 
-                if (!invokedSymbols.Contains(removableEvent.Symbol) &&
-                    !possiblyCopiedSymbols.Contains(removableEvent.Symbol))
-                {
-                    var eventField = removableEvent.SyntaxNode as VariableDeclaratorSyntax;
-                    var location = eventField != null
-                        ? eventField.Identifier.GetLocation()
-                        : ((EventDeclarationSyntax)removableEvent.SyntaxNode).Identifier.GetLocation();
+            Location GetLocation(SyntaxNode node) =>
+                node is VariableDeclaratorSyntax variableDeclarator
+                    ? variableDeclarator.Identifier.GetLocation()
+                    : ((EventDeclarationSyntax)node).Identifier.GetLocation();
 
-                    context.ReportDiagnosticIfNonGenerated(Diagnostic.Create(rule, location));
-                }
-            }
+            bool IsNotInvoked(SyntaxNodeSymbolSemanticModelTuple<SyntaxNode, ISymbol> tuple) =>
+                !invokedSymbols.Contains(tuple.Symbol);
+
+            bool IsNotCopied(SyntaxNodeSymbolSemanticModelTuple<SyntaxNode, ISymbol> tuple) =>
+                !possiblyCopiedSymbols.Contains(tuple.Symbol);
+
+            bool IsUsed(SyntaxNodeSymbolSemanticModelTuple<SyntaxNode, ISymbol> tuple) =>
+                usedSymbols.Contains(tuple.Symbol);
         }
 
         private static ISet<ISymbol> GetReferencedSymbolsWithMatchingNames(RemovableDeclarationCollector removableDeclarationCollector,

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UninvokedEventDeclaration.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UninvokedEventDeclaration.cs
@@ -126,4 +126,83 @@ namespace Tests.Diagnostics
             throw new NotImplementedException();
         }
     }
+
+    // Shows all different kinds of event invocations
+    public class EventInvocations
+    {
+        public event EventHandler MyEvent1;
+        public event EventHandler MyEvent2;
+        public event EventHandler MyEvent3;
+        public event EventHandler MyEvent4;
+        public event EventHandler MyEvent5;
+        public event EventHandler MyEvent6;
+
+        public event Action<object, EventArgs> MyAction1;
+        public event Action<object, EventArgs> MyAction2;
+        public event Action<object, EventArgs> MyAction3;
+        public event Action<object, EventArgs> MyAction4;
+        public event Action<object, EventArgs> MyAction5;
+        public event Action<object, EventArgs> MyAction6;
+
+        public void InvokeAll()
+        {
+            MyEvent1(this, EventArgs.Empty);
+            MyEvent2.Invoke(this, EventArgs.Empty);
+            MyEvent3.DynamicInvoke(this, EventArgs.Empty);
+            MyEvent4.BeginInvoke(this, EventArgs.Empty, null, null);
+            this.MyEvent5(this, EventArgs.Empty);
+            MyEvent6?.Invoke(this, EventArgs.Empty);
+
+            MyAction1(this, EventArgs.Empty);
+            MyAction2.Invoke(this, EventArgs.Empty);
+            MyAction3.DynamicInvoke(this, EventArgs.Empty);
+            MyAction4.BeginInvoke(this, EventArgs.Empty, null, null);
+            this.MyAction5(this, EventArgs.Empty);
+            MyAction6?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    // Shows all different kinds of event invocations from an inner class
+    public class EventInvocationsFromInnerClass
+    {
+        public event EventHandler MyEvent1;
+        public event EventHandler MyEvent2;
+        public event EventHandler MyEvent3;
+        public event EventHandler MyEvent4;
+        public event EventHandler MyEvent5;
+        public event EventHandler MyEvent6;
+
+        public event Action<object, EventArgs> MyAction1;
+        public event Action<object, EventArgs> MyAction2;
+        public event Action<object, EventArgs> MyAction3;
+        public event Action<object, EventArgs> MyAction4;
+        public event Action<object, EventArgs> MyAction5;
+        public event Action<object, EventArgs> MyAction6;
+
+        public class Inner
+        {
+            readonly EventInvocationsFromInnerClass outer;
+            public Inner(EventInvocationsFromInnerClass outer)
+            {
+                this.outer = outer;
+            }
+
+            public void InvokeAll()
+            {
+                outer.MyEvent1(this, EventArgs.Empty);
+                outer.MyEvent2.Invoke(this, EventArgs.Empty);
+                outer.MyEvent3.DynamicInvoke(this, EventArgs.Empty);
+                outer.MyEvent4.BeginInvoke(this, EventArgs.Empty, null, null);
+                outer.MyEvent5(this, EventArgs.Empty);
+                outer.MyEvent6?.Invoke(this, EventArgs.Empty);
+
+                outer.MyAction1(this, EventArgs.Empty);
+                outer.MyAction2.Invoke(this, EventArgs.Empty);
+                outer.MyAction3.DynamicInvoke(this, EventArgs.Empty);
+                outer.MyAction4.BeginInvoke(this, EventArgs.Empty, null, null);
+                outer.MyAction5(this, EventArgs.Empty);
+                outer.MyAction6?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Removed the check for EventDeclarationSyntax as it cannot be invoked. One can only invoke EventFieldDeclarationSyntax but checking whether the event declaration is using the _correct_ field is a different rule IMO. S3237 will report if the value of the accessor is not used (e.g. if you don't assign an event field).

Refactored the implementation a bit to make it more functional and somewhat easier to understand.

Fix #1219 
Fix #1123 