### PR TITLE
Rule S2259: False positive on 'try/catch' with exception filter

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
@@ -143,6 +143,10 @@ namespace SonarAnalyzer.SymbolicExecution
                     VisitBinaryBranch(binaryBranchBlock, node, ((ConditionalExpressionSyntax)binaryBranchBlock.BranchingNode).Condition);
                     return;
 
+                case SyntaxKind.CatchFilterClause:
+                    VisitBinaryBranch(binaryBranchBlock, node, ((CatchFilterClauseSyntax)binaryBranchBlock.BranchingNode).FilterExpression);
+                    return;
+
                 default:
                     System.Diagnostics.Debug.Fail($"Branch kind '{binaryBranchBlock.BranchingNode.Kind()}' not handled");
                     VisitBinaryBranch(binaryBranchBlock, node, null);

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
@@ -475,7 +475,16 @@ namespace SonarAnalyzer.SymbolicExecution.ControlFlowGraph
 
             var catchBlocks = tryStatement.Catches
                 .Reverse()
-                .Select(catchClause => BuildBlock(catchClause.Block, CreateBlock(catchSuccessor)))
+                .Select(catchClause =>
+                {
+                    Block catchBlock = BuildBlock(catchClause.Block, CreateBlock(catchSuccessor));
+                    if (catchClause.Filter?.FilterExpression != null)
+                    {
+                        catchBlock = BuildExpression(catchClause.Filter.FilterExpression,
+                            CreateBinaryBranchBlock(catchClause.Filter, catchBlock, catchSuccessor));
+                    }
+                    return catchBlock;
+                })
                 .ToList();
 
             // If there is a catch with no Exception filter or equivalent we don't want to

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
@@ -625,19 +625,4 @@ namespace Tests.Diagnostics
         [AttributeUsage(AttributeTargets.Parameter)]
         public sealed class ValidatedNotNullAttribute : Attribute { }
     }
-
-    public class ExceptionFilters // https://github.com/SonarSource/sonar-csharp/issues/1324
-    {
-        public void Run(object o)
-        {
-            try
-            {
-                Console.WriteLine(o?.ToString());
-            }
-            catch (Exception) when (o != null)
-            {
-                Console.WriteLine(o.ToString());
-            }
-        }
-    }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
@@ -625,4 +625,19 @@ namespace Tests.Diagnostics
         [AttributeUsage(AttributeTargets.Parameter)]
         public sealed class ValidatedNotNullAttribute : Attribute { }
     }
+
+    public class ExceptionFilters // https://github.com/SonarSource/sonar-csharp/issues/1324
+    {
+        public void Run(object o)
+        {
+            try
+            {
+                Console.WriteLine(o?.ToString());
+            }
+            catch (Exception) when (o != null)
+            {
+                Console.WriteLine(o.ToString());
+            }
+        }
+    }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereferenceCSharp6.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereferenceCSharp6.cs
@@ -35,9 +35,13 @@ namespace Tests.Diagnostics
             {
                 var a = o?.ToString();
             }
-            catch (Exception) when (o != null)
+            catch (InvalidOperationException) when (o != null)
             {
                 var b = o.ToString(); // Compliant, o is checked for null in this branch
+            }
+            catch (ApplicationException) when (o == null)
+            {
+                var b = o.ToString(); // Noncompliant
             }
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereferenceCSharp6.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereferenceCSharp6.cs
@@ -25,7 +25,7 @@ namespace Tests.Diagnostics
             {
                 o = new object();
             }
-            return o.ToString();
+            return o.ToString(); // Noncompliant, when e.Message is null o will be null
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereferenceCSharp6.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereferenceCSharp6.cs
@@ -27,5 +27,30 @@ namespace Tests.Diagnostics
             }
             return o.ToString(); // Noncompliant, when e.Message is null o will be null
         }
+
+        // https://github.com/SonarSource/sonar-csharp/issues/1324
+        public void FlasePositive(object o)
+        {
+            try
+            {
+                var a = o?.ToString();
+            }
+            catch (Exception) when (o != null)
+            {
+                var b = o.ToString(); // Compliant, o is checked for null in this branch
+            }
+        }
+
+        public void TryCatch4(object o)
+        {
+            try
+            {
+                var a = o?.ToString();
+            }
+            catch (Exception e) when (e.Message != null)
+            {
+                var b = o.ToString(); // Noncompliant, o could be null here
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #1324 

We were not adding the exception filters to the CFG, hence the code was evaluated as unconditional and some false positives were generated. I added `BinaryBranchBlock` to the CFG for each exception filter, connecting the catch block and the finally/after-try block. I had to add support for `CatchFilterSyntax` in the `CSharpExplodedGraph` too.