### PR TITLE
 Support SECURITY_HOTSPOT rules and populate Security Standards data for Security Hotspots and Vulnerabilities rules

### DIFF
--- a/scripts/rspec/rspec.ps1
+++ b/scripts/rspec/rspec.ps1
@@ -59,6 +59,7 @@ $categoriesMap = @{
     "BUG" = "Bug";
     "CODE_SMELL" = "Code Smell";
     "VULNERABILITY" = "Vulnerability";
+    "SECURITY_HOTSPOT" = "Security Hotspot";
 }
 
 $severitiesMap = @{
@@ -189,8 +190,14 @@ function CreateStringResources($lang, $rules) {
 
         $severity = $severitiesMap.Get_Item(${json}.defaultSeverity)
 
+        # Ensure compatibility with SonarQube 6.7 LTS (the $resourcesPath file is used to generate rules.xml, which is deserialized at runtime)
+        $backwardsCompatibleType = ${json}.type;
+        if ($backwardsCompatibleType -eq "SECURITY_HOTSPOT") {
+            $backwardsCompatibleType = "VULNERABILITY";
+        }
+
         [void]$resources.Add("${rule}_Description=${description}")
-        [void]$resources.Add("${rule}_Type=$(${json}.type)")
+        [void]$resources.Add("${rule}_Type=$backwardsCompatibleType")
         [void]$resources.Add("${rule}_Title=$(${json}.title)")
         [void]$resources.Add("${rule}_Category=${severity} $($categoriesMap.Get_Item(${json}.type))")
         [void]$resources.Add("${rule}_IsActivatedByDefault=$(${sonarWayRules}.ruleKeys -Contains ${rule})")

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -63,7 +63,8 @@
   </scm>
 
   <properties>
-    <sonar.version>7.3-alpha1</sonar.version>
+    <sonar.version>7.3</sonar.version>
+    <sonarLTS.version>6.7</sonarLTS.version>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <sonarAnalyzer.workDirectory>${project.build.directory}/analyzer</sonarAnalyzer.workDirectory>
   </properties>
@@ -204,7 +205,7 @@
           <pluginClass>org.sonar.plugins.csharp.CSharpPlugin</pluginClass>
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <sonarLintSupported>false</sonarLintSupported>
-          <sonarQubeMinVersion>6.7</sonarQubeMinVersion> <!-- allow to depend on API 6.7+ but run on LTS(6.7) -->
+          <sonarQubeMinVersion>${sonarLTS.version}</sonarQubeMinVersion> <!-- runtime minimal API version -->
         </configuration>
       </plugin>
        <plugin>
@@ -300,7 +301,7 @@
                         <include name="rules.xml"/>
                       </fileset>
                       <fileset dir="${project.build.directory}/../../sonaranalyzer-dotnet/rspec/cs">
-                        <include name="*.json" />
+                        <include name="*.json" /> <!-- Allows to copy each rule definition json file and the Sonar-way profile. -->
                       </fileset>
                     </copy>
 
@@ -403,7 +404,7 @@
                     </copy>
                     <copy todir="${sonarAnalyzer.workDirectory}/org/sonar/plugins/csharp">
                       <fileset dir="${project.build.directory}/../../sonaranalyzer-dotnet/rspec/cs">
-                        <include name="*.json" />
+                        <include name="*.json" /> <!-- Allows to copy each rule definition json file and the Sonar-way profile. -->
                       </fileset>
                     </copy>
                     <echo file="${sonarAnalyzer.workDirectory}/static/version.txt" message="${project.version}" encoding="utf-8" />

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -63,7 +63,7 @@
   </scm>
 
   <properties>
-    <sonar.version>6.7</sonar.version>
+    <sonar.version>7.3-alpha1</sonar.version>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <sonarAnalyzer.workDirectory>${project.build.directory}/analyzer</sonarAnalyzer.workDirectory>
   </properties>
@@ -96,7 +96,7 @@
       <version>${sonar.version}</version>
       <scope>provided</scope>
     </dependency>
-    
+
     <!-- test dependencies -->
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -134,6 +134,52 @@
       <version>19.0</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- FIXME the following 3 dependencies are due to some issue of integrating unit tests with sonar-plugin-api 7.3+ -->
+    <dependency>
+      <groupId>org.codehaus.woodstox</groupId>
+      <artifactId>stax2-api</artifactId>
+      <version>3.1.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>stax</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.woodstox</groupId>
+      <artifactId>woodstox-core-lgpl</artifactId>
+      <version>4.4.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.staxmate</groupId>
+      <artifactId>staxmate</artifactId>
+      <version>2.0.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.woodstox</groupId>
+          <artifactId>woodstox-core-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>stax</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.woodstox</groupId>
+          <artifactId>stax2-api</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -158,7 +204,7 @@
           <pluginClass>org.sonar.plugins.csharp.CSharpPlugin</pluginClass>
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <sonarLintSupported>false</sonarLintSupported>
-          <sonarQubeMinVersion>${sonar.version}</sonarQubeMinVersion>
+          <sonarQubeMinVersion>6.7</sonarQubeMinVersion> <!-- allow to depend on API 6.7+ but run on LTS(6.7) -->
         </configuration>
       </plugin>
        <plugin>
@@ -254,7 +300,7 @@
                         <include name="rules.xml"/>
                       </fileset>
                       <fileset dir="${project.build.directory}/../../sonaranalyzer-dotnet/rspec/cs">
-                        <include name="Sonar_way_profile.json" />
+                        <include name="*.json" />
                       </fileset>
                     </copy>
 
@@ -357,7 +403,7 @@
                     </copy>
                     <copy todir="${sonarAnalyzer.workDirectory}/org/sonar/plugins/csharp">
                       <fileset dir="${project.build.directory}/../../sonaranalyzer-dotnet/rspec/cs">
-                        <include name="Sonar_way_profile.json" />
+                        <include name="*.json" />
                       </fileset>
                     </copy>
                     <echo file="${sonarAnalyzer.workDirectory}/static/version.txt" message="${project.version}" encoding="utf-8" />

--- a/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/SonarVersion.java
+++ b/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/SonarVersion.java
@@ -19,18 +19,12 @@
  */
 package org.sonar.plugins.csharp;
 
+import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.batch.ScannerSide;
-import org.sonarsource.dotnet.shared.plugins.AbstractRulesDefinition;
+import org.sonar.api.internal.SonarRuntimeImpl;
+import org.sonar.api.utils.Version;
 
-import static org.sonar.plugins.csharp.CSharpPlugin.REPOSITORY_KEY;
-import static org.sonar.plugins.csharp.CSharpPlugin.REPOSITORY_NAME;
-
-@ScannerSide
-public class CSharpSonarRulesDefinition extends AbstractRulesDefinition {
-  private static final String RULES_XML = "/org/sonar/plugins/csharp/rules.xml";
-
-  public CSharpSonarRulesDefinition(SonarRuntime sonarRuntime) {
-    super(REPOSITORY_KEY, REPOSITORY_NAME, CSharpPlugin.LANGUAGE_KEY, RULES_XML, sonarRuntime);
-  }
+public class SonarVersion {
+  static final SonarRuntime SQ_73_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(7, 3), SonarQubeSide.SERVER);
+  static final SonarRuntime SQ_67_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(6, 7), SonarQubeSide.SERVER);
 }

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -14,7 +14,7 @@
   <description>Share code between C# and VB.NET plugins</description>
 
   <properties>
-    <sonar.version>6.7</sonar.version>
+    <sonar.version>7.3-alpha1</sonar.version>
     <protobuf.version>3.1.0</protobuf.version>
     <protobuf.compiler>${settings.localRepository}/com/google/protobuf/protoc/${protobuf.version}/protoc-${protobuf.version}-${os.detected.classifier}.exe</protobuf.compiler>
     <!-- used for deployment to SonarSource Artifactory -->

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -14,7 +14,7 @@
   <description>Share code between C# and VB.NET plugins</description>
 
   <properties>
-    <sonar.version>7.3-alpha1</sonar.version>
+    <sonar.version>7.3</sonar.version>
     <protobuf.version>3.1.0</protobuf.version>
     <protobuf.compiler>${settings.localRepository}/com/google/protobuf/protoc/${protobuf.version}/protoc-${protobuf.version}-${os.detected.classifier}.exe</protobuf.compiler>
     <!-- used for deployment to SonarSource Artifactory -->

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/AbstractRulesDefinition.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/AbstractRulesDefinition.java
@@ -126,7 +126,7 @@ public abstract class AbstractRulesDefinition implements RulesDefinition {
       return  stream != null
         ? GSON.fromJson(new InputStreamReader(stream, StandardCharsets.UTF_8), RuleMetadata.class)
         : new RuleMetadata();
-      } catch (IOException e) {
+    } catch (IOException e) {
       throw new IllegalStateException("Failed to read: " + resourcePath, e);
     }
   }

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/AbstractRulesDefinitionTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/AbstractRulesDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarC#
+ * SonarSource :: .NET :: Shared library
  * Copyright (C) 2014-2018 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
@@ -17,20 +17,23 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.plugins.csharp;
+package org.sonarsource.dotnet.shared.plugins;
 
-import org.sonar.api.SonarRuntime;
-import org.sonar.api.batch.ScannerSide;
-import org.sonarsource.dotnet.shared.plugins.AbstractRulesDefinition;
+import org.junit.Test;
 
-import static org.sonar.plugins.csharp.CSharpPlugin.REPOSITORY_KEY;
-import static org.sonar.plugins.csharp.CSharpPlugin.REPOSITORY_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@ScannerSide
-public class CSharpSonarRulesDefinition extends AbstractRulesDefinition {
-  private static final String RULES_XML = "/org/sonar/plugins/csharp/rules.xml";
+public class AbstractRulesDefinitionTest {
+  @Test
+  public void constructor_with_null() {
+    TestRulesDefinition test = new TestRulesDefinition();
+    assertThat(test).isNotNull();
+  }
 
-  public CSharpSonarRulesDefinition(SonarRuntime sonarRuntime) {
-    super(REPOSITORY_KEY, REPOSITORY_NAME, CSharpPlugin.LANGUAGE_KEY, RULES_XML, sonarRuntime);
+  private static class TestRulesDefinition extends AbstractRulesDefinition {
+    TestRulesDefinition() {
+      super("test", "test", "test", "test");
+    }
   }
 }
+

--- a/sonaranalyzer-dotnet/rspec/cs/S1313_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S1313_c#.json
@@ -1,6 +1,6 @@
 {
-  "title": "IP addresses should not be hardcoded",
-  "type": "VULNERABILITY",
+  "title": "Using hardcoded IP addresses is security-sensitive",
+  "type": "SECURITY_HOTSPOT",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",

--- a/sonaranalyzer-dotnet/rspec/cs/S2092_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S2092_c#.json
@@ -1,6 +1,6 @@
 {
-  "title": "Cookies should be \"secure\"",
-  "type": "VULNERABILITY",
+  "title": "Creating cookies without the \"secure\" flag is security-sensitive",
+  "type": "SECURITY_HOTSPOT",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
@@ -20,5 +20,16 @@
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-2092",
   "sqKey": "S2092",
-  "scope": "Main"
+  "scope": "Main",
+  "securityStandards": {
+    "CWE": [
+      614,
+      311,
+      315
+    ],
+    "OWASP": [
+      "A2",
+      "A3"
+    ]
+  }
 }

--- a/sonaranalyzer-dotnet/rspec/cs/S2245_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S2245_c#.json
@@ -1,6 +1,6 @@
 {
-  "title": "Pseudorandom number generators (PRNGs) should not be used in secure contexts",
-  "type": "VULNERABILITY",
+  "title": "Using pseudorandom number generators (PRNGs) is security-sensitive",
+  "type": "SECURITY_HOTSPOT",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
@@ -18,5 +18,16 @@
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-2245",
   "sqKey": "S2245",
-  "scope": "Main"
+  "scope": "Main",
+  "securityStandards": {
+    "CWE": [
+      338,
+      330,
+      326,
+      310
+    ],
+    "OWASP": [
+      "A3"
+    ]
+  }
 }

--- a/sonaranalyzer-dotnet/rspec/cs/S2255_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S2255_c#.json
@@ -1,6 +1,6 @@
 {
-  "title": "Cookies should not be used to store sensitive information",
-  "type": "VULNERABILITY",
+  "title": "Storing personal data in cookies is security-sensitive",
+  "type": "SECURITY_HOTSPOT",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
@@ -18,5 +18,14 @@
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-2255",
   "sqKey": "S2255",
-  "scope": "Main"
+  "scope": "Main",
+  "securityStandards": {
+    "CWE": [
+      315,
+      312
+    ],
+    "OWASP": [
+      "A3"
+    ]
+  }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -1726,7 +1726,7 @@
     <value>CODE_SMELL</value>
   </data>
   <data name="S1313_Category" xml:space="preserve">
-    <value>Major Vulnerability</value>
+    <value>Major Security Hotspot</value>
   </data>
   <data name="S1313_Description" xml:space="preserve">
     <value>Hardcoding an IP address into source code is a bad idea for several reasons:</value>
@@ -2716,7 +2716,7 @@
     <value>VULNERABILITY</value>
   </data>
   <data name="S2092_Category" xml:space="preserve">
-    <value>Minor Vulnerability</value>
+    <value>Minor Security Hotspot</value>
   </data>
   <data name="S2092_Description" xml:space="preserve">
     <value>The "secure" attribute prevents cookies from being sent over plaintext connections such as HTTP, where they would be easily eavesdropped upon. Instead, cookies with the secure attribute are only sent over encrypted HTTPS connections.</value>
@@ -2737,7 +2737,7 @@
     <value>Minor</value>
   </data>
   <data name="S2092_Tags" xml:space="preserve">
-    <value>cwe,spring,sans-top25-porous,owasp-a2,owasp-a3</value>
+    <value>cwe,sans-top25-porous,owasp-a2,owasp-a3</value>
   </data>
   <data name="S2092_Title" xml:space="preserve">
     <value>Creating cookies without the "secure" flag is security-sensitive</value>
@@ -3226,7 +3226,7 @@
     <value>CODE_SMELL</value>
   </data>
   <data name="S2245_Category" xml:space="preserve">
-    <value>Critical Vulnerability</value>
+    <value>Critical Security Hotspot</value>
   </data>
   <data name="S2245_Description" xml:space="preserve">
     <value>When software generates predictable values in a context requiring unpredictability, it may be possible for an attacker to guess the next value that will be generated, and use this guess to impersonate another user or access sensitive information.</value>
@@ -3256,7 +3256,7 @@
     <value>VULNERABILITY</value>
   </data>
   <data name="S2255_Category" xml:space="preserve">
-    <value>Minor Vulnerability</value>
+    <value>Minor Security Hotspot</value>
   </data>
   <data name="S2255_Description" xml:space="preserve">
     <value>Attackers can use widely-available tools to view cookies and read any sensitive information they may contain. Even if the information is encoded in a way that is not human-readable, certain techniques could determine which encoding is being used, then decode the information.</value>


### PR DESCRIPTION
Fix #1562 and fix #1588 
- to ensure backwards compatibility, the rules.xml is kept the same
- after deserializing the rules.xml at runtime, the json files are used to set the rule type and the security-specific metadata