### PR TITLE
Remove deprecated TEST_SUCCESS_DENSITY

### DIFF
--- a/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
+++ b/sonar-dotnet-tests-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
@@ -98,14 +98,6 @@ public class UnitTestResultsImportSensor implements Sensor {
         .withValue(executionTime)
         .save();
     }
-
-    if (aggregatedResults.tests() > 0) {
-      context.<Double>newMeasure()
-        .forMetric(CoreMetrics.TEST_SUCCESS_DENSITY)
-        .on(context.module())
-        .withValue(aggregatedResults.passedPercentage())
-        .save();
-    }
   }
 
 }

--- a/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensorTest.java
+++ b/sonar-dotnet-tests-library/src/test/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensorTest.java
@@ -86,7 +86,6 @@ public class UnitTestResultsImportSensorTest {
       .extracting("metric.key", "value")
       .containsOnly(
         tuple(CoreMetrics.TESTS_KEY, 42),
-        tuple(CoreMetrics.TEST_SUCCESS_DENSITY_KEY, 84d),
         tuple(CoreMetrics.SKIPPED_TESTS_KEY, 1),
         tuple(CoreMetrics.TEST_FAILURES_KEY, 2),
         tuple(CoreMetrics.TEST_ERRORS_KEY, 3),


### PR DESCRIPTION
This is a "finding" we made with Julien when trying to understand what was wrong with reporting metrics at module level when no files are analyzed (triggered more often when analyzing PRs).