### PR TITLE
Adding conditional UCFG to DOT serialization

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/BlockIdMap.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/BlockIdMap.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using SonarAnalyzer.SymbolicExecution.ControlFlowGraph;
+
+namespace SonarAnalyzer.Helpers
+{
+    public  class BlockIdMap
+    {
+        private readonly Dictionary<Block, string> map = new Dictionary<Block, string>();
+        private int counter;
+
+        public string Get(Block cfgBlock) =>
+            map.GetOrAdd(cfgBlock, b => $"{counter++}");
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CfgSerializer.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CfgSerializer.cs
@@ -1,0 +1,147 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.SymbolicExecution.ControlFlowGraph;
+
+namespace SonarAnalyzer.Helpers
+{
+    internal static class CfgSerializer
+    {
+        public static string Serialize(string methodName, IControlFlowGraph cfg)
+        {
+            var stringBuilder = new StringBuilder();
+            using (var writer = new StringWriter(stringBuilder))
+            {
+                Serialize(methodName, cfg, writer);
+            }
+            return stringBuilder.ToString();
+        }
+
+        public static void Serialize(string methodName, IControlFlowGraph cfg, TextWriter writer)
+        {
+            new CfgWalker(new DotWriter(writer)).Visit(methodName, cfg);
+        }
+
+        private class CfgWalker
+        {
+            private readonly BlockIdMap blockId = new BlockIdMap();
+            private readonly DotWriter writer;
+
+            public CfgWalker(DotWriter writer)
+            {
+                this.writer = writer;
+            }
+
+            public void Visit(string methodName, IControlFlowGraph cfg)
+            {
+                writer.WriteGraphStart(methodName);
+
+                foreach (var block in cfg.Blocks)
+                {
+                    Visit(block);
+                }
+
+                writer.WriteGraphEnd();
+            }
+
+            private void Visit(Block block)
+            {
+                Func<Block, string> getLabel = b => string.Empty;
+
+                if (block is BinaryBranchBlock binaryBranchBlock)
+                {
+                    WriteNode(block, binaryBranchBlock.BranchingNode);
+                    // Add labels to the binary branch block successors
+                    getLabel = b =>
+                    {
+                        if (b == binaryBranchBlock.TrueSuccessorBlock)
+                        {
+                            return bool.TrueString;
+                        }
+                        else if (b == binaryBranchBlock.FalseSuccessorBlock)
+                        {
+                            return bool.FalseString;
+                        }
+                        return string.Empty;
+                    };
+                }
+                else if (block is BranchBlock branchBlock)
+                {
+                    WriteNode(block, branchBlock.BranchingNode);
+                }
+                else if (block is ExitBlock exitBlock)
+                {
+                    WriteNode(block);
+                }
+                else if (block is ForeachCollectionProducerBlock foreachBlock)
+                {
+                    WriteNode(foreachBlock, foreachBlock.ForeachNode);
+                }
+                else if (block is ForInitializerBlock forBlock)
+                {
+                    WriteNode(forBlock, forBlock.ForNode);
+                }
+                else if (block is JumpBlock jumpBlock)
+                {
+                    WriteNode(jumpBlock, jumpBlock.JumpNode);
+                }
+                else if (block is LockBlock lockBlock)
+                {
+                    WriteNode(lockBlock, lockBlock.LockNode);
+                }
+                else if (block is UsingEndBlock usingBlock)
+                {
+                    WriteNode(usingBlock, usingBlock.UsingStatement);
+                }
+                else
+                {
+                    WriteNode(block);
+                }
+                WriteEdges(block, getLabel);
+            }
+
+            private void WriteNode(Block block, SyntaxNode terminator = null)
+            {
+                var header = block.GetType().Name.SplitCamelCaseToWords().First().ToUpperInvariant();
+                if (terminator != null)
+                {
+                    // shorten the text
+                    var terminatorType = terminator.GetType().Name.Replace("Syntax", string.Empty);
+
+                    header += ":" + terminatorType;
+                }
+                writer.WriteNode(blockId.Get(block), header, block.Instructions.Select(i => i.ToString()).ToArray());
+            }
+
+            private void WriteEdges(Block block, Func<Block, string> getLabel)
+            {
+                foreach (var successor in block.SuccessorBlocks)
+                {
+                    writer.WriteEdge(blockId.Get(block), blockId.Get(successor), getLabel(successor));
+                }
+            }
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/DotWriter.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/DotWriter.cs
@@ -1,0 +1,82 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+using System.Linq;
+
+namespace SonarAnalyzer.Helpers
+{
+    internal class DotWriter
+    {
+        private readonly TextWriter writer;
+
+        public DotWriter(TextWriter writer)
+        {
+            this.writer = writer;
+        }
+
+        public void WriteGraphStart(string graphName)
+        {
+            writer.WriteLine($"digraph \"{Encode(graphName)}\" {{");
+        }
+
+        public void WriteGraphEnd()
+        {
+            writer.WriteLine("}");
+        }
+
+        public void WriteNode(string id, string header, params string[] items)
+        {
+            // Curly braces in the label reverse the orientation of the columns/rows
+            // Columns/rows are created with pipe
+            // New lines are inserted with \n; \r\n does not work well.
+            // ID [shape=record label="{<header>|<line1>\n<line2>\n...}"]
+            writer.Write(id);
+            writer.Write(" [shape=record label=\"{" + header);
+            if (items.Length > 0)
+            {
+                writer.Write("|");
+                writer.Write(string.Join("|", items.Select(Encode)));
+            }
+            writer.Write("}\"");
+            writer.WriteLine("]");
+        }
+
+        internal void WriteEdge(string startId, string endId, string label)
+        {
+            writer.Write($"{startId} -> {endId}");
+            if (!string.IsNullOrEmpty(label))
+            {
+                writer.Write($" [label=\"{label}\"]");
+            }
+            writer.WriteLine();
+        }
+
+        private static string Encode(string s) =>
+            s.Replace("\r", string.Empty)
+            .Replace("\n", "\\n")
+            .Replace("{", "\\{")
+            .Replace("}", "\\}")
+            .Replace("|", "\\|")
+            .Replace("<", "\\<")
+            .Replace(">", "\\>")
+            .Replace("\"", "\\\"");
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/UcfgSerializer.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/UcfgSerializer.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Helpers
 
         private class UcfgWalker
         {
-            private DotWriter writer;
+            private readonly DotWriter writer;
 
             public UcfgWalker(DotWriter writer)
             {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/UcfgSerializer.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/UcfgSerializer.cs
@@ -1,0 +1,100 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using SonarAnalyzer.Protobuf.Ucfg;
+
+namespace SonarAnalyzer.Helpers
+{
+    public class UcfgSerializer
+    {
+        public static string Serialize(UCFG ucfg)
+        {
+            var stringBuilder = new StringBuilder();
+            using (var writer = new StringWriter(stringBuilder))
+            {
+                Serialize(ucfg, writer);
+            }
+            return stringBuilder.ToString();
+        }
+
+        public static void Serialize(UCFG ucfg, TextWriter writer)
+        {
+            new UcfgWalker(new DotWriter(writer)).Visit(ucfg.MethodId, ucfg);
+        }
+
+        private class UcfgWalker
+        {
+            private DotWriter writer;
+
+            public UcfgWalker(DotWriter writer)
+            {
+                this.writer = writer;
+            }
+
+            public void Visit(string methodName, UCFG ucfg)
+            {
+                writer.WriteGraphStart(methodName);
+
+                writer.WriteNode("ENTRY", "ENTRY", ucfg.Parameters.ToArray());
+
+                foreach (var entry in ucfg.Entries)
+                {
+                    writer.WriteEdge("ENTRY", entry, string.Empty);
+                }
+
+                foreach (var block in ucfg.BasicBlocks)
+                {
+                    Visit(block);
+                }
+
+                writer.WriteNode("EXIT", "EXIT");
+
+                writer.WriteGraphEnd();
+            }
+
+            private void Visit(BasicBlock block)
+            {
+                writer.WriteNode(block.Id, "BLOCK", block.Instructions.Select(SerializeInstruction).ToArray());
+                if (block.TerminatorCase == BasicBlock.TerminatorOneofCase.Jump)
+                {
+                    foreach (var destination in block.Jump.Destinations)
+                    {
+                        writer.WriteEdge(block.Id, destination, string.Empty);
+                    }
+                }
+                else
+                {
+                    writer.WriteEdge(block.Id, "EXIT", string.Empty);
+                }
+            }
+
+            private string SerializeInstruction(Instruction instruction) =>
+                $"{instruction.Variable} {instruction.MethodId} {string.Join(",", instruction.Args.Select(SerializeExpression))}";
+
+            private string SerializeExpression(Expression expression) =>
+                expression.ExprCase == Expression.ExprOneofCase.Const
+                    ? "CONST"
+                    : expression.Var.Name;
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Security/Ucfg/UniversalControlFlowGraphBuilder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Security/Ucfg/UniversalControlFlowGraphBuilder.cs
@@ -462,14 +462,5 @@ namespace SonarAnalyzer.Security.Ucfg
                     parameter.Identifier.ValueText;
             }
         }
-
-        private class BlockIdMap
-        {
-            private readonly Dictionary<Block, string> map = new Dictionary<Block, string>();
-            private int counter;
-
-            public string Get(Block cfgBlock) =>
-                map.GetOrAdd(cfgBlock, b => $"{counter++}");
-        }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/BlockIdMapTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/BlockIdMapTest.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.SymbolicExecution.ControlFlowGraph;
+
+namespace SonarAnalyzer.Helpers.UnitTest
+{
+    [TestClass]
+    public class BlockIdMapTest
+    {
+        private BlockIdMap blockId;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            blockId = new BlockIdMap();
+        }
+
+        [TestMethod]
+        public void Get_Returns_Same_Id_For_Same_Block()
+        {
+            var block = new TemporaryBlock();
+
+            blockId.Get(block).Should().Be("0");
+            blockId.Get(block).Should().Be("0");
+            blockId.Get(block).Should().Be("0");
+        }
+
+        [TestMethod]
+        public void Get_Returns_Different_Id_For_Different_Block()
+        {
+            var id1 = blockId.Get(new TemporaryBlock());
+            var id2 = blockId.Get(new TemporaryBlock());
+            var id3 = blockId.Get(new TemporaryBlock());
+
+            id1.Should().Be("0");
+            id2.Should().Be("1");
+            id3.Should().Be("2");
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/CfgSerializerTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/CfgSerializerTest.cs
@@ -1,0 +1,264 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.SymbolicExecution.ControlFlowGraph;
+using SonarAnalyzer.UnitTest.Security;
+
+namespace SonarAnalyzer.Helpers.UnitTest
+{
+    [TestClass]
+    public class CfgSerializerTest
+    {
+        [TestMethod]
+        public void Serialize_Empty_Method()
+        {
+            var code = @"
+class C
+{
+    void Foo()
+    {
+    }
+}
+";
+            var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
+
+            dot.Should().Be(@"digraph ""Foo"" {
+0 [shape=record label=""{EXIT}""]
+}
+");
+        }
+
+        [TestMethod]
+        public void Serialize_Branch_Jump()
+        {
+            var code = @"
+class C
+{
+    void Foo(int a)
+    {
+        switch (a)
+        {
+            case 1:
+                c1();
+                break;
+            case 2:
+                c2();
+                break;
+        }
+    }
+}
+";
+            var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
+
+            dot.Should().Be(@"digraph ""Foo"" {
+0 [shape=record label=""{BRANCH:SwitchStatement|a}""]
+0 -> 1
+0 -> 2
+0 -> 3
+2 [shape=record label=""{JUMP:BreakStatement|c2|c2()}""]
+2 -> 3
+1 [shape=record label=""{JUMP:BreakStatement|c1|c1()}""]
+1 -> 3
+3 [shape=record label=""{EXIT}""]
+}
+");
+        }
+
+        [TestMethod]
+        public void Serialize_BinaryBranch_Simple()
+        {
+            var code = @"
+class C
+{
+    void Foo()
+    {
+        if (true)
+        {
+            Bar();
+        }
+    }
+    void Bar() { }
+}
+";
+            var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
+
+            dot.Should().Be(@"digraph ""Foo"" {
+0 [shape=record label=""{BINARY:IfStatement|true}""]
+0 -> 1 [label=""True""]
+0 -> 2 [label=""False""]
+1 [shape=record label=""{SIMPLE|Bar|Bar()}""]
+1 -> 2
+2 [shape=record label=""{EXIT}""]
+}
+");
+        }
+
+        [TestMethod]
+        public void Serialize_Foreach_Binary_Simple()
+        {
+            var code = @"
+class C
+{
+    void Foo()
+    {
+        foreach (var i in items)
+        {
+            Bar();
+        }
+    }
+}
+";
+            var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
+
+            dot.Should().Be(@"digraph ""Foo"" {
+0 [shape=record label=""{FOREACH:ForEachStatement|items}""]
+0 -> 1
+1 [shape=record label=""{BINARY:ForEachStatement}""]
+1 -> 2 [label=""True""]
+1 -> 3 [label=""False""]
+2 [shape=record label=""{SIMPLE|Bar|Bar()}""]
+2 -> 1
+3 [shape=record label=""{EXIT}""]
+}
+");
+        }
+
+        [TestMethod]
+        public void Serialize_For_Binary_Simple()
+        {
+            var code = @"
+class C
+{
+    void Foo()
+    {
+        for (var i = 0; i < 10; i++)
+        {
+            Bar();
+        }
+    }
+}
+";
+            var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
+
+            dot.Should().Be(@"digraph ""Foo"" {
+0 [shape=record label=""{FOR:ForStatement|0|i = 0}""]
+0 -> 1
+1 [shape=record label=""{BINARY:ForStatement|i|10|i \< 10}""]
+1 -> 2 [label=""True""]
+1 -> 3 [label=""False""]
+2 [shape=record label=""{SIMPLE|Bar|Bar()}""]
+2 -> 4
+4 [shape=record label=""{SIMPLE|i|i++}""]
+4 -> 1
+3 [shape=record label=""{EXIT}""]
+}
+");
+        }
+
+        [TestMethod]
+        public void Serialize_Jump_Using()
+        {
+            var code = @"
+class C
+{
+    void Foo()
+    {
+        using (x)
+        {
+            Bar();
+        }
+    }
+}
+";
+            var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
+
+            dot.Should().Be(@"digraph ""Foo"" {
+0 [shape=record label=""{JUMP:UsingStatement|x}""]
+0 -> 1
+1 [shape=record label=""{USING:UsingStatement|Bar|Bar()}""]
+1 -> 2
+2 [shape=record label=""{EXIT}""]
+}
+");
+        }
+
+        [TestMethod]
+        public void Serialize_Lock_Simple()
+        {
+            var code = @"
+class C
+{
+    void Foo()
+    {
+        lock (x)
+        {
+            Bar();
+        }
+    }
+}
+";
+            var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
+
+            dot.Should().Be(@"digraph ""Foo"" {
+0 [shape=record label=""{LOCK:LockStatement|x}""]
+0 -> 1
+1 [shape=record label=""{SIMPLE|Bar|Bar()}""]
+1 -> 2
+2 [shape=record label=""{EXIT}""]
+}
+");
+        }
+
+
+        [TestMethod]
+        public void Serialize_Lambda()
+        {
+            var code = @"
+class C
+{
+    void Foo()
+    {
+        Bar(x =>
+        {
+            return 1 + 1;
+        });
+    }
+}
+";
+            var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
+
+            dot.Should().Be(@"digraph ""Foo"" {
+0 [shape=record label=""{SIMPLE|Bar|x =\>\n        \{\n            return 1 + 1;\n        \}|Bar(x =\>\n        \{\n            return 1 + 1;\n        \})}""]
+0 -> 1
+1 [shape=record label=""{EXIT}""]
+}
+");
+        }
+
+        protected IControlFlowGraph GetCfgForMethod(string code, string methodName)
+        {
+            (var method, var semanticModel) = TestHelper.Compile(code).GetMethod(methodName);
+
+            return CSharpControlFlowGraph.Create(method.Body, semanticModel);
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/CfgSerializerTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/CfgSerializerTest.cs
@@ -21,6 +21,7 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.SymbolicExecution.ControlFlowGraph;
+using SonarAnalyzer.UnitTest.Helpers;
 using SonarAnalyzer.UnitTest.Security;
 
 namespace SonarAnalyzer.Helpers.UnitTest
@@ -41,7 +42,7 @@ class C
 ";
             var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
 
-            dot.Should().Be(@"digraph ""Foo"" {
+            dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{EXIT}""]
 }
 ");
@@ -69,7 +70,7 @@ class C
 ";
             var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
 
-            dot.Should().Be(@"digraph ""Foo"" {
+            dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{BRANCH:SwitchStatement|a}""]
 0 -> 1
 0 -> 2
@@ -101,7 +102,7 @@ class C
 ";
             var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
 
-            dot.Should().Be(@"digraph ""Foo"" {
+            dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{BINARY:IfStatement|true}""]
 0 -> 1 [label=""True""]
 0 -> 2 [label=""False""]
@@ -129,7 +130,7 @@ class C
 ";
             var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
 
-            dot.Should().Be(@"digraph ""Foo"" {
+            dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{FOREACH:ForEachStatement|items}""]
 0 -> 1
 1 [shape=record label=""{BINARY:ForEachStatement}""]
@@ -159,7 +160,7 @@ class C
 ";
             var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
 
-            dot.Should().Be(@"digraph ""Foo"" {
+            dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{FOR:ForStatement|0|i = 0}""]
 0 -> 1
 1 [shape=record label=""{BINARY:ForStatement|i|10|i \< 10}""]
@@ -191,7 +192,7 @@ class C
 ";
             var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
 
-            dot.Should().Be(@"digraph ""Foo"" {
+            dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{JUMP:UsingStatement|x}""]
 0 -> 1
 1 [shape=record label=""{USING:UsingStatement|Bar|Bar()}""]
@@ -218,7 +219,7 @@ class C
 ";
             var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
 
-            dot.Should().Be(@"digraph ""Foo"" {
+            dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{LOCK:LockStatement|x}""]
 0 -> 1
 1 [shape=record label=""{SIMPLE|Bar|Bar()}""]
@@ -227,7 +228,6 @@ class C
 }
 ");
         }
-
 
         [TestMethod]
         public void Serialize_Lambda()
@@ -246,7 +246,7 @@ class C
 ";
             var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
 
-            dot.Should().Be(@"digraph ""Foo"" {
+            dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{SIMPLE|Bar|x =\>\n        \{\n            return 1 + 1;\n        \}|Bar(x =\>\n        \{\n            return 1 + 1;\n        \})}""]
 0 -> 1
 1 [shape=record label=""{EXIT}""]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/DotWriterTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/DotWriterTest.cs
@@ -1,0 +1,87 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SonarAnalyzer.Helpers.UnitTest
+{
+    [TestClass]
+    public class DotWriterTest
+    {
+        [TestMethod]
+        public void WriteGraphStart_Should_Write_Name()
+        {
+            var stringBuilder = new StringBuilder();
+            var writer = new DotWriter(new StringWriter(stringBuilder));
+
+            writer.WriteGraphStart("test");
+
+            stringBuilder.ToString().Should().Be("digraph \"test\" {\r\n");
+        }
+
+        [TestMethod]
+        public void WriteGraphEnd_Test()
+        {
+            var stringBuilder = new StringBuilder();
+            var writer = new DotWriter(new StringWriter(stringBuilder));
+
+            writer.WriteGraphEnd();
+
+            stringBuilder.ToString().Should().Be("}\r\n");
+        }
+
+        [TestMethod]
+        public void WriteNode_With_Items()
+        {
+            var stringBuilder = new StringBuilder();
+            var writer = new DotWriter(new StringWriter(stringBuilder));
+
+            writer.WriteNode("1", "header", "a", "b", "c");
+
+            stringBuilder.ToString().Should().Be("1 [shape=record label=\"{header|a|b|c}\"]\r\n");
+        }
+
+        [TestMethod]
+        public void WriteNode_With_Encoding()
+        {
+            var stringBuilder = new StringBuilder();
+            var writer = new DotWriter(new StringWriter(stringBuilder));
+
+            writer.WriteNode("1", "header", "\r", "\n", "{", "}", "<", ">", "|", "\"");
+
+            stringBuilder.ToString().Should().Be(@"1 [shape=record label=""{header||\n|\{|\}|\<|\>|\||\""}""]
+");
+        }
+
+        [TestMethod]
+        public void WriteNode_No_Items()
+        {
+            var stringBuilder = new StringBuilder();
+            var writer = new DotWriter(new StringWriter(stringBuilder));
+
+            writer.WriteNode("1", "header");
+
+            stringBuilder.ToString().Should().Be("1 [shape=record label=\"{header}\"]\r\n");
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/DotWriterTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/DotWriterTest.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.Helpers;
 
 namespace SonarAnalyzer.Helpers.UnitTest
 {
@@ -36,7 +37,7 @@ namespace SonarAnalyzer.Helpers.UnitTest
 
             writer.WriteGraphStart("test");
 
-            stringBuilder.ToString().Should().Be("digraph \"test\" {\r\n");
+            stringBuilder.ToString().Should().BeIgnoringLineEndings("digraph \"test\" {\r\n");
         }
 
         [TestMethod]
@@ -47,7 +48,7 @@ namespace SonarAnalyzer.Helpers.UnitTest
 
             writer.WriteGraphEnd();
 
-            stringBuilder.ToString().Should().Be("}\r\n");
+            stringBuilder.ToString().Should().BeIgnoringLineEndings("}\r\n");
         }
 
         [TestMethod]
@@ -58,7 +59,7 @@ namespace SonarAnalyzer.Helpers.UnitTest
 
             writer.WriteNode("1", "header", "a", "b", "c");
 
-            stringBuilder.ToString().Should().Be("1 [shape=record label=\"{header|a|b|c}\"]\r\n");
+            stringBuilder.ToString().Should().BeIgnoringLineEndings("1 [shape=record label=\"{header|a|b|c}\"]\r\n");
         }
 
         [TestMethod]
@@ -69,8 +70,7 @@ namespace SonarAnalyzer.Helpers.UnitTest
 
             writer.WriteNode("1", "header", "\r", "\n", "{", "}", "<", ">", "|", "\"");
 
-            stringBuilder.ToString().Should().Be(@"1 [shape=record label=""{header||\n|\{|\}|\<|\>|\||\""}""]
-");
+            stringBuilder.ToString().Should().BeIgnoringLineEndings(@"1 [shape=record label=""{header||\n|\{|\}|\<|\>|\||\""}""]" + "\r\n");
         }
 
         [TestMethod]
@@ -81,7 +81,7 @@ namespace SonarAnalyzer.Helpers.UnitTest
 
             writer.WriteNode("1", "header");
 
-            stringBuilder.ToString().Should().Be("1 [shape=record label=\"{header}\"]\r\n");
+            stringBuilder.ToString().Should().BeIgnoringLineEndings("1 [shape=record label=\"{header}\"]\r\n");
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/FluentTestHelper.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/FluentTestHelper.cs
@@ -20,12 +20,16 @@
 
 using FluentAssertions;
 using FluentAssertions.Collections;
+using FluentAssertions.Primitives;
 using System;
 
 namespace SonarAnalyzer.UnitTest.Helpers
 {
     internal static class FluentTestHelper
     {
+        private const string WindowsLineEnding = "\r\n";
+        private const string UnixLineEnding = "\n";
+
         public static void OnlyContain<T, TAssertions>(this SelfReferencingCollectionAssertions<T, TAssertions> self, params T[] expected)
              where TAssertions : SelfReferencingCollectionAssertions<T, TAssertions>
         {
@@ -51,5 +55,14 @@ namespace SonarAnalyzer.UnitTest.Helpers
                 .Should().HaveSameCount(expected)
                 .And.ContainInOrder(expected);
         }
+
+        public static void BeIgnoringLineEndings(this StringAssertions stringAssertions, string expected)
+        {
+            stringAssertions.Subject.ToLinuxLineEndings().Should().Be(expected.ToLinuxLineEndings());
+        }
+
+        // This allows to deal with multiple line endings
+        private static string ToLinuxLineEndings(this string str) =>
+            str.Replace(WindowsLineEnding, UnixLineEnding);
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/UcfgSerializerTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/UcfgSerializerTest.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.Security.Ucfg;
+
+namespace SonarAnalyzer.Helpers.UnitTest
+{
+    [TestClass]
+    public class UcfgSerializerTest : UcfgBuilderTestBase
+    {
+        [TestMethod]
+        public void Serialize_Some_Method()
+        {
+            var code = @"
+class C
+{
+    void Foo(string a, string b)
+    {
+        var x = a + b;
+        if (true)
+        {
+            Bar(a, 1);
+        }
+        else
+        {
+            Bar(b, 2);
+        }
+    }
+    void Bar(string a, int x) { }
+}
+";
+            var dot = UcfgSerializer.Serialize(GetUcfgForMethod(code, "Foo"));
+
+            dot.Should().Be(@"digraph ""C.Foo(string, string)"" {
+ENTRY [shape=record label=""{ENTRY|a|b}""]
+ENTRY -> 0
+0 [shape=record label=""{BLOCK|%0 __concat b,a|x __id %0}""]
+0 -> 1
+0 -> 2
+1 [shape=record label=""{BLOCK|%0 C.Bar(string, int) a,CONST}""]
+1 -> 3
+2 [shape=record label=""{BLOCK|%0 C.Bar(string, int) b,CONST}""]
+2 -> 3
+3 [shape=record label=""{BLOCK}""]
+3 -> EXIT
+EXIT [shape=record label=""{EXIT}""]
+}
+");
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/UcfgSerializerTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/UcfgSerializerTest.cs
@@ -20,6 +20,7 @@
 
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.Helpers;
 using SonarAnalyzer.UnitTest.Security.Ucfg;
 
 namespace SonarAnalyzer.Helpers.UnitTest
@@ -50,7 +51,7 @@ class C
 ";
             var dot = UcfgSerializer.Serialize(GetUcfgForMethod(code, "Foo"));
 
-            dot.Should().Be(@"digraph ""C.Foo(string, string)"" {
+            dot.Should().BeIgnoringLineEndings(@"digraph ""C.Foo(string, string)"" {
 ENTRY [shape=record label=""{ENTRY|a|b}""]
 ENTRY -> 0
 0 [shape=record label=""{BLOCK|%0 __concat b,a|x __id %0}""]


### PR DESCRIPTION
To enable set the following env var `SONARANALYZER_GENERATE_DOT` to `TRUE` (should be case insensitive).

Both `Visitor` classes are not exactly following the visitor pattern; I did not wanted to modify many existing classes and did simpler implementation. If we do a proper `Visitor` implementation it would be of help for the UCFG generation too.