### PR TITLE
[DO NOT MERGE] fix captured variable handling

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy-{34576216-0DCA-4B0F-A0DC-9075E75A676F}-S3900.json
@@ -457,6 +457,19 @@
 },
 {
 "id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'requestedPath' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Conventions\StaticContentConventionBuilder.cs",
+"region":  {
+"startLine":  36,
+"startColumn":  18,
+"endLine":  36,
+"endColumn":  31
+}
+}
+},
+{
+"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'conventions' before using it.",
 "location":  {
 "uri":  "sources\Nancy\src\Nancy\Conventions\StaticContentsConventionsExtensions.cs",
@@ -1544,6 +1557,19 @@
 "startColumn":  39,
 "endLine":  22,
 "endColumn":  45
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'source' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Extensions\StreamExtensions.cs",
+"region":  {
+"startLine":  70,
+"startColumn":  13,
+"endLine":  70,
+"endColumn":  19
 }
 }
 },
@@ -2823,6 +2849,19 @@
 },
 {
 "id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'capturedParameters' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Routing\Trie\Nodes\GreedyRegExCaptureNode.cs",
+"region":  {
+"startLine":  59,
+"startColumn":  21,
+"endLine":  59,
+"endColumn":  39
+}
+}
+},
+{
+"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'segments' before using it.",
 "location":  {
 "uri":  "sources\Nancy\src\Nancy\Routing\Trie\Nodes\RootNode.cs",
@@ -3135,6 +3174,19 @@
 },
 {
 "id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'implementationTypes' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\TinyIoc\TinyIoC.cs",
+"region":  {
+"startLine":  1444,
+"startColumn":  34,
+"endLine":  1444,
+"endColumn":  53
+}
+}
+},
+{
+"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'registrationType' before using it.",
 "location":  {
 "uri":  "sources\Nancy\src\Nancy\TinyIoc\TinyIoC.cs",
@@ -3156,6 +3208,19 @@
 "startColumn":  145,
 "endLine":  1461,
 "endColumn":  161
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'implementationTypes' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\TinyIoc\TinyIoC.cs",
+"region":  {
+"startLine":  1467,
+"startColumn":  34,
+"endLine":  1467,
+"endColumn":  53
 }
 }
 },

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Embedded-{D8EBA39B-63AE-4A66-BD0E-F7F95E572135}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Embedded-{D8EBA39B-63AE-4A66-BD0E-F7F95E572135}-S3900.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'requestedPath' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Embedded\Conventions\EmbeddedStaticContentConventionBuilder.cs",
+"region":  {
+"startLine":  32,
+"startColumn":  18,
+"endLine":  32,
+"endColumn":  31
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing-{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Testing-{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}-S3900.json
@@ -279,6 +279,45 @@
 "location":  {
 "uri":  "sources\Nancy\src\Nancy.Testing\BrowserResponseExtensions.cs",
 "region":  {
+"startLine":  32,
+"startColumn":  129,
+"endLine":  32,
+"endColumn":  137
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'response' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\BrowserResponseExtensions.cs",
+"region":  {
+"startLine":  35,
+"startColumn":  18,
+"endLine":  35,
+"endColumn":  26
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'response' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\BrowserResponseExtensions.cs",
+"region":  {
+"startLine":  37,
+"startColumn":  114,
+"endLine":  37,
+"endColumn":  122
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'response' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Testing\BrowserResponseExtensions.cs",
+"region":  {
 "startLine":  45,
 "startColumn":  17,
 "endLine":  45,

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.DotLiquid-{B795886D-9D70-45B1-BFB5-AD54CBC9A447}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.DotLiquid-{B795886D-9D70-45B1-BFB5-AD54CBC9A447}-S3900.json
@@ -2,6 +2,71 @@
 "issues":  [
 {
 "id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'renderContext' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.DotLiquid\DotLiquidViewEngine.cs",
+"region":  {
+"startLine":  79,
+"startColumn":  26,
+"endLine":  79,
+"endColumn":  39
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'renderContext' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.DotLiquid\DotLiquidViewEngine.cs",
+"region":  {
+"startLine":  90,
+"startColumn":  47,
+"endLine":  90,
+"endColumn":  60
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'viewLocationResult' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.DotLiquid\DotLiquidViewEngine.cs",
+"region":  {
+"startLine":  104,
+"startColumn":  50,
+"endLine":  104,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'viewLocationResult' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.DotLiquid\DotLiquidViewEngine.cs",
+"region":  {
+"startLine":  104,
+"startColumn":  79,
+"endLine":  104,
+"endColumn":  97
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'viewLocationResult' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.DotLiquid\DotLiquidViewEngine.cs",
+"region":  {
+"startLine":  104,
+"startColumn":  104,
+"endLine":  104,
+"endColumn":  122
+}
+}
+},
+{
+"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'context' before using it.",
 "location":  {
 "uri":  "sources\Nancy\src\Nancy.ViewEngines.DotLiquid\LiquidNancyFileSystem.cs",

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.Razor-{2C6F51DF-015C-4DB6-B44C-0E5E4F25E2A9}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.Razor-{2C6F51DF-015C-4DB6-B44C-0E5E4F25E2A9}-S3900.json
@@ -90,6 +90,19 @@
 "endColumn":  19
 }
 }
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'model' before using it.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.Razor\RazorViewEngine.cs",
+"region":  {
+"startLine":  95,
+"startColumn":  44,
+"endLine":  95,
+"endColumn":  49
+}
+}
 }
 ]
 }

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S2589.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S2589.json
@@ -4,6 +4,19 @@
 "id":  "S2589",
 "message":  "Change this condition so that it does not always evaluate to 'true'.",
 "location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\MatchHandler\CachedMatchCompiler.cs",
+"region":  {
+"startLine":  38,
+"startColumn":  16,
+"endLine":  38,
+"endColumn":  41
+}
+}
+},
+{
+"id":  "S2589",
+"message":  "Change this condition so that it does not always evaluate to 'true'.",
+"location":  {
 "uri":  "sources\akka.net\src\core\Akka\Util\MonoConcurrentQueue.cs",
 "region":  {
 "startLine":  157,

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S3900.json
@@ -67,6 +67,19 @@
 },
 {
 "id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'watcher' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\ActorCell.DeathWatch.cs",
+"region":  {
+"startLine":  161,
+"startColumn":  31,
+"endLine":  161,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'watchee' before using it.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Actor\ActorCell.DeathWatch.cs",
@@ -74,6 +87,19 @@
 "startLine":  185,
 "startColumn":  31,
 "endLine":  185,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'watcher' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\ActorCell.DeathWatch.cs",
+"region":  {
+"startLine":  186,
+"startColumn":  31,
+"endLine":  186,
 "endColumn":  38
 }
 }
@@ -652,6 +678,19 @@
 },
 {
 "id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'target' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\GracefulStopSupport.cs",
+"region":  {
+"startLine":  62,
+"startColumn":  13,
+"endLine":  62,
+"endColumn":  19
+}
+}
+},
+{
+"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'system' before using it.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Actor\Inbox.cs",
@@ -673,6 +712,45 @@
 "startColumn":  13,
 "endLine":  286,
 "endColumn":  21
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'extension' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\Internal\ActorSystemImpl.cs",
+"region":  {
+"startLine":  180,
+"startColumn":  41,
+"endLine":  180,
+"endColumn":  50
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'extension' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\Internal\ActorSystemImpl.cs",
+"region":  {
+"startLine":  182,
+"startColumn":  36,
+"endLine":  182,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'extension' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\Internal\ActorSystemImpl.cs",
+"region":  {
+"startLine":  185,
+"startColumn":  20,
+"endLine":  185,
+"endColumn":  29
 }
 }
 },
@@ -777,6 +855,19 @@
 "startColumn":  25,
 "endLine":  251,
 "endColumn":  29
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'system' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\Scheduler\DedicatedThreadScheduler.cs",
+"region":  {
+"startLine":  28,
+"startColumn":  29,
+"endLine":  28,
+"endColumn":  35
 }
 }
 },
@@ -2017,6 +2108,19 @@
 },
 {
 "id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'node' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Routing\ConsistentHash.cs",
+"region":  {
+"startLine":  159,
+"startColumn":  51,
+"endLine":  159,
+"endColumn":  55
+}
+}
+},
+{
+"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'hash' before using it.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Routing\ConsistentHash.cs",
@@ -2025,6 +2129,19 @@
 "startColumn":  42,
 "endLine":  160,
 "endColumn":  46
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'node' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Routing\ConsistentHash.cs",
+"region":  {
+"startLine":  172,
+"startColumn":  51,
+"endLine":  172,
+"endColumn":  55
 }
 }
 },
@@ -2064,6 +2181,19 @@
 "startColumn":  49,
 "endLine":  154,
 "endColumn":  55
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'routees' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Routing\ConsistentHashRouter.cs",
+"region":  {
+"startLine":  165,
+"startColumn":  55,
+"endLine":  165,
+"endColumn":  62
 }
 }
 },
@@ -2610,6 +2740,71 @@
 "startColumn":  21,
 "endLine":  47,
 "endColumn":  23
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'task' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\TaskExtensions.cs",
+"region":  {
+"startLine":  17,
+"startColumn":  17,
+"endLine":  17,
+"endColumn":  21
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'task' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\TaskExtensions.cs",
+"region":  {
+"startLine":  18,
+"startColumn":  58,
+"endLine":  18,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'task' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\TaskExtensions.cs",
+"region":  {
+"startLine":  20,
+"startColumn":  17,
+"endLine":  20,
+"endColumn":  21
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'task' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\TaskExtensions.cs",
+"region":  {
+"startLine":  21,
+"startColumn":  34,
+"endLine":  21,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'task' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\TaskExtensions.cs",
+"region":  {
+"startLine":  23,
+"startColumn":  17,
+"endLine":  23,
+"endColumn":  21
 }
 }
 },

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster-{6AB00F61-269A-4501-B06A-026707F000A7}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster-{6AB00F61-269A-4501-B06A-026707F000A7}-S3900.json
@@ -2,6 +2,45 @@
 "issues":  [
 {
 "id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'system' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\Cluster.cs",
+"region":  {
+"startLine":  61,
+"startColumn":  45,
+"endLine":  61,
+"endColumn":  51
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'system' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\Cluster.cs",
+"region":  {
+"startLine":  68,
+"startColumn":  25,
+"endLine":  68,
+"endColumn":  31
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'system' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\Cluster.cs",
+"region":  {
+"startLine":  81,
+"startColumn":  31,
+"endLine":  81,
+"endColumn":  37
+}
+}
+},
+{
+"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'settings' before using it.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Cluster\ClusterActorRefProvider.cs",
@@ -101,6 +140,19 @@
 "startColumn":  29,
 "endLine":  571,
 "endColumn":  33
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'cluster' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\ClusterReadView.cs",
+"region":  {
+"startLine":  72,
+"startColumn":  28,
+"endLine":  72,
+"endColumn":  35
 }
 }
 },
@@ -244,6 +296,19 @@
 "startColumn":  66,
 "endLine":  273,
 "endColumn":  70
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'allowed' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\Reachability.cs",
+"region":  {
+"startLine":  233,
+"startColumn":  38,
+"endLine":  233,
+"endColumn":  45
 }
 }
 },

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster.Sharding-{A05C31E8-0246-46A1-B3BC-4D6FE7A9AA49}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Cluster.Sharding-{A05C31E8-0246-46A1-B3BC-4D6FE7A9AA49}-S3900.json
@@ -28,6 +28,19 @@
 },
 {
 "id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'messageExtractor' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.Cluster.Sharding\ClusterSharding.cs",
+"region":  {
+"startLine":  407,
+"startColumn":  64,
+"endLine":  407,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'system' before using it.",
 "location":  {
 "uri":  "sources\akka.net\src\contrib\cluster\Akka.Cluster.Sharding\ClusterShardingSettings.cs",
@@ -101,6 +114,19 @@
 "startColumn":  90,
 "endLine":  397,
 "endColumn":  97
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'rebalanceInProgress' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.Cluster.Sharding\ShardAllocationStrategy.cs",
+"region":  {
+"startLine":  82,
+"startColumn":  17,
+"endLine":  82,
+"endColumn":  36
 }
 }
 },

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Persistence-{FCA84DEA-C118-424B-9EB8-34375DFEF18A}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Persistence-{FCA84DEA-C118-424B-9EB8-34375DFEF18A}-S3900.json
@@ -43,6 +43,84 @@
 "id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'upcomingState' before using it.",
 "location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\Fsm\PersistentFSM.cs",
+"region":  {
+"startLine":  41,
+"startColumn":  17,
+"endLine":  41,
+"endColumn":  30
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'upcomingState' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\Fsm\PersistentFSM.cs",
+"region":  {
+"startLine":  43,
+"startColumn":  45,
+"endLine":  43,
+"endColumn":  58
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'upcomingState' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\Fsm\PersistentFSM.cs",
+"region":  {
+"startLine":  48,
+"startColumn":  35,
+"endLine":  48,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'upcomingState' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\Fsm\PersistentFSM.cs",
+"region":  {
+"startLine":  48,
+"startColumn":  63,
+"endLine":  48,
+"endColumn":  76
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'upcomingState' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\Fsm\PersistentFSM.cs",
+"region":  {
+"startLine":  50,
+"startColumn":  58,
+"endLine":  50,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'upcomingState' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\Fsm\PersistentFSM.cs",
+"region":  {
+"startLine":  50,
+"startColumn":  83,
+"endLine":  50,
+"endColumn":  96
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'upcomingState' before using it.",
+"location":  {
 "uri":  "sources\akka.net\src\core\Akka.Persistence\Fsm\PersistentFSMBase.cs",
 "region":  {
 "startLine":  418,

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote-{EA4FF8FD-7C53-49C8-B9AA-02E458B3E6A7}-S3900.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote-{EA4FF8FD-7C53-49C8-B9AA-02E458B3E6A7}-S3900.json
@@ -288,6 +288,45 @@
 },
 {
 "id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'watchee' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\RemoteWatcher.cs",
+"region":  {
+"startLine":  432,
+"startColumn":  70,
+"endLine":  432,
+"endColumn":  77
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'watchee' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\RemoteWatcher.cs",
+"region":  {
+"startLine":  438,
+"startColumn":  63,
+"endLine":  438,
+"endColumn":  70
+}
+}
+},
+{
+"id":  "S3900",
+"message":  "Refactor this method to add validation of parameter 'watchee' before using it.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\RemoteWatcher.cs",
+"region":  {
+"startLine":  442,
+"startColumn":  40,
+"endLine":  442,
+"endColumn":  47
+}
+}
+},
+{
+"id":  "S3900",
 "message":  "Refactor this method to add validation of parameter 'routeeProps' before using it.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\Routing\RemoteRouterConfig.cs",

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
@@ -431,7 +431,12 @@ namespace SonarAnalyzer.SymbolicExecution
                         var invocationVisitor = new InvocationVisitor(invocation, SemanticModel, newProgramState);
                         newProgramState = invocationVisitor.ProcessInvocation();
 
-                        if (invocation.Expression.IsOnThis() && !invocation.IsNameof(SemanticModel))
+                        var invocationSymbol = SemanticModel.GetSymbolInfo(invocation.Expression).Symbol;
+
+                        var isLocal = IsLocalScoped(invocationSymbol);
+
+                        if ((invocation.Expression.IsOnThis() && !invocation.IsNameof(SemanticModel)) || isLocal
+                            )
                         {
                             newProgramState = newProgramState.RemoveSymbols(IsFieldSymbol);
                         }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/LiveVariableAnalysis/CSharpLiveVariableAnalysis.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/LiveVariableAnalysis/CSharpLiveVariableAnalysis.cs
@@ -209,7 +209,7 @@ namespace SonarAnalyzer.SymbolicExecution.LiveVariableAnalysis
                 argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword);
         }
 
-        private bool IsLocalScoped(ISymbol symbol)
+        public override bool IsLocalScoped(ISymbol symbol)
         {
             return IsLocalScoped(symbol, declaration);
         }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/AbstractExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/AbstractExplodedGraph.cs
@@ -284,8 +284,7 @@ namespace SonarAnalyzer.SymbolicExecution
 
         internal bool IsSymbolTracked(ISymbol symbol)
         {
-            if (symbol == null ||
-                lva.CapturedVariables.Contains(symbol)) // Captured variables are not locally scoped, they are compiled to class fields
+            if (symbol == null)
             {
                 return false;
             }
@@ -314,7 +313,8 @@ namespace SonarAnalyzer.SymbolicExecution
         {
             var field = symbol as IFieldSymbol;
 
-            return field != null &&
+            return IsCaptured(symbol) || // Captured variables are not locally scoped, they are compiled to class fields
+                field != null &&
                 (field.IsConst ||
                 declaration.ContainingType
                     .GetSelfAndBaseTypes()
@@ -443,5 +443,11 @@ namespace SonarAnalyzer.SymbolicExecution
                 type.IsValueType &&
                 !type.OriginalDefinition.Is(KnownType.System_Nullable_T);
         }
+
+        protected bool IsLocalScoped(ISymbol symbol) =>
+            lva.IsLocalScoped(symbol);
+
+        protected bool IsCaptured(ISymbol symbol) =>
+            lva.IsCaptured(symbol);
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/LiveVariableAnalysis/AbstractLiveVariableAnalysis.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SymbolicExecution/LiveVariableAnalysis/AbstractLiveVariableAnalysis.cs
@@ -58,6 +58,11 @@ namespace SonarAnalyzer.SymbolicExecution.LiveVariableAnalysis
 
         public IReadOnlyList<ISymbol> CapturedVariables => capturedVariables.ToImmutableArray();
 
+        public bool IsCaptured(ISymbol symbol) =>
+            capturedVariables.Contains(symbol);
+
+        public abstract bool IsLocalScoped(ISymbol symbol);
+
         protected void PerformAnalysis()
         {
             foreach (var block in reversedBlocks)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConditionEvaluatesToConstantTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConditionEvaluatesToConstantTest.cs
@@ -30,6 +30,28 @@ namespace SonarAnalyzer.UnitTest.Rules
     {
         [TestMethod]
         [TestCategory("Rule")]
+        public void ConditionEvaluatesToConstant_Temp()
+        {
+            Verifier.VerifyCSharpAnalyzer(@"
+using System;
+public class C
+{
+    public void Lambda()
+    {
+        var fail = false;
+        Action a = new Action(() => { fail = true; });
+        a();
+        if (fail) // This is compliant, we don't know anything about 'fail'
+        {
+        }
+    }
+}
+
+", new ConditionEvaluatesToConstant(),
+                new CSharpParseOptions(LanguageVersion.CSharp6));
+        }
+        [TestMethod]
+        [TestCategory("Rule")]
         public void ConditionEvaluatesToConstant()
         {
             Verifier.VerifyAnalyzer(@"TestCases\ConditionEvaluatesToConstant.cs", new ConditionEvaluatesToConstant(),

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NullPointerDereferenceTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NullPointerDereferenceTest.cs
@@ -19,15 +19,81 @@
  */
 
 extern alias csharp;
+using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using csharp::SonarAnalyzer.Rules.CSharp;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
+    using System.Linq;
+    using System.Collections.Generic;
+    public class D
+    {
+        public IList<string> Strings { get; set; }
+    }
+
+    public class C
+    {
+        public object Original(D d)
+        {
+            var a = d?.Strings;
+            if (a != null)
+            {
+                return d.Strings.Select(s => a[0]);
+            }
+            return null;
+        }
+        public object EquivalentToOriginal(D d)
+        {
+            IList<string> a;
+            if (d == null)
+            {
+                a = null;
+            }
+            else
+            {
+                a = d.Strings;
+            }
+            // since "a" is captured we don't store SV-Symbol relation and we don't "know" that
+            // when "a != null" "d" is always not null.
+            if (a != null)
+            {
+                return d.Strings.Select(s => a[0]);
+            }
+            return null;
+        }
+    }
+
     [TestClass]
     public class NullPointerDereferenceTest
     {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void NullPointerDereference_Temp()
+        {
+            Verifier.VerifyCSharpAnalyzer(@"
+    using System.Linq;
+    using System.Collections.Generic;
+    public class D
+    {
+        public IList<string> Strings { get; set; }
+    }
+
+    public class C
+    {
+        public object Original(D d)
+        {
+            var a = d?.Strings;
+            if (a != null)
+            {
+                return d.Strings.Select(s => a[0]);
+            }
+            return null;
+        }
+    }
+", new NullPointerDereference());
+        }
+
         [TestMethod]
         [TestCategory("Rule")]
         public void NullPointerDereference()


### PR DESCRIPTION
Fix #1301 

We count the captured variables as fields in some places, in other - we don't. This change is trying to unify the handling of captured variables and fields.

The assumption is not very true however, as the captured variables are not compiled as fields in the current class, but fields in a new class and this should be taken into account.

The current implementation raises some false positives that need to be fixed before merging to master.

See the unit tests for a simplified case that resembles the bug report snippet.

TODO: We need to distinguish between captured variables and fields when clearing constraints because field constraints are cleared only on local calls (e.g. this.Foo() will clear constraints on all fields) but captured variables' constraints should be cleared when a lambda is called. Different types of lambda invocation should be covered, including x.Invoke(), x(), list.Select(x), etc.