### PR TITLE
Fix S1144: Unused private members should not report false positives w…

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -43,6 +43,14 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
+        private static ISet<KnownType> IgnoredTypes = new HashSet<KnownType>
+        {
+            KnownType.UnityEditor_AssetModificationProcessor,
+            KnownType.UnityEditor_AssetPostprocessor,
+            KnownType.UnityEngine_MonoBehaviour,
+            KnownType.UnityEngine_ScriptableObject,
+        };
+
         protected sealed override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterCompilationStartAction(
@@ -60,7 +68,8 @@ namespace SonarAnalyzer.Rules.CSharp
                         {
                             var namedType = (INamedTypeSymbol)cc.Symbol;
                             if (!namedType.IsClassOrStruct() ||
-                                namedType.ContainingType != null)
+                                namedType.ContainingType != null ||
+                                namedType.DerivesFromAny(IgnoredTypes))
                             {
                                 return;
                             }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -321,6 +321,10 @@ namespace SonarAnalyzer.Helpers
             new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>")
         };
         internal static readonly KnownType Sytem_Resources_ResourceManager = new KnownType("System.Resources.ResourceManager");
+        internal static readonly KnownType UnityEditor_AssetModificationProcessor = new KnownType("UnityEditor.AssetModificationProcessor");
+        internal static readonly KnownType UnityEditor_AssetPostprocessor = new KnownType("UnityEditor.AssetPostprocessor");
+        internal static readonly KnownType UnityEngine_MonoBehaviour = new KnownType("UnityEngine.MonoBehaviour");
+        internal static readonly KnownType UnityEngine_ScriptableObject = new KnownType("UnityEngine.ScriptableObject");
         internal static readonly KnownType Xunit_Assert = new KnownType("Xunit.Assert");
         internal static readonly KnownType Xunit_FactAttribute = new KnownType("Xunit.FactAttribute");
         internal static readonly KnownType Xunit_TheoryAttribute = new KnownType("Xunit.TheoryAttribute");

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
@@ -716,6 +716,46 @@ public class NewClass
 
         [TestMethod]
         [TestCategory("Rule")]
+        public void Unity3D_Ignored()
+        {
+            Verifier.VerifyCSharpAnalyzer(@"
+// https://github.com/SonarSource/sonar-csharp/issues/159
+public class UnityMessages1 : UnityEngine.MonoBehaviour
+{
+    private void SomeMethod(bool hasFocus) { } // Compliant
+}
+
+public class UnityMessages2 : UnityEngine.ScriptableObject
+{
+    private void SomeMethod(bool hasFocus) { } // Compliant
+}
+
+public class UnityMessages3 : UnityEditor.AssetPostprocessor
+{
+    private void SomeMethod(bool hasFocus) { } // Compliant
+}
+
+public class UnityMessages4 : UnityEditor.AssetModificationProcessor
+{
+    private void SomeMethod(bool hasFocus) { } // Compliant
+}
+
+// Unity3D does not seem to to available as a nuget package and we cannot use the original classes
+namespace UnityEngine
+{
+    public class MonoBehaviour { }
+    public class ScriptableObject { }
+}
+namespace UnityEditor
+{
+    public class AssetPostprocessor { }
+    public class AssetModificationProcessor { }
+}
+", new UnusedPrivateMember());
+        }
+
+        [TestMethod]
+        [TestCategory("Rule")]
         public void UnusedPrivateMember()
         {
             Verifier.VerifyAnalyzer(@"TestCases\UnusedPrivateMember.cs", new UnusedPrivateMember());


### PR DESCRIPTION
…ith Unity classes

Fix #159 

The ticket mentions more types than the added to the IgnoredTypes collection. They however, are all subclasses of `MonoBehaviour` and `ScriptableObject`, hence they will be automatically ignored.