### PR TITLE
Fix S4586: False positive when returning null from inside Task.Run

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NonAsyncTaskShouldNotReturnNull.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NonAsyncTaskShouldNotReturnNull.cs
@@ -20,7 +20,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -42,26 +41,33 @@ namespace SonarAnalyzer.Rules.CSharp
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
-        private static ISet<KnownType> TaskTypes =
+        private static readonly ISet<KnownType> TaskTypes =
             new HashSet<KnownType>
             {
                 KnownType.System_Threading_Tasks_Task,
                 KnownType.System_Threading_Tasks_Task_T
             };
 
-        private static ISet<SyntaxKind> TrackedNullLiteralLocations =
+        private static readonly ISet<SyntaxKind> TrackedNullLiteralLocations =
             new HashSet<SyntaxKind>
             {
                 SyntaxKind.ArrowExpressionClause,
                 SyntaxKind.ReturnStatement,
             };
 
-        private static ISet<SyntaxKind> PossibleEnclosingSyntax =
+        private static readonly ISet<SyntaxKind> PossibleEnclosingSyntax =
             new HashSet<SyntaxKind>
             {
                 SyntaxKind.VariableDeclaration,
                 SyntaxKind.PropertyDeclaration,
                 SyntaxKind.MethodDeclaration
+            };
+
+        private static readonly ISet<SyntaxKind> IgnoredEnclosingSyntax =
+            new HashSet<SyntaxKind>
+            {
+                SyntaxKind.ParenthesizedLambdaExpression,
+                SyntaxKind.SimpleLambdaExpression
             };
 
         protected override void Initialize(SonarAnalysisContext context)
@@ -76,7 +82,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    var enclosingMember = nullLiteral.Ancestors().FirstOrDefault(n => n.IsAnyKind(PossibleEnclosingSyntax));
+                    var enclosingMember = GetEnclosingMember(nullLiteral);
                     if (enclosingMember == null ||
                         enclosingMember.IsKind(SyntaxKind.VariableDeclaration))
                     {
@@ -95,6 +101,27 @@ namespace SonarAnalyzer.Rules.CSharp
                     c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, nullLiteral.GetLocation()));
                 },
                 SyntaxKind.NullLiteralExpression);
+        }
+
+        private static SyntaxNode GetEnclosingMember(LiteralExpressionSyntax literal)
+        {
+            foreach (var ancestor in literal.Ancestors())
+            {
+                if (ancestor.IsAnyKind(IgnoredEnclosingSyntax))
+                {
+                    return null;
+                }
+                else if (ancestor.IsAnyKind(PossibleEnclosingSyntax))
+                {
+                    return ancestor;
+                }
+                else
+                {
+                    // do nothing
+                }
+            }
+
+            return null;
         }
 
         private static bool IsTaskReturnType(ISymbol symbol) =>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NonAsyncTaskShouldNotReturnNull.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NonAsyncTaskShouldNotReturnNull.cs
@@ -63,13 +63,6 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.MethodDeclaration
             };
 
-        private static readonly ISet<SyntaxKind> IgnoredEnclosingSyntax =
-            new HashSet<SyntaxKind>
-            {
-                SyntaxKind.ParenthesizedLambdaExpression,
-                SyntaxKind.SimpleLambdaExpression
-            };
-
         protected override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
@@ -107,7 +100,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             foreach (var ancestor in literal.Ancestors())
             {
-                if (ancestor.IsAnyKind(IgnoredEnclosingSyntax))
+                if (ancestor.IsKind(SyntaxKind.ParenthesizedLambdaExpression))
                 {
                     return null;
                 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NonAsyncTaskShouldNotReturnNull.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NonAsyncTaskShouldNotReturnNull.cs
@@ -28,6 +28,21 @@ namespace Tests.Diagnostics
         }
 
         public Task Foo { get; set; }
+
+        public Task<object> GetFooAsync()
+        {
+            return Task.Run(() =>
+            {
+                if (false)
+                {
+                    return new object();
+                }
+                else
+                {
+                    return null;
+                }
+            });
+        }
     }
 
     public class NonCompliantUseCases

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NonAsyncTaskShouldNotReturnNull.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NonAsyncTaskShouldNotReturnNull.cs
@@ -43,6 +43,13 @@ namespace Tests.Diagnostics
                 }
             });
         }
+
+        public Task GetBar()
+        {
+            Func<Task> func = () => null;
+
+            return func(); // False negative
+        }
     }
 
     public class NonCompliantUseCases


### PR DESCRIPTION
Fix #1436 

I decided to ignore all return null from within a lambda but we could have looked for some specific invocations instead. This choice is motivated by having a fast fix which would only result in some FN but should cover more FPs.