### PR TITLE
Rule S1313: do not report issue for loopback address (#1540)

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/HardcodedIpAddress.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/HardcodedIpAddress.cs
@@ -59,6 +59,11 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
+                    if (text == "127.0.0.1")
+                    {
+                        return;
+                    }
+
                     if (!IPAddress.TryParse(text, out var address))
                     {
                         return;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/HardcodedIpAddress.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/HardcodedIpAddress.cs
@@ -20,7 +20,7 @@ namespace Tests.Diagnostics
         public HardcodedIpAddress()
         {
             string ip = "192.168.0.1"; // Noncompliant {{Make this IP '192.168.0.1' address configurable.}}
-//                      ^^^^^^^^^^^
+//                      ^^^^^^^^^^^^^
 
             ip = "300.0.0.0"; // Compliant, not a valid IP
             ip = "127.0.0.1"; // Compliant, this is an exception in the rule (see: https://github.com/SonarSource/sonar-csharp/issues/1540)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/HardcodedIpAddress.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/HardcodedIpAddress.cs
@@ -19,10 +19,11 @@ namespace Tests.Diagnostics
         [SomeAttribute("127.0.0.1")] // this is mainly for assembly versions
         public HardcodedIpAddress()
         {
-            string ip = "127.0.0.1"; // Noncompliant {{Make this IP '127.0.0.1' address configurable.}}
+            string ip = "192.168.0.1"; // Noncompliant {{Make this IP '192.168.0.1' address configurable.}}
 //                      ^^^^^^^^^^^
 
             ip = "300.0.0.0"; // Compliant, not a valid IP
+            ip = "127.0.0.1"; // Compliant, this is an exception in the rule (see: https://github.com/SonarSource/sonar-csharp/issues/1540)
             ip = "    127.0.0.0    "; // Compliant
             ip = @"    ""127.0.0.0""    "; // Compliant
 


### PR DESCRIPTION
Fix #1540 

- Adds exception for 127.0.0.1
- Changes compliant IP address example since the original test was actually for the address the exception is being added for!