### PR TITLE
Fix NullReferenceException while converting VariableDeclaratorSyntax …

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/ControlFlowGraph/UcfgObjectFactory.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/ControlFlowGraph/UcfgObjectFactory.cs
@@ -106,7 +106,12 @@ namespace SonarAnalyzer.ControlFlowGraph.CSharp
             GetMappedExpression(syntaxNode).Var != null;
 
         private Expression GetMappedExpression(SyntaxNode syntaxNode) =>
-            nodeExpressionMap.GetValueOrDefault(syntaxNode.RemoveParentheses());
+            nodeExpressionMap.GetValueOrDefault(syntaxNode.RemoveParentheses())
+            // In some cases the CFG does not contain all syntax nodes that were used in
+            // an expression, for example when ternary operator is passed as an argument.
+            // This could potentially be improved, but for the time being the constant
+            // expression fallback will do what we used to do before.
+            ?? ConstantExpression;
 
         private Instruction CreateInstruction(SyntaxNode syntaxNode, UcfgMethod method, string returnVariable,
             params SyntaxNode[] arguments)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Security/Ucfg/UcfgBuilder_Instructions.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Security/Ucfg/UcfgBuilder_Instructions.cs
@@ -451,6 +451,25 @@ public class Class1
             a.Should().Be(c);
         }
 
+        [TestMethod]
+        public void Regression_SyntaxNode_Not_In_CFG()
+        {
+            const string code = @"
+using System;
+
+public class Foo
+{
+    public void Bar(bool b)
+    {
+        // The ternary operator is not walked because it is a Jump node of a block
+        // that's why when we create instruction for the variable declarator we
+        // get NRE for the assignment argument.
+        var s = b ? ""s1"" : ""s2"";
+    }
+}";
+            UcfgVerifier.GetUcfgForMethod(code, "Bar");
+        }
+
         private static void ValidateInstruction(Instruction instruction, string methodId, string variable, params string[] args)
         {
             instruction.Assigncall.MethodId.Should().Be(methodId);


### PR DESCRIPTION
…with a branching instruction (ternary operator)