### PR TITLE
CfgSerializer writes the branching node Kind instead of Type, thus st…

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/ControlFlowGraph/CfgSerializer.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/ControlFlowGraph/CfgSerializer.cs
@@ -23,6 +23,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.ControlFlowGraph.CSharp
@@ -128,7 +129,7 @@ namespace SonarAnalyzer.ControlFlowGraph.CSharp
                 if (terminator != null)
                 {
                     // shorten the text
-                    var terminatorType = terminator.GetType().Name.Replace("Syntax", string.Empty);
+                    var terminatorType = terminator.Kind().ToString().Replace("Syntax", string.Empty);
 
                     header += ":" + terminatorType;
                 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/CfgSerializerTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/CfgSerializerTest.cs
@@ -105,7 +105,7 @@ class C
             var dot = CfgSerializer.Serialize("Foo", GetCfgForMethod(code, "Foo"));
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
-0 [shape=record label=""{BINARY:IfStatement|true}""]
+0 [shape=record label=""{BINARY:TrueLiteralExpression|true}""]
 0 -> 1 [label=""True""]
 0 -> 2 [label=""False""]
 1 [shape=record label=""{SIMPLE|Bar|Bar()}""]


### PR DESCRIPTION
…oring more precise information about the underlying object