### PR TITLE
Fix a NRE with parameter validation in async methods

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInMethodShouldBeWrapped.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInMethodShouldBeWrapped.cs
@@ -62,7 +62,8 @@ namespace SonarAnalyzer.Rules.CSharp
                         .Select(identifierSyntax =>
                             c.SemanticModel.GetSymbolInfo(identifierSyntax).Symbol.ToSymbolWithSyntax(identifierSyntax))
                         .Where(tuple =>
-                            (tuple.Symbol.OriginalDefinition as ITypeSymbol).DerivesFrom(KnownType.System_ArgumentException))
+                            tuple.Symbol?.OriginalDefinition is ITypeSymbol typeSymbol &&
+                            typeSymbol.DerivesFrom(KnownType.System_ArgumentException))
                         .Select(tuple => tuple.Syntax.Identifier.GetLocation())
                         .ToList();
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ParameterValidationInAsyncShouldBeWrapped.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ParameterValidationInAsyncShouldBeWrapped.cs
@@ -57,6 +57,16 @@ namespace Tests.Diagnostics
                 }
             }
         }
+
+        public Task DoAsync(object o)
+        {
+            if (o == null)
+            {
+                throw new UnknownException(nameof(o));
+            }
+
+            await UnresolvedAsync();
+        }
     }
 
     public class ValidCases


### PR DESCRIPTION
Fix #1389 