### PR TITLE
Refactoring symbolic execution analysis to run once per mehod

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S3900.json
@@ -1848,32 +1848,6 @@
 },
 {
 "id":  "S3900",
-"message":  "Refactor this method to add validation of parameter 'modelType' before using it.",
-"location":  {
-"uri":  "sources\Nancy\src\Nancy\ModelBinding\DefaultBinder.cs",
-"region":  {
-"startLine":  76,
-"startColumn":  35,
-"endLine":  76,
-"endColumn":  44
-}
-}
-},
-{
-"id":  "S3900",
-"message":  "Refactor this method to add validation of parameter 'modelType' before using it.",
-"location":  {
-"uri":  "sources\Nancy\src\Nancy\ModelBinding\DefaultBinder.cs",
-"region":  {
-"startLine":  81,
-"startColumn":  25,
-"endLine":  81,
-"endColumn":  34
-}
-}
-},
-{
-"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'bodyStream' before using it.",
 "location":  {
 "uri":  "sources\Nancy\src\Nancy\ModelBinding\DefaultBodyDeserializers\JsonBodyDeserializer.cs",
@@ -2727,19 +2701,6 @@
 "startColumn":  39,
 "endLine":  46,
 "endColumn":  46
-}
-}
-},
-{
-"id":  "S3900",
-"message":  "Refactor this method to add validation of parameter 'path' before using it.",
-"location":  {
-"uri":  "sources\Nancy\src\Nancy\Routing\DefaultRouteSegmentExtractor.cs",
-"region":  {
-"startLine":  20,
-"startColumn":  41,
-"endLine":  20,
-"endColumn":  45
 }
 }
 },

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ISymbolicExecutionAnalyzer.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ISymbolicExecutionAnalyzer.cs
@@ -18,31 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using csharp::SonarAnalyzer.Rules.CSharp;
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 
-namespace SonarAnalyzer.UnitTest.Rules
+namespace SonarAnalyzer.Rules.CSharp
 {
-    [TestClass]
-    public class NullPointerDereferenceTest
+    public interface ISymbolicExecutionAnalyzer : IDisposable
     {
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void NullPointerDereference()
-        {
-            Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereference.cs",
-                new SymbolicExecutionAnalyzer(new NullPointerDereference()));
-        }
-
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void NullPointerDereferenceCSharp6()
-        {
-            Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereferenceCSharp6.cs",
-                new SymbolicExecutionAnalyzer(new NullPointerDereference()),
-                new CSharpParseOptions(LanguageVersion.CSharp6));
-        }
+        IEnumerable<Diagnostic> Diagnostics { get; }
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ISymbolicExecutionAnalyzerFactory.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ISymbolicExecutionAnalyzerFactory.cs
@@ -18,31 +18,19 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using csharp::SonarAnalyzer.Rules.CSharp;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.SymbolicExecution;
 
-namespace SonarAnalyzer.UnitTest.Rules
+namespace SonarAnalyzer.Rules.CSharp
 {
-    [TestClass]
-    public class NullPointerDereferenceTest
+    internal interface ISymbolicExecutionAnalyzerFactory
     {
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void NullPointerDereference()
-        {
-            Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereference.cs",
-                new SymbolicExecutionAnalyzer(new NullPointerDereference()));
-        }
+        ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
 
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void NullPointerDereferenceCSharp6()
-        {
-            Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereferenceCSharp6.cs",
-                new SymbolicExecutionAnalyzer(new NullPointerDereference()),
-                new CSharpParseOptions(LanguageVersion.CSharp6));
-        }
+        bool IsEnabled(SyntaxNodeAnalysisContext context);
+
+        ISymbolicExecutionAnalyzer Create(CSharpExplodedGraph explodedGraph);
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecutionAnalyzer.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecutionAnalyzer.cs
@@ -1,0 +1,97 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+using SonarAnalyzer.SymbolicExecution;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(NullPointerDereference.DiagnosticId)]
+    [Rule(ObjectsShouldNotBeDisposedMoreThanOnce.DiagnosticId)]
+    [Rule(EmptyNullableValueAccess.DiagnosticId)]
+    [Rule(EmptyCollectionsShouldNotBeEnumerated.DiagnosticId)]
+    [Rule(PublicMethodArgumentsShouldBeCheckedForNull.DiagnosticId)]
+    [Rule(ConditionEvaluatesToConstant.S2583DiagnosticId)]
+    [Rule(ConditionEvaluatesToConstant.S2589DiagnosticId)]
+    [Rule(InvalidCastToInterface.DiagnosticId)]
+    public class SymbolicExecutionAnalyzer : SonarDiagnosticAnalyzer
+    {
+        private readonly List<ISymbolicExecutionAnalyzerFactory> analyzerFactories;
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            analyzerFactories.SelectMany(factory => factory.SupportedDiagnostics).ToImmutableArray();
+
+        public SymbolicExecutionAnalyzer() : this(
+            new ConditionEvaluatesToConstant(),
+            new EmptyCollectionsShouldNotBeEnumerated(),
+            new EmptyNullableValueAccess(),
+            new InvalidCastToInterface(),
+            new NullPointerDereference(),
+            new ObjectsShouldNotBeDisposedMoreThanOnce(),
+            new PublicMethodArgumentsShouldBeCheckedForNull())
+        {
+        }
+
+        internal SymbolicExecutionAnalyzer(params ISymbolicExecutionAnalyzerFactory[] analyzers)
+        {
+            analyzerFactories = new List<ISymbolicExecutionAnalyzerFactory>(analyzers);
+        }
+
+        protected sealed override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterExplodedGraphBasedAnalysis(Analyze);
+        }
+
+        private void Analyze(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+        {
+            var analyzerInstances = analyzerFactories
+                .Where(factory => factory.IsEnabled(context))
+                .Select(factory => factory.Create(explodedGraph))
+                .ToList();
+
+            explodedGraph.ExplorationEnded += OnExplorationEnded;
+
+            try
+            {
+                explodedGraph.Walk();
+            }
+            finally
+            {
+                explodedGraph.ExplorationEnded -= OnExplorationEnded;
+
+                analyzerInstances.ForEach(analyzer => analyzer.Dispose());
+            }
+
+            void OnExplorationEnded(object sender, EventArgs e) =>
+                analyzerInstances
+                    .SelectMany(a => a.Diagnostics)
+                    .ToList()
+                    .ForEach(diagnostic => context.ReportDiagnosticWhenActive(diagnostic));
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
@@ -39,9 +39,9 @@ namespace SonarAnalyzer.SymbolicExecution
             : base(cfg, declaration, semanticModel, lva)
         {
             // Add mandatory checks
-            AddExplodedGraphCheck(new NullPointerDereference.NullPointerCheck(this));
-            AddExplodedGraphCheck(new EmptyNullableValueAccess.NullValueAccessedCheck(this));
-            AddExplodedGraphCheck(new InvalidCastToInterface.NullableCastCheck(this));
+            GetOrAddCheck(() => new NullPointerDereference.NullPointerCheck(this));
+            GetOrAddCheck(() => new EmptyNullableValueAccess.NullValueAccessedCheck(this));
+            GetOrAddCheck(() => new InvalidCastToInterface.NullableCastCheck(this));
         }
 
         #region Visit*

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
@@ -277,5 +277,9 @@ namespace SonarAnalyzer.Helpers
 
         public static bool IsStatic(this ISymbol symbol) =>
             symbol != null && symbol.IsStatic;
+
+        internal static bool IsExtensionMethod(this SyntaxNode expression, SemanticModel semanticModel) =>
+            semanticModel.GetSymbolInfo(expression).Symbol is IMethodSymbol memberSymbol &&
+                memberSymbol.IsExtensionMethod;
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/AbstractExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/AbstractExplodedGraph.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.SymbolicExecution
 {
     internal abstract class AbstractExplodedGraph
     {
-        internal const int MaxStepCount = 1000;
+        internal const int MaxStepCount = 2000;
         internal const int MaxInternalStateCount = 10000;
         private const int MaxProgramPointExecutionCount = 2;
 
@@ -146,19 +146,16 @@ namespace SonarAnalyzer.SymbolicExecution
             OnExplorationEnded();
         }
 
-        internal void AddExplodedGraphCheck<T>(T check)
+        public T GetOrAddCheck<T>(Func<T> factory)
             where T : ExplodedGraphCheck
         {
             var matchingCheck = explodedGraphChecks.OfType<T>().SingleOrDefault();
             if (matchingCheck == null)
             {
-                explodedGraphChecks.Add(check);
+                matchingCheck = factory();
+                explodedGraphChecks.Add(matchingCheck);
             }
-            else
-            {
-                explodedGraphChecks.Remove(matchingCheck);
-                explodedGraphChecks.Add(check);
-            }
+            return matchingCheck;
         }
 
         #region OnEvent*

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticAnalyzerContextHelperTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticAnalyzerContextHelperTest.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
     [TestClass]
     public class DiagnosticAnalyzerContextHelperTest
     {
-        private static void VerifyEmpty(string name, string content, DiagnosticAnalyzer diagnosticAnalyzer)
+        private static void VerifyEmpty(string name, string content, SonarDiagnosticAnalyzer diagnosticAnalyzer)
         {
             using (var workspace = new AdhocWorkspace())
             {
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
 
                 var compilation = document.Project.GetCompilationAsync().Result;
 
-                var diagnostics = Verifier.GetDiagnostics(compilation, diagnosticAnalyzer);
+                var diagnostics = Verifier.GetDiagnostics(compilation, new[] { diagnosticAnalyzer });
 
                 diagnostics.Should().HaveCount(0);
             }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConditionEvaluatesToConstantTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConditionEvaluatesToConstantTest.cs
@@ -32,7 +32,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void ConditionEvaluatesToConstant()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\ConditionEvaluatesToConstant.cs", new ConditionEvaluatesToConstant(),
+            Verifier.VerifyAnalyzer(@"TestCases\ConditionEvaluatesToConstant.cs",
+                new SymbolicExecutionAnalyzer(new ConditionEvaluatesToConstant()),
                 new CSharpParseOptions(LanguageVersion.CSharp6));
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyCollectionsShouldNotBeEnumeratedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyCollectionsShouldNotBeEnumeratedTest.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void EmptyCollectionsShouldNotBeEnumerated()
         {
             Verifier.VerifyAnalyzer(@"TestCases\EmptyCollectionsShouldNotBeEnumerated.cs",
-                new EmptyCollectionsShouldNotBeEnumerated());
+                new SymbolicExecutionAnalyzer(new EmptyCollectionsShouldNotBeEnumerated()));
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyNullableValueAccessTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyNullableValueAccessTest.cs
@@ -31,7 +31,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void EmptyNullableValueAccess()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\EmptyNullableValueAccess.cs", new EmptyNullableValueAccess());
+            Verifier.VerifyAnalyzer(@"TestCases\EmptyNullableValueAccess.cs",
+                new  SymbolicExecutionAnalyzer(new EmptyNullableValueAccess()));
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/InvalidCastToInterfaceTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/InvalidCastToInterfaceTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -31,7 +32,12 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void InvalidCastToInterface()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\InvalidCastToInterface.cs", new InvalidCastToInterface());
+            Verifier.VerifyAnalyzer(@"TestCases\InvalidCastToInterface.cs",
+                new SonarDiagnosticAnalyzer[]
+                {
+                    new InvalidCastToInterface(),
+                    new SymbolicExecutionAnalyzer(new InvalidCastToInterface()),
+                });
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void ObjectsShouldNotBeDisposedMoreThanOnce()
         {
             Verifier.VerifyAnalyzer(@"TestCases\ObjectsShouldNotBeDisposedMoreThanOnce.cs",
-                new ObjectsShouldNotBeDisposedMoreThanOnce());
+                new SymbolicExecutionAnalyzer(new ObjectsShouldNotBeDisposedMoreThanOnce()));
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void PublicMethodArgumentsShouldBeCheckedForNull()
         {
             Verifier.VerifyAnalyzer(@"TestCases\PublicMethodArgumentsShouldBeCheckedForNull.cs",
-                new PublicMethodArgumentsShouldBeCheckedForNull());
+                new SymbolicExecutionAnalyzer(new PublicMethodArgumentsShouldBeCheckedForNull()));
         }
     }
 }


### PR DESCRIPTION
Each existing SE rule was converted to a factory and analyzer (state) classes. The existing SE checks are not changed. There is a new diagnostic analyzer - SymbolicExecutionAnalyzer, which uses the registered factories to create analyzers for the corresponding rule when a SE analysis is requested.

Currently the factories are registered (hardcoded) in the SymbolicExecutionAnalyzer class' constructor. This could be changed in the future to reverse the dependency, but it will require more extensive testing, because we will introduce dependencies between diagnostic analyzers, which are generally meant to be independent. The hypothesis seems feasible, but it is not known whether it will work or not.

In general this will reduce the execution time of the its from ~600s to <500s (on my machine).

Best viewed without whitespace:
https://github.com/SonarSource/sonar-csharp/pull/1281/files?w=1