### PR TITLE
Remove whitespace from MSBUILD_PATH string

### DIFF
--- a/its/src/test/java/com/sonar/it/csharp/Tests.java
+++ b/its/src/test/java/com/sonar/it/csharp/Tests.java
@@ -69,7 +69,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 })
 public class Tests {
 
-  private static final String MSBUILD_PATH = "MSBUILD_PATH ";
+  private static final String MSBUILD_PATH = "MSBUILD_PATH";
   private static final String NUGET_PATH = "NUGET_PATH";
 
   @ClassRule


### PR DESCRIPTION
Environment vars should not have whitespace in name.