### PR TITLE
QA: UCFG test should fail if is any Roslyn analyzer error

### DIFF
--- a/its/src/test/java/com/sonar/it/csharp/UCFGDeserializationTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/UCFGDeserializationTest.java
@@ -180,6 +180,7 @@ public class UCFGDeserializationTest {
       .setDirectory(projectDir.toFile()), writer, 10 * 60 * 1000);
     result.addStatus(status);
 
+    assertThat(result.getLogs()).as("Roslyn analyzer errors").doesNotContain("AD0001");
     assertThat(result.isSuccess()).isTrue();
   }
 }


### PR DESCRIPTION
This PR should make the QA test fail in the future if any UCFG generation error occurs on the C# side.