### PR TITLE
Lazy one time result calculation of some properties and methods in im…

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/ExplodedGraphNode.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/ExplodedGraphNode.cs
@@ -27,10 +27,20 @@ namespace SonarAnalyzer.SymbolicExecution
         public ProgramState ProgramState { get; }
         public ProgramPoint ProgramPoint { get; }
 
+        private readonly Lazy<int> hash;
+
         public ExplodedGraphNode(ProgramPoint programPoint, ProgramState programState)
         {
             ProgramState = programState;
             ProgramPoint = programPoint;
+
+            hash = new Lazy<int>(() =>
+            {
+                var h = 19;
+                h = h * 31 + ProgramState.GetHashCode();
+                h = h * 31 + ProgramPoint.GetHashCode();
+                return h;
+            });
         }
 
         public override bool Equals(object obj)
@@ -54,12 +64,6 @@ namespace SonarAnalyzer.SymbolicExecution
             return ProgramState.Equals(other.ProgramState) && ProgramPoint.Equals(other.ProgramPoint);
         }
 
-        public override int GetHashCode()
-        {
-            var hash = 19;
-            hash = hash * 31 + ProgramState.GetHashCode();
-            hash = hash * 31 + ProgramPoint.GetHashCode();
-            return hash;
-        }
+        public override int GetHashCode() => hash.Value;
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/ProgramPoint.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/ProgramPoint.cs
@@ -28,10 +28,20 @@ namespace SonarAnalyzer.SymbolicExecution
         public Block Block { get; }
         public int Offset { get; }
 
+        private readonly Lazy<int> hash;
+
         internal ProgramPoint(Block block, int offset)
         {
             Block = block;
             Offset = offset;
+
+            hash = new Lazy<int>(() =>
+            {
+                var h = 19;
+                h = h * 31 + Block.GetHashCode();
+                h = h * 31 + Offset.GetHashCode();
+                return h;
+            });
         }
 
         internal ProgramPoint(Block block)
@@ -59,12 +69,6 @@ namespace SonarAnalyzer.SymbolicExecution
             return Block == other.Block && Offset == other.Offset;
         }
 
-        public override int GetHashCode()
-        {
-            var hash = 19;
-            hash = hash * 31 + Block.GetHashCode();
-            hash = hash * 31 + Offset.GetHashCode();
-            return hash;
-        }
+        public override int GetHashCode() => hash.Value;
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/ProgramState.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/ProgramState.cs
@@ -64,6 +64,37 @@ namespace SonarAnalyzer.SymbolicExecution
             SymbolicValue.Base
         };
 
+        private readonly Lazy<int> hash;
+
+        private int ComputeHash()
+        {
+            var h = 19;
+
+            foreach (var symbolValueAssociation in Values)
+            {
+                h = h * 31 + symbolValueAssociation.Key.GetHashCode();
+                h = h * 31 + symbolValueAssociation.Value.GetHashCode();
+            }
+
+            foreach (var constraint in Constraints)
+            {
+                h = h * 31 + constraint.Key.GetHashCode();
+                h = h * 31 + constraint.Value.GetHashCode();
+            }
+
+            foreach (var value in ExpressionStack)
+            {
+                h = h * 31 + value.GetHashCode();
+            }
+
+            foreach (var relationship in Relationships)
+            {
+                h = h * 31 + relationship.GetHashCode();
+            }
+
+            return h;
+        }
+
         public ProgramState()
             : this(ImmutableDictionary<ISymbol, SymbolicValue>.Empty,
                   InitialConstraints,
@@ -231,6 +262,7 @@ namespace SonarAnalyzer.SymbolicExecution
             ProgramPointVisitCounts = programPointVisitCounts;
             ExpressionStack = expressionStack;
             Relationships = relationships;
+            hash = new Lazy<int>(ComputeHash);
         }
 
         public ProgramState PushValue(SymbolicValue symbolicValue)
@@ -397,34 +429,7 @@ namespace SonarAnalyzer.SymbolicExecution
                 Relationships.SetEquals(other.Relationships);
         }
 
-        public override int GetHashCode()
-        {
-            var hash = 19;
-
-            foreach (var symbolValueAssociation in Values)
-            {
-                hash = hash * 31 + symbolValueAssociation.Key.GetHashCode();
-                hash = hash * 31 + symbolValueAssociation.Value.GetHashCode();
-            }
-
-            foreach (var constraint in Constraints)
-            {
-                hash = hash * 31 + constraint.Key.GetHashCode();
-                hash = hash * 31 + constraint.Value.GetHashCode();
-            }
-
-            foreach (var value in ExpressionStack)
-            {
-                hash = hash * 31 + value.GetHashCode();
-            }
-
-            foreach (var relationship in Relationships)
-            {
-                hash = hash * 31 + relationship.GetHashCode();
-            }
-
-            return hash;
-        }
+        public override int GetHashCode() => hash.Value;
 
         public ProgramState SetConstraint(SymbolicValue symbolicValue, SymbolicValueConstraint constraint)
         {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/Relationships/BinaryRelationship.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/Relationships/BinaryRelationship.cs
@@ -25,6 +25,8 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
 {
     public abstract class BinaryRelationship : IEquatable<BinaryRelationship>
     {
+        private readonly Lazy<int> hash;
+
         internal SymbolicValue LeftOperand { get; }
         internal SymbolicValue RightOperand { get; }
 
@@ -32,6 +34,15 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
         {
             LeftOperand = leftOperand;
             RightOperand = rightOperand;
+
+            hash = new Lazy<int>(() =>
+            {
+                var h = 19;
+                h = h * 31 + GetType().GetHashCode();
+                h = h * 31 + LeftOperand.GetHashCode();
+                h = h * 31 + RightOperand.GetHashCode();
+                return h;
+            });
         }
 
         public override bool Equals(object obj)
@@ -55,14 +66,7 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
             return LeftOperand.Equals(other.LeftOperand) && RightOperand.Equals(other.RightOperand);
         }
 
-        public override int GetHashCode()
-        {
-            var hash = 19;
-            hash = hash * 31 + GetType().GetHashCode();
-            hash = hash * 31 + LeftOperand.GetHashCode();
-            hash = hash * 31 + RightOperand.GetHashCode();
-            return hash;
-        }
+        public override int GetHashCode() => hash.Value;
 
         internal abstract BinaryRelationship CreateNew(SymbolicValue leftOperand, SymbolicValue rightOperand);
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/Relationships/ComparisonRelationship.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/Relationships/ComparisonRelationship.cs
@@ -27,12 +27,22 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
 {
     public sealed class ComparisonRelationship : BinaryRelationship, IEquatable<ComparisonRelationship>
     {
+        private readonly Lazy<int> hash;
+
         internal ComparisonKind ComparisonKind { get; }
 
         public ComparisonRelationship(ComparisonKind comparisonKind, SymbolicValue leftOperand, SymbolicValue rightOperand)
             : base(leftOperand, rightOperand)
         {
             ComparisonKind = comparisonKind;
+
+            hash = new Lazy<int>(() =>
+            {
+                var h = 19;
+                h = h * 31 + ComparisonKind.GetHashCode();
+                h = h * 31 + base.GetHashCode();
+                return h;
+            });
         }
 
         public override BinaryRelationship Negate()
@@ -204,13 +214,7 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
             return base.Equals(other);
         }
 
-        public override int GetHashCode()
-        {
-            var hash = 19;
-            hash = hash * 31 + ComparisonKind.GetHashCode();
-            hash = hash * 31 + base.GetHashCode();
-            return hash;
-        }
+        public override int GetHashCode() => hash.Value;
 
         internal override BinaryRelationship CreateNew(SymbolicValue leftOperand, SymbolicValue rightOperand)
         {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/Relationships/EqualsRelationship.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/Relationships/EqualsRelationship.cs
@@ -24,9 +24,18 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
 {
     public abstract class EqualsRelationship : BinaryRelationship, IEquatable<EqualsRelationship>
     {
+        private readonly Lazy<int> hash;
+
         protected EqualsRelationship(SymbolicValue leftOperand, SymbolicValue rightOperand)
             : base(leftOperand, rightOperand)
         {
+            hash = new Lazy<int>(() =>
+            {
+                var left = LeftOperand.GetHashCode();
+                var right = RightOperand.GetHashCode();
+
+                return GetHashCodeMinMaxOrdered(left, right, GetType().GetHashCode());
+            });
         }
 
         public bool Equals(EqualsRelationship other)
@@ -34,13 +43,7 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
             return other != null && AreOperandsMatching(other);
         }
 
-        public sealed override int GetHashCode()
-        {
-            var left = LeftOperand.GetHashCode();
-            var right = RightOperand.GetHashCode();
-
-            return GetHashCodeMinMaxOrdered(left, right, GetType().GetHashCode());
-        }
+        public sealed override int GetHashCode() => hash.Value;
 
         public sealed override bool Equals(object obj)
         {
@@ -57,11 +60,11 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
             var min = Math.Min(leftHash, rightHash);
             var max = Math.Max(leftHash, rightHash);
 
-            var hash = 19;
-            hash = hash * 31 + typeHash;
-            hash = hash * 31 + min.GetHashCode();
-            hash = hash * 31 + max.GetHashCode();
-            return hash;
+            var h = 19;
+            h = h * 31 + typeHash;
+            h = h * 31 + min.GetHashCode();
+            h = h * 31 + max.GetHashCode();
+            return h;
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/Relationships/NotEqualsRelationship.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/Relationships/NotEqualsRelationship.cs
@@ -24,9 +24,18 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
 {
     public abstract class NotEqualsRelationship : BinaryRelationship, IEquatable<NotEqualsRelationship>
     {
+        private readonly Lazy<int> hash;
+
         protected NotEqualsRelationship(SymbolicValue leftOperand, SymbolicValue rightOperand)
             : base(leftOperand, rightOperand)
         {
+            hash = new Lazy<int>(() =>
+            {
+                var left = LeftOperand.GetHashCode();
+                var right = RightOperand.GetHashCode();
+
+                return EqualsRelationship.GetHashCodeMinMaxOrdered(left, right, GetType().GetHashCode());
+            });
         }
 
         public sealed override bool Equals(object obj)
@@ -44,12 +53,6 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
             return other != null && AreOperandsMatching(other);
         }
 
-        public sealed override int GetHashCode()
-        {
-            var left = LeftOperand.GetHashCode();
-            var right = RightOperand.GetHashCode();
-
-            return EqualsRelationship.GetHashCodeMinMaxOrdered(left, right, GetType().GetHashCode());
-        }
+        public sealed override int GetHashCode() => hash.Value;
     }
 }


### PR DESCRIPTION
…mutable objects

The modified classes are immutable, hence the one-time calculation of GetHashCode is possible. The performance improvement in ITs is as follows (very rough measurement, on my machine with other apps and antivirus running):


Rule | Before | After | Diff | Percent
-- | -- | -- | -- | --
---- | ---- | ---- |   |  
EmptyNullableValueAccess | 43.982 | 40.807 | 3.175 | 7.218862262
InvalidCastToInterface | 39.882 | 35.454 | 4.428 | 11.10275312
EmptyCollectionsShouldNotBeEnumerated | 27.134 | 21.503 | 5.631 | 20.75256136
ObjectsShouldNotBeDisposedMoreThanOnce | 26.105 | 19.486 | 6.619 | 25.35529592
ConditionEvaluatesToConstant | 23.976 | 18.882 | 5.094 | 21.24624625
NullPointerDereference | 12.151 | 10.18 | 1.971 | 16.22088717
PublicMethodArgumentsShouldBeCheckedForNull | 7.698 | 7.171 | 0.527 | 6.845934009
  |   |   |   |  
Total: | 562.504 | 537.758 | 24.746 |  

