### PR TITLE
Adding support for 'yield return' in CFG

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
@@ -102,6 +102,7 @@ namespace SonarAnalyzer.Rules.CSharp
             return !IsInsideSwitch(jumpBlock) &&
                    !IsReturnWithExpression(jumpBlock) &&
                    !IsThrow(jumpBlock) &&
+                   !IsYieldReturn(jumpBlock) &&
                    !IsOnlyYieldBreak(jumpBlock, yieldStatementCount) &&
                    jumpBlock.SuccessorBlock == jumpBlock.WouldBeSuccessor;
         }
@@ -112,10 +113,18 @@ namespace SonarAnalyzer.Rules.CSharp
             return jumpBlock.JumpNode.AncestorsAndSelf().OfType<SwitchStatementSyntax>().Any();
         }
 
+        private static bool IsYieldReturn(JumpBlock jumpBlock)
+        {
+            // yield return cannot be redundant
+            return jumpBlock.JumpNode is YieldStatementSyntax yieldStatement &&
+                yieldStatement.IsKind(SyntaxKind.YieldReturnStatement);
+        }
+
         private static bool IsOnlyYieldBreak(JumpBlock jumpBlock, int yieldStatementCount)
         {
-            var yieldStatement = jumpBlock.JumpNode as YieldStatementSyntax;
-            return yieldStatement != null && yieldStatementCount == 1;
+            return jumpBlock.JumpNode is YieldStatementSyntax yieldStatement &&
+                yieldStatement.IsKind(SyntaxKind.YieldBreakStatement) &&
+                yieldStatementCount == 1;
         }
 
         private static bool IsThrow(JumpBlock jumpBlock)

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
@@ -91,6 +91,12 @@ namespace SonarAnalyzer.SymbolicExecution
                 return;
             }
 
+            if (block is JumpBlock jumpBlock &&
+                jumpBlock.JumpNode.IsKind(SyntaxKind.YieldReturnStatement))
+            {
+                newProgramState = newProgramState.RemoveSymbols(IsFieldSymbol);
+            }
+
             base.VisitSimpleBlock(block, node);
         }
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
@@ -144,9 +144,7 @@ namespace SonarAnalyzer.SymbolicExecution.ControlFlowGraph
                     return BuildThrowStatement((ThrowStatementSyntax)statement, currentBlock);
 
                 case SyntaxKind.YieldReturnStatement:
-                    // A JumpBlock could be used, just to mark that something special is happening here.
-                    // But for the time being we wouldn't do anything with that information.
-                    return BuildExpression(((YieldStatementSyntax)statement).Expression, currentBlock);
+                    return BuildYieldReturnStatement((YieldStatementSyntax)statement, currentBlock);
 
                 case SyntaxKind.EmptyStatement:
                     return currentBlock;
@@ -682,6 +680,11 @@ namespace SonarAnalyzer.SymbolicExecution.ControlFlowGraph
         private Block BuildYieldBreakStatement(YieldStatementSyntax yieldBreakStatement, Block currentBlock)
         {
             return BuildJumpToExitStatement(yieldBreakStatement, currentBlock);
+        }
+
+        private Block BuildYieldReturnStatement(YieldStatementSyntax yieldReturnStatement, Block currentBlock)
+        {
+            return BuildExpression(yieldReturnStatement.Expression, CreateJumpBlock(yieldReturnStatement, currentBlock, currentBlock));
         }
 
         private Block BuildJumpToExitStatement(StatementSyntax statement, Block currentBlock, ExpressionSyntax expression = null)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/FlowAnalysis/ControlFlowGraphTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/FlowAnalysis/ControlFlowGraphTest.cs
@@ -2164,8 +2164,11 @@ namespace NS
             var cfg = Build(@"yield return 5;");
             VerifyMinimalCfg(cfg);
 
-            cfg.EntryBlock.Should().BeOfType<SimpleBlock>();
-            VerifyAllInstructions(cfg.EntryBlock, "5");
+            cfg.EntryBlock.Should().BeOfType<JumpBlock>();
+
+            var jumpBlock = (JumpBlock)cfg.EntryBlock;
+            jumpBlock.JumpNode.Kind().Should().Be(SyntaxKind.YieldReturnStatement);
+            VerifyAllInstructions(jumpBlock, "5");
         }
 
         #endregion

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantJumpStatement.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantJumpStatement.cs
@@ -88,6 +88,11 @@ namespace Tests.Diagnostics
             yield break; // Compliant
         }
 
+        IEnumerable<int> YieldReturn(int j)
+        {
+            yield return 1;
+        }
+
         IEnumerable<int> YieldBreak2(int j)
         {
             yield return 1;


### PR DESCRIPTION
Related to #1295 but does not fully implement it.

The `yield return` statements used to generate s `SimpleBlock` in CFG. Now a `JumpBlock` is generated, which "jumps" to the next statement. The `JumpBlock` allows us to do additional processing for `yield return` statements, such as to delete the constraints from class fields.

