### PR TITLE
Fix S1168: "Return empty collection" should not raise when the method…

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2018 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -45,6 +45,11 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             KnownType.System_Collections_IEnumerable,
             KnownType.System_Array
+        };
+
+        private static readonly ISet<KnownType> IgnoredTypes = new HashSet<KnownType>
+        {
+            KnownType.System_Xml_XmlNode
         };
 
         protected override void Initialize(SonarAnalysisContext context)
@@ -103,7 +108,8 @@ namespace SonarAnalyzer.Rules.CSharp
 
             return methodSymbol != null &&
                 !methodSymbol.ReturnType.Is(KnownType.System_String) &&
-                methodSymbol.ReturnType.DerivesOrImplementsAny(CollectionTypes);
+                methodSymbol.ReturnType.DerivesOrImplementsAny(CollectionTypes) &&
+                !methodSymbol.ReturnType.DerivesFromAny(IgnoredTypes);
         }
 
         private static LiteralExpressionSyntax GetNullLiteralOrDefault(ArrowExpressionClauseSyntax expressionBody)

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Helpers
 {
     internal sealed class KnownType
     {
-        #region Known types        
+        #region Known types
 
         internal static readonly KnownType Microsoft_AspNetCore_Mvc_Controller = new KnownType("Microsoft.AspNetCore.Mvc.Controller");
         internal static readonly KnownType Microsoft_VisualBasic_Interaction = new KnownType("Microsoft.VisualBasic.Interaction");
@@ -253,6 +253,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_Windows_Forms_Application = new KnownType("System.Windows.Forms.Application");
         internal static readonly KnownType System_Windows_Markup_ConstructorArgumentAttribute = new KnownType("System.Windows.Markup.ConstructorArgumentAttribute");
         internal static readonly KnownType System_Xml_XmlDocument = new KnownType("System.Xml.XmlDocument");
+        internal static readonly KnownType System_Xml_XmlNode = new KnownType("System.Xml.XmlNode");
         internal static readonly ISet<KnownType> SystemActionVariants = new HashSet<KnownType>
         {
             new KnownType("System.Action"),

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ReturnEmptyCollectionInsteadOfNullTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ReturnEmptyCollectionInsteadOfNullTest.cs
@@ -32,7 +32,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void ReturnEmptyCollectionInsteadOfNull()
         {
             Verifier.VerifyAnalyzer(@"TestCases\ReturnEmptyCollectionInsteadOfNull.cs",
-                new ReturnEmptyCollectionInsteadOfNull());
+                new ReturnEmptyCollectionInsteadOfNull(),
+                additionalReferences: Verifier.SystemXmlAssembly);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ReturnEmptyCollectionInsteadOfNull.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ReturnEmptyCollectionInsteadOfNull.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Xml;
 
 namespace Tests.Diagnostics
 {
@@ -71,6 +72,21 @@ namespace Tests.Diagnostics
                 return null; // Compliant because we return from a func
             };
             return new List<int>();
+        }
+
+        public XmlNode GetXmlNode()
+        {
+            return null; // Compliant XmlNode and its descendants are ignored
+        }
+
+        public XmlDocument GetXmlDocument()
+        {
+            return null; // Compliant XmlNode and its descendants are ignored
+        }
+
+        public XmlElement GetXmlElement()
+        {
+            return null; // Compliant XmlNode and its descendants are ignored
         }
     }
 }


### PR DESCRIPTION
… return type is XmlNode

Fix #1037 