### PR TITLE
Rule S2245: Pseudorandom number generators (PRNGs) should not be used…

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S2245.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka-{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}-S2245.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S2245",
+"message":  "Use a cryptographically strong random number generator (RNG) like 'System.Security.Cryptography.RandomNumberGenerator'.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\ArrayExtensions.cs",
+"region":  {
+"startLine":  47,
+"startColumn":  26,
+"endLine":  47,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S2245",
+"message":  "Use a cryptographically strong random number generator (RNG) like 'System.Security.Cryptography.RandomNumberGenerator'.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\ThreadLocalRandom.cs",
+"region":  {
+"startLine":  22,
+"startColumn":  81,
+"endLine":  22,
+"endColumn":  125
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/ClusterSharding.Node-{30A0B17D-B913-49AB-8CBB-8DF383AB7A52}-S2245.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/ClusterSharding.Node-{30A0B17D-B913-49AB-8CBB-8DF383AB7A52}-S2245.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2245",
+"message":  "Use a cryptographically strong random number generator (RNG) like 'System.Security.Cryptography.RandomNumberGenerator'.",
+"location":  {
+"uri":  "sources\akka.net\src\examples\Cluster\ClusterSharding\ClusterSharding.Node\Program.cs",
+"region":  {
+"startLine":  57,
+"startColumn":  24,
+"endLine":  57,
+"endColumn":  36
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/ClusterToolsExample.Shared-{88D7D845-2F50-4D37-9026-B0A8353D0E8D}-S2245.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/ClusterToolsExample.Shared-{88D7D845-2F50-4D37-9026-B0A8353D0E8D}-S2245.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2245",
+"message":  "Use a cryptographically strong random number generator (RNG) like 'System.Security.Cryptography.RandomNumberGenerator'.",
+"location":  {
+"uri":  "sources\akka.net\src\examples\Cluster\ClusterTools\ClusterToolsExample.Shared\WorkerManager.cs",
+"region":  {
+"startLine":  11,
+"startColumn":  42,
+"endLine":  11,
+"endColumn":  54
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/rspec/cs/S2245_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S2245_c#.html
@@ -1,0 +1,38 @@
+<p>When software generates predictable values in a context requiring unpredictability, it may be possible for an attacker to guess the next value that
+will be generated, and use this guess to impersonate another user or access sensitive information.</p>
+<p>As the <code>System.Random</code> class relies on a pseudorandom number generator, it should not be used for security-critical applications or for
+protecting sensitive data. In such context, the <code>System.Cryptography.RandomNumberGenerator</code> class which relies on a cryptographically
+strong random number generator (RNG) should be used in place.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+var random = new Random(); // Noncompliant
+byte[] data = new byte[16];
+random.NextBytes(data);
+return BitConverter.ToString(data);
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System.Security.Cryptography;
+...
+var randomGenerator = RandomNumberGenerator.Create(); // Compliant
+byte[] data = new byte[16];
+randomGenerator.GetBytes(data);
+return BitConverter.ToString(data);
+</pre>
+<h2>See</h2>
+<ul>
+  <li> <a href="http://cwe.mitre.org/data/definitions/338.html">MITRE, CWE-338</a> - Use of Cryptographically Weak Pseudo-Random Number Generator
+  (PRNG) </li>
+  <li> <a href="http://cwe.mitre.org/data/definitions/330.html">MITRE, CWE-330</a> - Use of Insufficiently Random Values </li>
+  <li> <a href="http://cwe.mitre.org/data/definitions/326.html">MITRE, CWE-326</a> - Inadequate Encryption Strength </li>
+  <li> <a href="http://cwe.mitre.org/data/definitions/310">MITRE, CWE-310</a> - Cryptographic Issues </li>
+  <li> <a href="https://www.securecoding.cert.org/confluence/x/mAFqAQ">CERT, MSC02-J.</a> - Generate strong random numbers </li>
+  <li> <a href="https://www.securecoding.cert.org/confluence/x/qw4">CERT, MSC30-C.</a> - Do not use the rand() function for generating pseudorandom
+  numbers </li>
+  <li> <a href="https://www.securecoding.cert.org/confluence/x/WYIyAQ">CERT, MSC50-CPP.</a> - Do not use std::rand() for generating pseudorandom
+  numbers </li>
+  <li> OWASP Top 10 2017 Category A3 - Sensitive Data Exposure </li>
+  <li> Derived from FindSecBugs rule <a href="http://h3xstream.github.io/find-sec-bugs/bugs.htm#PREDICTABLE_RANDOM">Predictable Pseudo Random Number
+  Generator</a> </li>
+</ul>
+

--- a/sonaranalyzer-dotnet/rspec/cs/S2245_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S2245_c#.json
@@ -1,0 +1,22 @@
+{
+  "title": "Pseudorandom number generators (PRNGs) should not be used in secure contexts",
+  "type": "VULNERABILITY",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "10min"
+  },
+  "tags": [
+    "cwe",
+    "cert",
+    "owasp-a3"
+  ],
+  "standards": [
+    "CWE",
+    "OWASP Top Ten"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-2245",
+  "sqKey": "S2245",
+  "scope": "Main"
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -3225,6 +3225,36 @@
   <data name="S2234_Type" xml:space="preserve">
     <value>CODE_SMELL</value>
   </data>
+  <data name="S2245_Category" xml:space="preserve">
+    <value>Critical Vulnerability</value>
+  </data>
+  <data name="S2245_Description" xml:space="preserve">
+    <value>When software generates predictable values in a context requiring unpredictability, it may be possible for an attacker to guess the next value that will be generated, and use this guess to impersonate another user or access sensitive information.</value>
+  </data>
+  <data name="S2245_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S2245_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S2245_RemediationCost" xml:space="preserve">
+    <value>10min</value>
+  </data>
+  <data name="S2245_Scope" xml:space="preserve">
+    <value>Main</value>
+  </data>
+  <data name="S2245_Severity" xml:space="preserve">
+    <value>Critical</value>
+  </data>
+  <data name="S2245_Tags" xml:space="preserve">
+    <value>cwe,cert,owasp-a3</value>
+  </data>
+  <data name="S2245_Title" xml:space="preserve">
+    <value>Pseudorandom number generators (PRNGs) should not be used in secure contexts</value>
+  </data>
+  <data name="S2245_Type" xml:space="preserve">
+    <value>VULNERABILITY</value>
+  </data>
   <data name="S2259_Category" xml:space="preserve">
     <value>Major Bug</value>
   </data>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/DoNotUseRandom.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/DoNotUseRandom.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(DiagnosticId)]
+    public sealed class DoNotUseRandom : SonarDiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "S2245";
+        private const string MessageFormat = "Use a cryptographically strong random number generator (RNG) like " +
+            "'System.Security.Cryptography.RandomNumberGenerator'.";
+
+        private static readonly DiagnosticDescriptor rule =
+            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionInNonGenerated(
+                c =>
+                {
+                    var objectCreationSyntax = (ObjectCreationExpressionSyntax)c.Node;
+
+                    var argumentsCount = objectCreationSyntax.ArgumentList?.Arguments.Count;
+
+                    if (argumentsCount <= 1 && // Random has two ctors - with zero and one parameter
+                        c.SemanticModel.GetSymbolInfo(objectCreationSyntax).Symbol is IMethodSymbol methodSymbol &&
+                        methodSymbol.ContainingType.Is(KnownType.System_Random))
+                    {
+                        c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, objectCreationSyntax.GetLocation()));
+                    }
+                },
+                SyntaxKind.ObjectCreationExpression);
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -181,6 +181,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_Object = new KnownType(SpecialType.System_Object, "object");
         internal static readonly KnownType System_ObsoleteAttribute = new KnownType("System.ObsoleteAttribute");
         internal static readonly KnownType System_OutOfMemoryException = new KnownType("System.OutOfMemoryException");
+        internal static readonly KnownType System_Random = new KnownType("System.Random");
         internal static readonly KnownType System_Reflection_Assembly = new KnownType("System.Reflection.Assembly");
         internal static readonly KnownType System_Reflection_AssemblyVersionAttribute = new KnownType("System.Reflection.AssemblyVersionAttribute");
         internal static readonly KnownType System_Reflection_MemberInfo = new KnownType("System.Reflection.MemberInfo");

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S2245.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S2245.html
@@ -1,0 +1,38 @@
+<p>When software generates predictable values in a context requiring unpredictability, it may be possible for an attacker to guess the next value that
+will be generated, and use this guess to impersonate another user or access sensitive information.</p>
+<p>As the <code>System.Random</code> class relies on a pseudorandom number generator, it should not be used for security-critical applications or for
+protecting sensitive data. In such context, the <code>System.Cryptography.RandomNumberGenerator</code> class which relies on a cryptographically
+strong random number generator (RNG) should be used in place.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+var random = new Random(); // Noncompliant
+byte[] data = new byte[16];
+random.NextBytes(data);
+return BitConverter.ToString(data);
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+using System.Security.Cryptography;
+...
+var randomGenerator = RandomNumberGenerator.Create(); // Compliant
+byte[] data = new byte[16];
+randomGenerator.GetBytes(data);
+return BitConverter.ToString(data);
+</pre>
+<h2>See</h2>
+<ul>
+  <li> <a href="http://cwe.mitre.org/data/definitions/338.html">MITRE, CWE-338</a> - Use of Cryptographically Weak Pseudo-Random Number Generator
+  (PRNG) </li>
+  <li> <a href="http://cwe.mitre.org/data/definitions/330.html">MITRE, CWE-330</a> - Use of Insufficiently Random Values </li>
+  <li> <a href="http://cwe.mitre.org/data/definitions/326.html">MITRE, CWE-326</a> - Inadequate Encryption Strength </li>
+  <li> <a href="http://cwe.mitre.org/data/definitions/310">MITRE, CWE-310</a> - Cryptographic Issues </li>
+  <li> <a href="https://www.securecoding.cert.org/confluence/x/mAFqAQ">CERT, MSC02-J.</a> - Generate strong random numbers </li>
+  <li> <a href="https://www.securecoding.cert.org/confluence/x/qw4">CERT, MSC30-C.</a> - Do not use the rand() function for generating pseudorandom
+  numbers </li>
+  <li> <a href="https://www.securecoding.cert.org/confluence/x/WYIyAQ">CERT, MSC50-CPP.</a> - Do not use std::rand() for generating pseudorandom
+  numbers </li>
+  <li> OWASP Top 10 2017 Category A3 - Sensitive Data Exposure </li>
+  <li> Derived from FindSecBugs rule <a href="http://h3xstream.github.io/find-sec-bugs/bugs.htm#PREDICTABLE_RANDOM">Predictable Pseudo Random Number
+  Generator</a> </li>
+</ul>
+

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/PackagingTests/CsRuleTypeMapping.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/PackagingTests/CsRuleTypeMapping.cs
@@ -2242,7 +2242,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
             //["2242"],
             //["2243"],
             //["2244"],
-            //["2245"],
+            ["2245"] = "VULNERABILITY",
             //["2246"],
             //["2247"],
             //["2248"],

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseRandomTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseRandomTest.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+extern alias csharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using csharp::SonarAnalyzer.Rules.CSharp;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class DoNotUseRandomTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void DoNotUseRandom()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\DoNotUseRandom.cs",
+                new DoNotUseRandom());
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/DoNotUseRandom.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/DoNotUseRandom.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Security.Cryptography;
+
+namespace Tests.Diagnostics
+{
+    class Program
+    {
+        public void Main()
+        {
+            var random1 = new Random(); // Noncompliant {{Use a cryptographically strong random number generator (RNG) like 'System.Security.Cryptography.RandomNumberGenerator'.}}
+//                        ^^^^^^^^^^^^
+            var random2 = new Random(1); // Noncompliant
+
+            var somethingElse = new EventArgs(); // Compliant, not Random
+
+            var secureRandom = RandomNumberGenerator.Create(); // This is how it should be done
+        }
+    }
+}


### PR DESCRIPTION
… in secure contexts

Fix #1294