### PR TITLE
Upgrade Orchestrator to 3.19

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.18.0.1547</version>
+      <version>3.19.0.1641</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.scanner.msbuild</groupId>

--- a/its/src/test/java/com/sonar/it/csharp/UCFGDeserializationTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/UCFGDeserializationTest.java
@@ -23,6 +23,7 @@ import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.OrchestratorBuilder;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.ScannerForMSBuild;
+import com.sonar.orchestrator.container.Edition;
 import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.locator.Location;
 import com.sonar.orchestrator.locator.MavenLocation;
@@ -73,9 +74,9 @@ public class UCFGDeserializationTest {
       csharpLocation = MavenLocation.of("org.sonarsource.dotnet", "sonar-csharp-plugin", csharpVersion);
     }
     builder
+      .setEdition(Edition.DEVELOPER)
       .addPlugin(csharpLocation)
-      .addPlugin(MavenLocation.of("com.sonarsource.security", "sonar-security-plugin", "1.0.0.847"))
-      .addPlugin(MavenLocation.of("com.sonarsource.license", "sonar-dev-license-plugin", "3.3.0.1341"));
+      .addPlugin(MavenLocation.of("com.sonarsource.security", "sonar-security-plugin", "1.0.0.847"));
 
     orchestrator = builder.build();
     orchestrator.start();


### PR DESCRIPTION
Fix compatibility of integration tests with SQ 7.2

(same changes as https://github.com/SonarSource/sonar-csharp/pull/1471, but rebased)