### PR TITLE
[DO NOT SQUASH] Fix S3242: Rule should not suggest base type resulting in inconsistent accessibility

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Common/AnalyzerLanguage.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Common/AnalyzerLanguage.cs
@@ -147,5 +147,18 @@ namespace SonarAnalyzer.Common
 
             throw new NotSupportedException($"Can't get file extension for '{ToString()}'.");
         }
+
+        public static AnalyzerLanguage FromPath(string path)
+        {
+            switch (System.IO.Path.GetExtension(path).ToUpperInvariant())
+            {
+                case ".CS":
+                    return CSharp;
+                case ".VB":
+                    return VisualBasic;
+                default:
+                    return None;
+            }
+        }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/SonarAnalysisContextTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/SonarAnalysisContextTest.cs
@@ -27,6 +27,7 @@ using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Helpers
 {
@@ -106,7 +107,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
                     {
                         // Verifier expects all diagnostics to increase the counter in order to check that all rules call the
                         // extension method and not the direct `ReportDiagnostic`.
-                        Verifier.IncrementReportCount(context.Diagnostic.Id);
+                        DiagnosticVerifier.SuppressionHandler.IncrementReportCount(context.Diagnostic.Id);
                         context.ReportDiagnostic(context.Diagnostic);
                     }
                 };

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/SymbolHelperTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/SymbolHelperTest.cs
@@ -23,7 +23,9 @@ using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Helpers
 {
@@ -81,26 +83,22 @@ namespace NS
         [TestInitialize]
         public void Compile()
         {
-            using (var workspace = new AdhocWorkspace())
-            {
-                var document = workspace.CurrentSolution.AddProject("foo", "foo.dll", LanguageNames.CSharp)
-                    .AddMetadataReference(FrameworkMetadataReference.Mscorlib)
-                    .AddMetadataReference(FrameworkMetadataReference.System)
-                    .AddMetadataReference(FrameworkMetadataReference.SystemCore)
-                    .AddDocument("test", TestInput);
-                var compilation = document.Project.GetCompilationAsync().Result;
-                tree = compilation.SyntaxTrees.First();
-                semanticModel = compilation.GetSemanticModel(tree);
+            var compilation = SolutionBuilder
+                .Create()
+                .AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false)
+                .AddSnippet(TestInput)
+                .GetCompilation();
+            tree = compilation.SyntaxTrees.First();
+            semanticModel = compilation.GetSemanticModel(tree);
 
-                baseClassDeclaration = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()
-                    .First(m => m.Identifier.ValueText == "Base");
-                derivedClassDeclaration1 = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()
-                    .First(m => m.Identifier.ValueText == "Derived1");
-                derivedClassDeclaration2 = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()
-                    .First(m => m.Identifier.ValueText == "Derived2");
-                interfaceDeclaration = tree.GetRoot().DescendantNodes().OfType<InterfaceDeclarationSyntax>()
-                    .First(m => m.Identifier.ValueText == "IInterface");
-            }
+            baseClassDeclaration = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()
+                .First(m => m.Identifier.ValueText == "Base");
+            derivedClassDeclaration1 = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()
+                .First(m => m.Identifier.ValueText == "Derived1");
+            derivedClassDeclaration2 = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()
+                .First(m => m.Identifier.ValueText == "Derived2");
+            interfaceDeclaration = tree.GetRoot().DescendantNodes().OfType<InterfaceDeclarationSyntax>()
+                .First(m => m.Identifier.ValueText == "IInterface");
         }
 
         [TestMethod]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldUseBaseTypesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldUseBaseTypesTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void MethodsShouldUseBaseTypes_Internals()
         {
             var solution = SolutionBuilder.Create()
-                .AddProject("project1", AnalyzerLanguage.CSharp)
+                .AddProject(AnalyzerLanguage.CSharp)
                 .AddSnippet(@"
 internal interface IFoo
 {
@@ -46,7 +46,7 @@ public class Foo : IFoo
     public bool IsFoo { get; set; }
 }
 ")              .GetSolution()
-                .AddProject("project2", AnalyzerLanguage.CSharp)
+                .AddProject(AnalyzerLanguage.CSharp)
                 .AddProjectReference(sln => sln.ProjectIds[0])
                 .AddSnippet(@"
 internal class Bar
@@ -60,7 +60,7 @@ internal class Bar
 
             foreach (var compilation in solution.Compile())
             {
-                NewVerifier.Verify(compilation, new MethodsShouldUseBaseTypes());
+                DiagnosticVerifier.Verify(compilation, new MethodsShouldUseBaseTypes());
             }
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/CodeFixVerifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/CodeFixVerifier.cs
@@ -1,0 +1,184 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.UnitTest.TestFramework
+{
+    internal static class CodeFixVerifier
+    {
+        public static void VerifyCodeFix(string path, string pathToExpected, string pathToBatchExpected,
+            SonarDiagnosticAnalyzer diagnosticAnalyzer, SonarCodeFixProvider codeFixProvider, string codeFixTitle,
+            params MetadataReference[] additionalReferences)
+        {
+            var parseOptions = ParseOptionsHelper.GetParseOptionsByFileExtension(Path.GetExtension(path));
+
+            foreach (var parseOption in parseOptions)
+            {
+                RunCodeFixWhileDocumentChanges(diagnosticAnalyzer, codeFixProvider, codeFixTitle,
+                    CreateDocument(path, additionalReferences), parseOption, pathToExpected);
+            }
+
+            var fixAllProvider = codeFixProvider.GetFixAllProvider();
+            if (fixAllProvider == null)
+            {
+                return;
+            }
+
+            foreach (var parseOption in parseOptions)
+            {
+                RunFixAllProvider(diagnosticAnalyzer, codeFixProvider, codeFixTitle, fixAllProvider,
+                    CreateDocument(path, additionalReferences), parseOption, pathToBatchExpected);
+            }
+        }
+
+        private static Document CreateDocument(string path, params MetadataReference[] additionalReferences) =>
+            SolutionBuilder.Create()
+                .AddProject(AnalyzerLanguage.FromPath(path))
+                .AddReferences(additionalReferences)
+                .AddDocument(path, true)
+                .FindDocument(Path.GetFileName(path));
+
+        private static void RunCodeFixWhileDocumentChanges(DiagnosticAnalyzer diagnosticAnalyzer, CodeFixProvider codeFixProvider,
+            string codeFixTitle, Document document, ParseOptions parseOption, string pathToExpected)
+        {
+            var currentDocument = document;
+            CalculateDiagnosticsAndCode(diagnosticAnalyzer, currentDocument, parseOption, out var diagnostics, out var actualCode);
+
+            diagnostics.Should().NotBeEmpty();
+
+            string codeBeforeFix;
+            var codeFixExecutedAtLeastOnce = false;
+
+            do
+            {
+                codeBeforeFix = actualCode;
+
+                var codeFixExecuted = false;
+                for (var diagnosticIndexToFix = 0; !codeFixExecuted && diagnosticIndexToFix < diagnostics.Count; diagnosticIndexToFix++)
+                {
+                    var codeActionsForDiagnostic = GetCodeActionsForDiagnostic(codeFixProvider, currentDocument, diagnostics[diagnosticIndexToFix]);
+
+                    if (TryGetCodeActionToApply(codeFixTitle, codeActionsForDiagnostic, out var codeActionToExecute))
+                    {
+                        currentDocument = ApplyCodeFix(currentDocument, codeActionToExecute);
+                        CalculateDiagnosticsAndCode(diagnosticAnalyzer, currentDocument, parseOption, out diagnostics, out actualCode);
+
+                        codeFixExecutedAtLeastOnce = true;
+                        codeFixExecuted = true;
+                    }
+                }
+            } while (codeBeforeFix != actualCode);
+
+            codeFixExecutedAtLeastOnce.Should().BeTrue();
+
+            AreEqualIgnoringLineEnding(pathToExpected, actualCode);
+        }
+
+        private static void AreEqualIgnoringLineEnding(string pathToExpected, string actualCode)
+        {
+            const string WindowsLineEnding = "\r\n";
+            const string UnixLineEnding = "\n";
+
+            var actualWithUnixLineEnding = actualCode.Replace(WindowsLineEnding, UnixLineEnding);
+            var expectedWithUnixLineEnding = File.ReadAllText(pathToExpected).Replace(WindowsLineEnding, UnixLineEnding);
+            actualWithUnixLineEnding.Should().Be(expectedWithUnixLineEnding);
+        }
+
+        private static void RunFixAllProvider(DiagnosticAnalyzer diagnosticAnalyzer, CodeFixProvider codeFixProvider,
+            string codeFixTitle, FixAllProvider fixAllProvider, Document document, ParseOptions parseOption, string pathToExpected)
+        {
+            var currentDocument = document;
+            CalculateDiagnosticsAndCode(diagnosticAnalyzer, currentDocument, parseOption, out var diagnostics, out var actualCode);
+
+            diagnostics.Should().NotBeEmpty();
+
+            var fixAllDiagnosticProvider = new FixAllDiagnosticProvider(
+                codeFixProvider.FixableDiagnosticIds.ToHashSet(),
+                (doc, ids, ct) => Task.FromResult(
+                    DiagnosticVerifier.GetDiagnostics(currentDocument.Project.GetCompilationAsync(ct).Result, diagnosticAnalyzer)),
+                null);
+
+            var fixAllContext = new FixAllContext(currentDocument, codeFixProvider, FixAllScope.Document,
+                codeFixTitle, codeFixProvider.FixableDiagnosticIds, fixAllDiagnosticProvider, CancellationToken.None);
+            var codeActionToExecute = fixAllProvider.GetFixAsync(fixAllContext).Result;
+
+            codeActionToExecute.Should().NotBeNull();
+
+            currentDocument = ApplyCodeFix(currentDocument, codeActionToExecute);
+
+            CalculateDiagnosticsAndCode(diagnosticAnalyzer, currentDocument, parseOption, out diagnostics, out actualCode);
+
+            AreEqualIgnoringLineEnding(pathToExpected, actualCode);
+        }
+
+        private static void CalculateDiagnosticsAndCode(DiagnosticAnalyzer diagnosticAnalyzer, Document document, ParseOptions parseOption,
+            out List<Diagnostic> diagnostics,
+            out string actualCode)
+        {
+            var project = document.Project;
+            if (parseOption != null)
+            {
+                project = project.WithParseOptions(parseOption);
+            }
+
+            diagnostics = DiagnosticVerifier.GetDiagnostics(project.GetCompilationAsync().Result, diagnosticAnalyzer).ToList();
+            actualCode = document.GetSyntaxRootAsync().Result.GetText().ToString();
+        }
+
+        private static Document ApplyCodeFix(Document document, CodeAction codeAction)
+        {
+            var operations = codeAction.GetOperationsAsync(CancellationToken.None).Result;
+            var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
+            return solution.GetDocument(document.Id);
+        }
+
+        private static bool TryGetCodeActionToApply(string codeFixTitle, IEnumerable<CodeAction> codeActions,
+            out CodeAction codeAction)
+        {
+            codeAction = codeFixTitle != null
+                ? codeActions.SingleOrDefault(action => action.Title == codeFixTitle)
+                : codeActions.FirstOrDefault();
+
+            return codeAction != null;
+        }
+
+        private static IEnumerable<CodeAction> GetCodeActionsForDiagnostic(CodeFixProvider codeFixProvider, Document document,
+            Diagnostic diagnostic)
+        {
+            var actions = new List<CodeAction>();
+            var context = new CodeFixContext(document, diagnostic, (a, d) => actions.Add(a), CancellationToken.None);
+
+            codeFixProvider.RegisterCodeFixesAsync(context).Wait();
+            return actions;
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/NewVerifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/NewVerifier.cs
@@ -1,0 +1,249 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+using CS = Microsoft.CodeAnalysis.CSharp;
+using VB = Microsoft.CodeAnalysis.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.TestFramework
+{
+    public static class NewVerifier
+    {
+        private const string AnalyzerFailedDiagnosticId = "AD0001";
+
+        public static void Verify(string path, DiagnosticAnalyzer analyzer, params MetadataReference[] additionalReferences)
+        {
+            var solution = SolutionBuilder
+                .Create()
+                .AddProject("TestProject", Path.GetExtension(path))
+                .AddDocument(path)
+                .AddReferences(additionalReferences)
+                .GetSolution();
+
+            foreach (var compilation in solution.Compile())
+            {
+                Verify(compilation, analyzer);
+            }
+        }
+
+        public static void VerifySnippet(string snippet, AnalyzerLanguage language, DiagnosticAnalyzer analyzer,
+            params MetadataReference[] additionalReferences)
+        {
+            var solution = SolutionBuilder
+               .Create()
+               .AddProject("TestProject", language)
+               .AddSnippet(snippet)
+               .AddReferences(additionalReferences)
+               .GetSolution();
+
+            // TODO: add [CallerLineNumber]int lineNumber = 0
+            // then add ability to shift result reports with this line number
+            foreach (var compilation in solution.Compile())
+            {
+                Verify(compilation, analyzer);
+            }
+        }
+
+        public static void Verify(Compilation compilation, DiagnosticAnalyzer diagnosticAnalyzer, Action<DiagnosticAnalyzer, Compilation> additionalVerify = null)
+        {
+            try
+            {
+                SuppressionHandler.HookSuppression();
+
+                var diagnostics = GetDiagnostics(compilation, diagnosticAnalyzer);
+
+                var expectedIssues = new IssueLocationCollector()
+                    .GetExpectedIssueLocations(compilation.SyntaxTrees.Skip(1).First().GetText().Lines)
+                    .ToList();
+
+                foreach (var diagnostic in diagnostics)
+                {
+                    VerifyIssue(expectedIssues, issue => issue.IsPrimary, diagnostic.Location, diagnostic.GetMessage(), out var issueId);
+
+                    diagnostic.AdditionalLocations
+                        .Select((location, i) => diagnostic.GetSecondaryLocation(i))
+                        .OrderBy(x => x.Location.GetLineNumberToReport())
+                        .ThenBy(x => x.Location.GetLineSpan().StartLinePosition.Character)
+                        .ToList()
+                        .ForEach(secondaryLocation =>
+                        {
+                            VerifyIssue(expectedIssues, issue => issue.IssueId == issueId && !issue.IsPrimary,
+                                secondaryLocation.Location, secondaryLocation.Message, out issueId);
+                        });
+                }
+
+                if (expectedIssues.Count != 0)
+                {
+                    Execute.Assertion.FailWith($"Issue expected but not raised on line(s) {string.Join(",", expectedIssues.Select(i => i.LineNumber))}.");
+                }
+
+                // When there are no diagnostics reported from the test (for example the FileLines analyzer
+                // does not report in each call to Verifier.VerifyAnalyzer) we skip the check for the extension
+                // method.
+                if (diagnostics.Any())
+                {
+                    SuppressionHandler.ExtensionMethodsCalledForAllDiagnostics(diagnosticAnalyzer).Should()
+                        .BeTrue("The ReportDiagnosticWhenActive should be used instead of ReportDiagnostic");
+                }
+
+                additionalVerify?.Invoke(diagnosticAnalyzer, compilation);
+            }
+            finally
+            {
+                SuppressionHandler.UnHookSuppression();
+            }
+        }
+
+        private static void VerifyIssue(IList<IIssueLocation> expectedIssues, Func<IIssueLocation, bool> issueFilter, Location location, string message, out string issueId)
+        {
+            var lineNumber = location.GetLineNumberToReport();
+
+            var expectedIssue = expectedIssues
+                .Where(issueFilter)
+                .FirstOrDefault(issue => issue.LineNumber == lineNumber);
+
+            if (expectedIssue == null)
+            {
+                Execute.Assertion.FailWith($"Issue with message '{message}' not expected on line {lineNumber}");
+            }
+
+            if (expectedIssue.Message != null && expectedIssue.Message != message)
+            {
+                Execute.Assertion.FailWith($"Expected message on line {lineNumber} to be '{expectedIssue.Message}', but got '{message}'.");
+            }
+
+            var diagnosticStart = location.GetLineSpan().StartLinePosition.Character;
+
+            if (expectedIssue.Start.HasValue && expectedIssue.Start != diagnosticStart)
+            {
+                Execute.Assertion.FailWith(
+                    $"Expected issue on line {lineNumber} to start on column {expectedIssue.Start} but got column {diagnosticStart}.");
+            }
+
+            if (expectedIssue.Length.HasValue && expectedIssue.Length != location.SourceSpan.Length)
+            {
+                Execute.Assertion.FailWith(
+                    $"Expected issue on line {lineNumber} to have a length of {expectedIssue.Length} but got a length of {location.SourceSpan.Length}).");
+            }
+
+            expectedIssues.Remove(expectedIssue);
+
+            issueId = expectedIssue.IssueId;
+        }
+
+        internal static IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation, DiagnosticAnalyzer diagnosticAnalyzer)
+        {
+            var ids = new HashSet<string>(diagnosticAnalyzer.SupportedDiagnostics.Select(diagnostic => diagnostic.Id));
+
+            var diagnostics = GetAllDiagnostics(compilation, new[] { diagnosticAnalyzer }).ToList();
+            VerifyNoExceptionThrown(diagnostics);
+
+            return diagnostics.Where(d => ids.Contains(d.Id));
+        }
+
+        private static void VerifyNoExceptionThrown(IEnumerable<Diagnostic> diagnostics)
+        {
+            diagnostics.Where(d => d.Id == AnalyzerFailedDiagnosticId).Should().BeEmpty();
+        }
+
+        private static IEnumerable<Diagnostic> GetAllDiagnostics(Compilation compilation,
+            IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers)
+        {
+            var compilationOptions = compilation.Language == LanguageNames.CSharp
+                ? (CompilationOptions)new CS.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true)
+                : new VB.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+            var supportedDiagnostics = diagnosticAnalyzers
+                    .SelectMany(analyzer => analyzer.SupportedDiagnostics)
+                    .ToList();
+            compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                supportedDiagnostics
+                    .Select(diagnostic =>
+                        new KeyValuePair<string, ReportDiagnostic>(diagnostic.Id, ReportDiagnostic.Warn))
+                    .Union(
+                        new[]
+                        {
+                                new KeyValuePair<string, ReportDiagnostic>(AnalyzerFailedDiagnosticId, ReportDiagnostic.Error)
+                        }));
+
+            var compilationWithOptions = compilation.WithOptions(compilationOptions);
+            var compilationWithAnalyzer = compilationWithOptions
+                .WithAnalyzers(diagnosticAnalyzers.ToImmutableArray());
+
+            return compilationWithAnalyzer.GetAllDiagnosticsAsync().Result;
+        }
+
+        private static class SuppressionHandler
+        {
+            private static bool isHooked = false;
+
+            private static ConcurrentDictionary<string, int> counters = new ConcurrentDictionary<string, int>();
+
+            public static void HookSuppression()
+            {
+                if (isHooked)
+                {
+                    return;
+                }
+                isHooked = true;
+
+                SonarAnalysisContext.ShouldDiagnosticBeReported = (s, d) => { IncrementReportCount(d.Id); return true; };
+            }
+
+            public static void UnHookSuppression()
+            {
+                if (!isHooked)
+                {
+                    return;
+                }
+                isHooked = false;
+
+                SonarAnalysisContext.ShouldDiagnosticBeReported = null;
+            }
+
+            internal static void IncrementReportCount(string ruleId)
+            {
+                counters.AddOrUpdate(ruleId, addValueFactory: key => 1, updateValueFactory: (key, count) => count + 1);
+            }
+
+            public static bool ExtensionMethodsCalledForAllDiagnostics(DiagnosticAnalyzer analyzer)
+            {
+                // In general this check is not very precise, because when the tests are run in parallel
+                // we cannot determine which diagnostic was reported from which analyzer instance. In other
+                // words, we cannot distinguish between diagnostics reported from different tests. That's
+                // why we require each diagnostic to be reported through the extension methods at least once.
+                return analyzer.SupportedDiagnostics
+                    .Select(d => counters.GetValueOrDefault(d.Id))
+                    .Any(count => count > 0);
+            }
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/ParseOptionsHelper.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/ParseOptionsHelper.cs
@@ -1,0 +1,84 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.Helpers;
+using CS = Microsoft.CodeAnalysis.CSharp;
+using VB = Microsoft.CodeAnalysis.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.TestFramework
+{
+    internal static class ParseOptionsHelper
+    {
+        private static readonly IEnumerable<ParseOptions> defaultParseOptions =
+            ImmutableArray.Create<ParseOptions>(
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp5),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp6),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7),
+                new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic12),
+                new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic14),
+                new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic15));
+
+        public static IEnumerable<ParseOptions> GetParseOptionsOrDefault(IEnumerable<ParseOptions> parseOptions) =>
+            parseOptions != null && parseOptions.WhereNotNull().Any()
+                ? parseOptions
+                : defaultParseOptions;
+
+        public static IEnumerable<ParseOptions> GetParseOptions(Func<ParseOptions, bool> filter) =>
+            defaultParseOptions.Where(filter);
+
+        public static IEnumerable<ParseOptions> GetParseOptionsByFileExtension(string extension) =>
+            defaultParseOptions.Where(GetFilterByFileExtension(extension));
+
+        public static Func<ParseOptions, bool> GetFilterByLanguage(string language)
+        {
+            if (language == LanguageNames.CSharp)
+            {
+                return CSharpFilter;
+            }
+            else if (language == LanguageNames.VisualBasic)
+            {
+                return VisualBasicFilter;
+            }
+            throw new NotSupportedException($"Not supported language '{language}'");
+        }
+
+        public static Func<ParseOptions, bool> GetFilterByFileExtension(string extension)
+        {
+            if (extension == ".cs")
+            {
+                return CSharpFilter;
+            }
+            else if (extension == ".vb")
+            {
+                return VisualBasicFilter;
+            }
+            throw new NotSupportedException($"Not supported language extension '{extension}'");
+        }
+
+        private static Func<ParseOptions, bool> VisualBasicFilter = (options) => options is VB.VisualBasicParseOptions;
+
+        private static Func<ParseOptions, bool> CSharpFilter = (options) => options is CS.CSharpParseOptions;
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/ProjectBuilder.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/ProjectBuilder.cs
@@ -1,0 +1,147 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+
+namespace SonarAnalyzer.UnitTest.TestFramework
+{
+    public struct ProjectBuilder
+    {
+        private const string FIXED_MESSAGE = "Fixed";
+
+        private readonly Lazy<SolutionBuilder> solutionWrapper;
+
+        public Project Project { get; }
+
+        public SolutionBuilder GetSolution() =>
+            solutionWrapper.Value;
+
+        private ProjectBuilder(Project project)
+        {
+            Project = project;
+            solutionWrapper = new Lazy<SolutionBuilder>(() => SolutionBuilder.FromSolution(project.Solution));
+        }
+
+        public ProjectBuilder AddReference(MetadataReference reference) =>
+            FromProject(Project.AddMetadataReference(reference));
+
+        public ProjectBuilder AddReferences(IEnumerable<MetadataReference> reference) =>
+            FromProject(Project.AddMetadataReferences(reference));
+
+        public ProjectBuilder AddProjectReference(Func<SolutionBuilder, ProjectId> getProjectId) =>
+            FromProject(Project.AddProjectReference(new ProjectReference(getProjectId(GetSolution()))));
+
+        public ProjectBuilder AddProjectReferences(Func<SolutionBuilder, IEnumerable<ProjectId>> getProjectIds) =>
+            FromProject(Project.AddProjectReferences(getProjectIds(GetSolution()).Select(id => new ProjectReference(id))));
+
+        public ProjectBuilder AddDocuments(IEnumerable<string> paths, bool removeAnalysisComments = false)
+        {
+            var projectBuilder = this;
+            foreach (var path in paths)
+            {
+                projectBuilder = projectBuilder.AddDocument(path, removeAnalysisComments);
+            }
+            return projectBuilder;
+        }
+
+        public ProjectBuilder AddDocument(string path, bool removeAnalysisComments = false)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            var fileInfo = new FileInfo(path);
+
+            if (fileInfo.Extension != GetFileExtension(Project))
+            {
+                throw new ArgumentException($"The file extension '{fileInfo.Extension}' does not" +
+                    $" match the project language '{Project.Language}'.", nameof(path));
+            }
+
+            return AddDocument(Project, fileInfo.Name, File.ReadAllText(fileInfo.FullName, Encoding.UTF8), removeAnalysisComments);
+        }
+
+        public ProjectBuilder AddSnippet(string code, string fileName = null, bool removeAnalysisComments = false)
+        {
+            if (code == null)
+            {
+                throw new ArgumentNullException(nameof(code));
+            }
+
+            fileName = fileName ?? $"snippet{Project.Documents.Count()}{GetFileExtension(Project)}";
+
+            return AddDocument(Project, fileName, code, removeAnalysisComments);
+        }
+
+        private static ProjectBuilder AddDocument(Project project, string fileName, string fileContent, bool removeAnalysisComments)
+        {
+            return FromProject(project.AddDocument(fileName, ReadDocument()).Project);
+
+            string ReadDocument()
+            {
+                const string WindowsLineEnding = "\r\n";
+                const string UnixLineEnding = "\n";
+
+                var lines = fileContent
+                    .Replace(WindowsLineEnding, UnixLineEnding) // This allows to deal with multiple line endings
+                    .Split(new[] { UnixLineEnding }, StringSplitOptions.None);
+
+                if (removeAnalysisComments)
+                {
+                    lines = lines.Where(IssueLocationCollector.IsNotIssueLocationLine)
+                        .Select(ReplaceNonCompliantComment)
+                        .ToArray();
+                }
+
+                return string.Join(UnixLineEnding, lines);
+            }
+        }
+
+        private static string ReplaceNonCompliantComment(string line)
+        {
+            var match = Regex.Match(line, IssueLocationCollector.ISSUE_LOCATION_PATTERN);
+            if (!match.Success)
+            {
+                return line;
+            }
+
+            if (match.Groups["issueType"].Value == "Noncompliant")
+            {
+                var startIndex = line.IndexOf(match.Groups["issueType"].Value);
+                return string.Concat(line.Remove(startIndex), FIXED_MESSAGE);
+            }
+
+            return line.Replace(match.Value, string.Empty).TrimEnd();
+        }
+
+        private static string GetFileExtension(Project project) =>
+            project.Language == LanguageNames.CSharp ? ".cs" : ".vb";
+
+        public static ProjectBuilder FromProject(Project project) =>
+            new ProjectBuilder(project);
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
@@ -1,0 +1,123 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.Common;
+using CS = Microsoft.CodeAnalysis.CSharp;
+using VB = Microsoft.CodeAnalysis.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.TestFramework
+{
+    public struct SolutionBuilder
+    {
+        private readonly Solution solution;
+
+        public IReadOnlyList<ProjectId> ProjectIds => solution.ProjectIds;
+
+        public ImmutableArray<ParseOptions> DefaultParseOptions { get; }
+
+        private SolutionBuilder(Solution solution)
+        {
+            this.solution = solution;
+
+            DefaultParseOptions = ImmutableArray.Create<ParseOptions>(
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp5),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp6),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7),
+                new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic12),
+                new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic14),
+                new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic15)
+            );
+        }
+
+        public ProjectBuilder AddProject(string projectName, string fileExtension)
+        {
+            var language = fileExtension == GetFileExtension(AnalyzerLanguage.CSharp)
+               ? AnalyzerLanguage.CSharp
+               : AnalyzerLanguage.VisualBasic;
+
+            return AddProject(projectName, language);
+        }
+
+        public ProjectBuilder AddProject(string projectName, AnalyzerLanguage language)
+        {
+            var project = solution.AddProject(projectName, projectName, GetLanguageName(language));
+
+            return ProjectBuilder.FromProject(project)
+                .AddReference(MetadataReferenceHelper.FromFrameworkAssembly("mscorlib.dll"))
+                .AddReference(MetadataReferenceHelper.FromFrameworkAssembly("System.dll"))
+                .AddReference(MetadataReferenceHelper.FromFrameworkAssembly("System.Core.dll"))
+
+                // adding an extra file to the project
+                // this won't trigger any issues, but it keeps a reference to the original ParseOption, so
+                // if an analyzer/codefix changes the language version, Roslyn throws an ArgumentException
+                .AddSnippet(string.Empty, fileName: "ExtraEmptyFile.g." + language.GetFileExtension());
+        }
+
+        private static string GetLanguageName(AnalyzerLanguage language) =>
+            language == AnalyzerLanguage.CSharp
+                ? LanguageNames.CSharp
+                : LanguageNames.VisualBasic;
+
+        public static SolutionBuilder Create() =>
+            FromSolution(new AdhocWorkspace().CurrentSolution);
+
+        public static SolutionBuilder FromSolution(Solution solution) =>
+            new SolutionBuilder(solution);
+
+        public IReadOnlyList<Compilation> Compile(IEnumerable<ParseOptions> parseOptions = null)
+        {
+            parseOptions = parseOptions ?? DefaultParseOptions;
+
+            return solution
+                .Projects
+                .SelectMany(project => parseOptions
+                    .Where(GetParseOptionsFilter(project.Language))
+                    .Select(options => GetCompilation(project, options)))
+                .ToList()
+                .AsReadOnly();
+        }
+        private static Compilation GetCompilation(Project project, ParseOptions options) =>
+            project
+                .WithParseOptions(options)
+                .GetCompilationAsync()
+                .Result;
+
+        private static Func<ParseOptions, bool> GetParseOptionsFilter(string language)
+        {
+            if (language == LanguageNames.CSharp)
+            {
+                return parseOptions => parseOptions is CS.CSharpParseOptions;
+            }
+            else if (language == LanguageNames.VisualBasic)
+            {
+                return parseOptions => parseOptions is VB.VisualBasicParseOptions;
+            }
+            throw new NotSupportedException($"Not supported language '{language}'");
+        }
+
+        private static string GetFileExtension(AnalyzerLanguage language) =>
+            "." + language.GetFileExtension();
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Verifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Verifier.cs
@@ -19,251 +19,140 @@
  */
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using FluentAssertions;
-using FluentAssertions.Execution;
 using Google.Protobuf;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules;
 using SonarAnalyzer.UnitTest.TestFramework;
-using CS = Microsoft.CodeAnalysis.CSharp;
-using VB = Microsoft.CodeAnalysis.VisualBasic;
 
 namespace SonarAnalyzer.UnitTest
 {
     internal static class Verifier
     {
-        private const string FIXED_MESSAGE = "Fixed";
-
-        private const string GeneratedAssemblyName = "foo";
-        private const string TestAssemblyName = "fooTest";
-        private const string AnalyzerFailedDiagnosticId = "AD0001";
-        private const string CSharpFileExtension = ".cs";
-        private const string VisualBasicFileExtension = ".vb";
-
-        private const string WindowsLineEnding = "\r\n";
-        private const string UnixLineEnding = "\n";
-
-        #region Verify
-
         public static void VerifyNoExceptionThrown(string path, IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers)
         {
-            using (var workspace = new AdhocWorkspace())
-            {
-                var file = new FileInfo(path);
-                var project = CreateProject(file.Extension, GeneratedAssemblyName, workspace).AddDocument(new DocumentInfo(file));
-                var compilation = project.GetCompilationAsync().Result;
-                var diagnostics = GetAllDiagnostics(compilation, diagnosticAnalyzers);
-                VerifyNoExceptionThrown(diagnostics);
-            }
+            var compilation = SolutionBuilder
+                .Create()
+                .AddProject(AnalyzerLanguage.FromPath(path))
+                .AddDocument(path)
+                .GetCompilation();
+
+            var diagnostics = DiagnosticVerifier.GetAllDiagnostics(compilation, diagnosticAnalyzers);
         }
 
         public static void VerifyCSharpAnalyzer(string snippet, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            ParseOptions options = null, params MetadataReference[] additionalReferences)
+            params MetadataReference[] additionalReferences)
         {
-            VerifyAnalyzer(new[] { new DocumentInfo($"file1{CSharpFileExtension}", snippet) },
-                CSharpFileExtension, diagnosticAnalyzer, options, null, additionalReferences);
+            var solution = SolutionBuilder
+               .Create()
+               .AddProject(AnalyzerLanguage.CSharp)
+               .AddSnippet(snippet)
+               .AddReferences(additionalReferences)
+               .GetSolution();
+
+            // TODO: add [CallerLineNumber]int lineNumber = 0
+            // then add ability to shift result reports with this line number
+            foreach (var compilation in solution.Compile())
+            {
+                DiagnosticVerifier.Verify(compilation, diagnosticAnalyzer);
+            }
         }
 
         public static void VerifyVisualBasicAnalyzer(string snippet, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            ParseOptions options = null, params MetadataReference[] additionalReferences)
+            params MetadataReference[] additionalReferences)
         {
-            VerifyAnalyzer(new[] { new DocumentInfo($"file1{VisualBasicFileExtension}", snippet) },
-                VisualBasicFileExtension, diagnosticAnalyzer, options, null, additionalReferences);
+            var solution = SolutionBuilder
+               .Create()
+               .AddProject(AnalyzerLanguage.VisualBasic)
+               .AddSnippet(snippet)
+               .AddReferences(additionalReferences)
+               .GetSolution();
+
+            // TODO: add [CallerLineNumber]int lineNumber = 0
+            // then add ability to shift result reports with this line number
+            foreach (var compilation in solution.Compile())
+            {
+                DiagnosticVerifier.Verify(compilation, diagnosticAnalyzer);
+            }
         }
 
         public static void VerifyAnalyzer(string path, SonarDiagnosticAnalyzer diagnosticAnalyzer,
             ParseOptions options = null, params MetadataReference[] additionalReferences)
         {
-            VerifyAnalyzer(new[] { path }, diagnosticAnalyzer, null, options, additionalReferences);
+            VerifyAnalyzer(new[] { path }, diagnosticAnalyzer, options, additionalReferences);
         }
 
         public static void VerifyUtilityAnalyzer<TMessage>(IEnumerable<string> paths, UtilityAnalyzerBase diagnosticAnalyzer,
             string protobufPath, Action<IList<TMessage>> verifyProtobuf)
             where TMessage : IMessage<TMessage>, new()
         {
-            VerifyAnalyzer(paths, diagnosticAnalyzer, (analyzer, compilation) =>
+            var solutionBuilder = SolutionBuilder.CreateSolutionFromPaths(paths);
+
+            foreach (var compilation in solutionBuilder.Compile())
             {
-                verifyProtobuf(ReadProtobuf<TMessage>(protobufPath).ToList());
-            });
+                DiagnosticVerifier.Verify(compilation, diagnosticAnalyzer);
+
+                verifyProtobuf(ReadProtobuf(protobufPath).ToList());
+            }
+
+            IEnumerable<TMessage> ReadProtobuf(string path)
+            {
+                using (var input = File.OpenRead(path))
+                {
+                    var parser = new MessageParser<TMessage>(() => new TMessage());
+                    while (input.Position < input.Length)
+                    {
+                        yield return parser.ParseDelimitedFrom(input);
+                    }
+                }
+            }
         }
 
         public static void VerifyAnalyzer(IEnumerable<string> paths, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            Action<DiagnosticAnalyzer, Compilation> additionalVerify = null, ParseOptions options = null,
-            params MetadataReference[] additionalReferences)
+            ParseOptions options = null, params MetadataReference[] additionalReferences)
         {
-            if (paths == null || !paths.Any())
+            var solutionBuilder = SolutionBuilder.CreateSolutionFromPaths(paths, additionalReferences);
+
+            foreach (var compilation in solutionBuilder.Compile(options))
             {
-                throw new ArgumentException("Please specify at least one file path to analyze.", nameof(paths));
+                DiagnosticVerifier.Verify(compilation, diagnosticAnalyzer);
             }
-
-            var files = paths.Select(path => new FileInfo(path)).ToList();
-            if (files.Select(file => file.Extension).Distinct().Count() != 1)
-            {
-                throw new ArgumentException("Please use a collection of paths with the same extension", nameof(paths));
-            }
-
-            var fileExtension = files[0].Extension;
-
-            var fileContents = files.Select(file => new DocumentInfo(file));
-
-            VerifyAnalyzer(fileContents, fileExtension, diagnosticAnalyzer, options, additionalVerify, additionalReferences);
-        }
-
-        private static IEnumerable<TMessage> ReadProtobuf<TMessage>(string path)
-            where TMessage : IMessage<TMessage>, new()
-        {
-            using (var input = File.OpenRead(path))
-            {
-                var parser = new MessageParser<TMessage>(() => new TMessage());
-                while (input.Position < input.Length)
-                {
-                    yield return parser.ParseDelimitedFrom(input);
-                }
-            }
-        }
-
-        private static void VerifyAnalyzer(IEnumerable<DocumentInfo> documents, string fileExtension,
-            DiagnosticAnalyzer diagnosticAnalyzer, ParseOptions options = null,
-            Action<DiagnosticAnalyzer, Compilation> additionalVerify = null, params MetadataReference[] additionalReferences)
-        {
-            try
-            {
-                HookSuppression();
-
-                var parseOptions = GetParseOptionsAlternatives(options, fileExtension);
-
-                using (var workspace = new AdhocWorkspace())
-                {
-                    var project = CreateProject(fileExtension, GeneratedAssemblyName, workspace, additionalReferences);
-                    foreach (var document in documents)
-                    {
-                        project = project.AddDocument(document, false);
-                    }
-
-                    var issueLocationCollector = new IssueLocationCollector();
-
-                    foreach (var parseOption in parseOptions)
-                    {
-                        if (parseOption != null)
-                        {
-                            project = project.WithParseOptions(parseOption);
-                        }
-
-                        var compilation = project.GetCompilationAsync().Result;
-
-                        var diagnostics = GetDiagnostics(compilation, diagnosticAnalyzer);
-
-                        var expectedIssues = issueLocationCollector
-                            .GetExpectedIssueLocations(compilation.SyntaxTrees.Skip(1).First().GetText().Lines)
-                            .ToList();
-
-                        foreach (var diagnostic in diagnostics)
-                        {
-                            VerifyIssue(expectedIssues, issue => issue.IsPrimary, diagnostic.Location, diagnostic.GetMessage(), out var issueId);
-
-                            diagnostic.AdditionalLocations
-                                .Select((location, i) => diagnostic.GetSecondaryLocation(i))
-                                .OrderBy(x => x.Location.GetLineNumberToReport())
-                                .ThenBy(x => x.Location.GetLineSpan().StartLinePosition.Character)
-                                .ToList()
-                                .ForEach(secondaryLocation =>
-                                {
-                                    VerifyIssue(expectedIssues, issue => issue.IssueId == issueId && !issue.IsPrimary,
-                                        secondaryLocation.Location, secondaryLocation.Message, out issueId);
-                                });
-                        }
-
-                        if (expectedIssues.Count != 0)
-                        {
-                            Execute.Assertion.FailWith($"Issue expected but not raised on line(s) {string.Join(",", expectedIssues.Select(i => i.LineNumber))}.");
-                        }
-
-                        // When there are no diagnostics reported from the test (for example the FileLines analyzer
-                        // does not report in each call to Verifier.VerifyAnalyzer) we skip the check for the extension
-                        // method.
-                        if (diagnostics.Any())
-                        {
-                            ExtensionMethodsCalledForAllDiagnostics(diagnosticAnalyzer).Should().BeTrue("The ReportDiagnosticWhenActive should be used instead of ReportDiagnostic");
-                        }
-
-                        additionalVerify?.Invoke(diagnosticAnalyzer, compilation);
-                    }
-                }
-            }
-            finally
-            {
-                UnHookSuppression();
-            }
-        }
-
-        private static void VerifyIssue(IList<IIssueLocation> expectedIssues, Func<IIssueLocation, bool> issueFilter, Location location, string message, out string issueId)
-        {
-            var lineNumber = location.GetLineNumberToReport();
-
-            var expectedIssue = expectedIssues
-                .Where(issueFilter)
-                .FirstOrDefault(issue => issue.LineNumber == lineNumber);
-
-            if (expectedIssue == null)
-            {
-                Execute.Assertion.FailWith($"Issue with message '{message}' not expected on line {lineNumber}");
-            }
-
-            if (expectedIssue.Message != null && expectedIssue.Message != message)
-            {
-                Execute.Assertion.FailWith($"Expected message on line {lineNumber} to be '{expectedIssue.Message}', but got '{message}'.");
-            }
-
-            var diagnosticStart = location.GetLineSpan().StartLinePosition.Character;
-
-            if (expectedIssue.Start.HasValue && expectedIssue.Start != diagnosticStart)
-            {
-                Execute.Assertion.FailWith(
-                    $"Expected issue on line {lineNumber} to start on column {expectedIssue.Start} but got column {diagnosticStart}.");
-            }
-
-            if (expectedIssue.Length.HasValue && expectedIssue.Length != location.SourceSpan.Length)
-            {
-                Execute.Assertion.FailWith(
-                    $"Expected issue on line {lineNumber} to have a length of {expectedIssue.Length} but got a length of {location.SourceSpan.Length}).");
-            }
-
-            expectedIssues.Remove(expectedIssue);
-
-            issueId = expectedIssue.IssueId;
         }
 
         public static void VerifyNoIssueReportedInTest(string path, SonarDiagnosticAnalyzer diagnosticAnalyzer,
             params MetadataReference[] additionalReferences)
         {
-            VerifyNoIssueReported(path, TestAssemblyName, diagnosticAnalyzer, additionalReferences);
+            var compilation = SolutionBuilder.Create()
+                .AddTestProject(AnalyzerLanguage.FromPath(path))
+                .AddReferences(additionalReferences)
+                .AddDocument(path)
+                .GetCompilation();
+
+            DiagnosticVerifier.VerifyNoIssueReported(compilation, diagnosticAnalyzer);
         }
 
         public static void VerifyNoIssueReported(string path, SonarDiagnosticAnalyzer diagnosticAnalyzer, ParseOptions options = null,
             params MetadataReference[] additionalReferences)
         {
-            VerifyNoIssueReported(path, GeneratedAssemblyName, diagnosticAnalyzer, additionalReferences, options);
+            var compilation = SolutionBuilder.Create()
+                .AddProject(AnalyzerLanguage.FromPath(path))
+                .AddReferences(additionalReferences)
+                .AddDocument(path)
+                .GetCompilation(options);
+
+            DiagnosticVerifier.VerifyNoIssueReported(compilation, diagnosticAnalyzer);
         }
 
         public static void VerifyCodeFix(string path, string pathToExpected,
             SonarDiagnosticAnalyzer diagnosticAnalyzer, SonarCodeFixProvider codeFixProvider,
             params MetadataReference[] additionalReferences)
         {
-            VerifyCodeFix(path, pathToExpected, pathToExpected, diagnosticAnalyzer, codeFixProvider,
+            CodeFixVerifier.VerifyCodeFix(path, pathToExpected, pathToExpected, diagnosticAnalyzer, codeFixProvider,
                 null, additionalReferences);
         }
 
@@ -271,7 +160,7 @@ namespace SonarAnalyzer.UnitTest
             SonarDiagnosticAnalyzer diagnosticAnalyzer, SonarCodeFixProvider codeFixProvider,
             params MetadataReference[] additionalReferences)
         {
-            VerifyCodeFix(path, pathToExpected, pathToBatchExpected, diagnosticAnalyzer, codeFixProvider,
+            CodeFixVerifier.VerifyCodeFix(path, pathToExpected, pathToBatchExpected, diagnosticAnalyzer, codeFixProvider,
                 null, additionalReferences);
         }
 
@@ -279,390 +168,8 @@ namespace SonarAnalyzer.UnitTest
             SonarDiagnosticAnalyzer diagnosticAnalyzer, SonarCodeFixProvider codeFixProvider, string codeFixTitle,
             params MetadataReference[] additionalReferences)
         {
-            VerifyCodeFix(path, pathToExpected, pathToExpected, diagnosticAnalyzer, codeFixProvider,
+            CodeFixVerifier.VerifyCodeFix(path, pathToExpected, pathToExpected, diagnosticAnalyzer, codeFixProvider,
                 codeFixTitle, additionalReferences);
-        }
-
-        public static void VerifyCodeFix(string path, string pathToExpected, string pathToBatchExpected,
-            SonarDiagnosticAnalyzer diagnosticAnalyzer, SonarCodeFixProvider codeFixProvider, string codeFixTitle,
-            params MetadataReference[] additionalReferences)
-        {
-            using (var workspace = new AdhocWorkspace())
-            {
-                var file = new FileInfo(path);
-                var parseOptions = GetParseOptionsWithDifferentLanguageVersions(null, file.Extension);
-
-                foreach (var parseOption in parseOptions)
-                {
-                    var document = CreateProject(file.Extension, GeneratedAssemblyName, workspace, additionalReferences)
-                        .AddDocument(new DocumentInfo(file), true)
-                        .Documents
-                        .Single(d => d.Name == file.Name);
-                    RunCodeFixWhileDocumentChanges(diagnosticAnalyzer, codeFixProvider, codeFixTitle, document, parseOption, pathToExpected);
-                }
-            }
-
-            VerifyFixAllCodeFix(path, pathToBatchExpected, diagnosticAnalyzer, codeFixProvider, codeFixTitle, additionalReferences);
-        }
-
-        #endregion
-
-        #region Generic helper
-
-        private static void VerifyNoIssueReported(string path, string assemblyName, DiagnosticAnalyzer diagnosticAnalyzer,
-            MetadataReference[] additionalReferences, ParseOptions parseOptions = null)
-        {
-            using (var workspace = new AdhocWorkspace())
-            {
-                var file = new FileInfo(path);
-                var project = CreateProject(file.Extension, assemblyName, workspace, additionalReferences)
-                    .AddDocument(new DocumentInfo(file));
-
-                project = parseOptions != null
-                    ? project.WithParseOptions(parseOptions)
-                    : project;
-
-                var compilation = project.GetCompilationAsync().Result;
-                var diagnostics = GetDiagnostics(compilation, diagnosticAnalyzer);
-
-                diagnostics.Should().BeEmpty();
-            }
-        }
-
-        private static void VerifyFixAllCodeFix(string path, string pathToExpected, DiagnosticAnalyzer diagnosticAnalyzer,
-            CodeFixProvider codeFixProvider, string codeFixTitle, params MetadataReference[] additionalReferences)
-        {
-            var fixAllProvider = codeFixProvider.GetFixAllProvider();
-            if (fixAllProvider == null)
-            {
-                return;
-            }
-
-            using (var workspace = new AdhocWorkspace())
-            {
-                var file = new FileInfo(path);
-                var parseOptions = GetParseOptionsWithDifferentLanguageVersions(null, file.Extension);
-
-                foreach (var parseOption in parseOptions)
-                {
-                    var document = CreateProject(file.Extension, GeneratedAssemblyName, workspace, additionalReferences)
-                        .AddDocument(new DocumentInfo(file), true)
-                        .Documents
-                        .Single(d => d.Name == file.Name);
-                    RunFixAllProvider(diagnosticAnalyzer, codeFixProvider, codeFixTitle, fixAllProvider, document, parseOption, pathToExpected);
-                }
-            }
-        }
-
-        private static Project CreateProject(string fileExtension, string assemblyName, AdhocWorkspace workspace,
-            params MetadataReference[] additionalReferences)
-        {
-            var language = fileExtension == CSharpFileExtension
-                ? LanguageNames.CSharp
-                : LanguageNames.VisualBasic;
-
-            var project = workspace.CurrentSolution.AddProject(assemblyName, $"{assemblyName}.dll", language)
-                .AddMetadataReference(FrameworkMetadataReference.Mscorlib)
-                .AddMetadataReference(FrameworkMetadataReference.System)
-                .AddMetadataReference(FrameworkMetadataReference.SystemCore)
-                .AddMetadataReferences(additionalReferences);
-
-            // adding an extra file to the project
-            // this won't trigger any issues, but it keeps a reference to the original ParseOption, so
-            // if an analyzer/codefix changes the language version, Roslyn throws an ArgumentException
-            project = project.AddDocument("ExtraEmptyFile.g" + fileExtension, string.Empty).Project;
-
-            return project;
-        }
-
-        private static Project AddDocument(this Project project, DocumentInfo document, bool removeAnalysisComments = false)
-        {
-            return project.AddDocument(document.Name, ReadDocument()).Project;
-
-            string ReadDocument()
-            {
-                var lines = document.Content
-                    .Replace(WindowsLineEnding, UnixLineEnding) // This allows to deal with multiple line endings
-                    .Split(new[] { UnixLineEnding }, StringSplitOptions.None);
-
-                if (removeAnalysisComments)
-                {
-                    lines = lines.Where(IssueLocationCollector.IsNotIssueLocationLine)
-                        .Select(ReplaceNonCompliantComment)
-                        .ToArray();
-                }
-
-                return string.Join(UnixLineEnding, lines);
-            }
-        }
-
-        private static string ReplaceNonCompliantComment(string line)
-        {
-            var match = Regex.Match(line, IssueLocationCollector.ISSUE_LOCATION_PATTERN);
-            if (!match.Success)
-            {
-                return line;
-            }
-
-            if (match.Groups["issueType"].Value == "Noncompliant")
-            {
-                var startIndex = line.IndexOf(match.Groups["issueType"].Value);
-                return string.Concat(line.Remove(startIndex), FIXED_MESSAGE);
-            }
-
-            return line.Replace(match.Value, string.Empty).TrimEnd();
-        }
-
-        #endregion
-
-        #region Analyzer helpers
-
-        private static IEnumerable<ParseOptions> GetParseOptionsAlternatives(ParseOptions options, string fileExtension)
-        {
-            return GetParseOptionsWithDifferentLanguageVersions(options, fileExtension).Concat(new[] { options });
-        }
-
-        private static IEnumerable<ParseOptions> GetParseOptionsWithDifferentLanguageVersions(ParseOptions options, string fileExtension)
-        {
-            if (fileExtension == CSharpFileExtension)
-            {
-                if (options == null)
-                {
-                    var csOptions = new CS.CSharpParseOptions();
-                    yield return csOptions.WithLanguageVersion(CS.LanguageVersion.CSharp7);
-                    yield return csOptions.WithLanguageVersion(CS.LanguageVersion.CSharp6);
-                    yield return csOptions.WithLanguageVersion(CS.LanguageVersion.CSharp5);
-                }
-                yield break;
-            }
-
-            var vbOptions = options as VB.VisualBasicParseOptions ?? new VB.VisualBasicParseOptions();
-            yield return vbOptions.WithLanguageVersion(VB.LanguageVersion.VisualBasic15);
-            yield return vbOptions.WithLanguageVersion(VB.LanguageVersion.VisualBasic14);
-            yield return vbOptions.WithLanguageVersion(VB.LanguageVersion.VisualBasic12);
-        }
-
-        internal static IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation,
-            DiagnosticAnalyzer diagnosticAnalyzer)
-        {
-            var ids = new HashSet<string>(diagnosticAnalyzer.SupportedDiagnostics.Select(diagnostic => diagnostic.Id));
-
-            var diagnostics = GetAllDiagnostics(compilation, new[] { diagnosticAnalyzer }).ToList();
-            VerifyNoExceptionThrown(diagnostics);
-
-            return diagnostics.Where(d => ids.Contains(d.Id));
-        }
-
-        private static void VerifyNoExceptionThrown(IEnumerable<Diagnostic> diagnostics)
-        {
-            diagnostics.Where(d => d.Id == AnalyzerFailedDiagnosticId).Should().BeEmpty();
-        }
-
-        private static IEnumerable<Diagnostic> GetAllDiagnostics(Compilation compilation,
-            IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers)
-        {
-            using (var tokenSource = new CancellationTokenSource())
-            {
-                var compilationOptions = compilation.Language == LanguageNames.CSharp
-                    ? (CompilationOptions)new CS.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true)
-                    : new VB.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
-                var supportedDiagnostics = diagnosticAnalyzers
-                        .SelectMany(analyzer => analyzer.SupportedDiagnostics)
-                        .ToList();
-                compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
-                    supportedDiagnostics
-                        .Select(diagnostic =>
-                            new KeyValuePair<string, ReportDiagnostic>(diagnostic.Id, ReportDiagnostic.Warn))
-                        .Union(
-                            new[]
-                            {
-                                new KeyValuePair<string, ReportDiagnostic>(AnalyzerFailedDiagnosticId, ReportDiagnostic.Error)
-                            }));
-
-                var compilationWithOptions = compilation.WithOptions(compilationOptions);
-                var compilationWithAnalyzer = compilationWithOptions
-                    .WithAnalyzers(
-                        diagnosticAnalyzers.ToImmutableArray(),
-                        cancellationToken: tokenSource.Token);
-
-                return compilationWithAnalyzer.GetAllDiagnosticsAsync().Result;
-            }
-        }
-
-        #endregion
-
-        #region Codefix helper
-
-        private static void RunCodeFixWhileDocumentChanges(DiagnosticAnalyzer diagnosticAnalyzer, CodeFixProvider codeFixProvider,
-            string codeFixTitle, Document document, ParseOptions parseOption, string pathToExpected)
-        {
-            var currentDocument = document;
-            CalculateDiagnosticsAndCode(diagnosticAnalyzer, currentDocument, parseOption, out var diagnostics, out var actualCode);
-
-            diagnostics.Should().NotBeEmpty();
-
-            string codeBeforeFix;
-            var codeFixExecutedAtLeastOnce = false;
-
-            do
-            {
-                codeBeforeFix = actualCode;
-
-                var codeFixExecuted = false;
-                for (var diagnosticIndexToFix = 0; !codeFixExecuted && diagnosticIndexToFix < diagnostics.Count; diagnosticIndexToFix++)
-                {
-                    var codeActionsForDiagnostic = GetCodeActionsForDiagnostic(codeFixProvider, currentDocument, diagnostics[diagnosticIndexToFix]);
-
-                    if (TryGetCodeActionToApply(codeFixTitle, codeActionsForDiagnostic, out var codeActionToExecute))
-                    {
-                        currentDocument = ApplyCodeFix(currentDocument, codeActionToExecute);
-                        CalculateDiagnosticsAndCode(diagnosticAnalyzer, currentDocument, parseOption, out diagnostics, out actualCode);
-
-                        codeFixExecutedAtLeastOnce = true;
-                        codeFixExecuted = true;
-                    }
-                }
-            } while (codeBeforeFix != actualCode);
-
-            codeFixExecutedAtLeastOnce.Should().BeTrue();
-
-            var actualWithUnixLineEnding = actualCode.Replace(WindowsLineEnding, UnixLineEnding);
-            var expectedWithUnixLineEnding = File.ReadAllText(pathToExpected).Replace(WindowsLineEnding, UnixLineEnding);
-            actualWithUnixLineEnding.Should().Be(expectedWithUnixLineEnding);
-        }
-
-        private static void RunFixAllProvider(DiagnosticAnalyzer diagnosticAnalyzer, CodeFixProvider codeFixProvider,
-            string codeFixTitle, FixAllProvider fixAllProvider, Document document, ParseOptions parseOption, string pathToExpected)
-        {
-            var currentDocument = document;
-            CalculateDiagnosticsAndCode(diagnosticAnalyzer, currentDocument, parseOption, out var diagnostics, out var actualCode);
-
-            diagnostics.Should().NotBeEmpty();
-
-            var fixAllDiagnosticProvider = new FixAllDiagnosticProvider(
-                codeFixProvider.FixableDiagnosticIds.ToHashSet(),
-                (doc, ids, ct) => Task.FromResult(
-                    GetDiagnostics(currentDocument.Project.GetCompilationAsync(ct).Result, diagnosticAnalyzer)),
-                null);
-            var fixAllContext = new FixAllContext(currentDocument, codeFixProvider, FixAllScope.Document,
-                codeFixTitle,
-                codeFixProvider.FixableDiagnosticIds,
-                fixAllDiagnosticProvider,
-                CancellationToken.None);
-            var codeActionToExecute = fixAllProvider.GetFixAsync(fixAllContext).Result;
-
-            codeActionToExecute.Should().NotBeNull();
-
-            currentDocument = ApplyCodeFix(currentDocument, codeActionToExecute);
-
-            CalculateDiagnosticsAndCode(diagnosticAnalyzer, currentDocument, parseOption, out diagnostics, out actualCode);
-
-            var actualWithUnixLineEnding = actualCode.Replace(WindowsLineEnding, UnixLineEnding);
-            var expectedWithUnixLineEnding = File.ReadAllText(pathToExpected).Replace(WindowsLineEnding, UnixLineEnding);
-            actualWithUnixLineEnding.Should().Be(expectedWithUnixLineEnding);
-        }
-
-        private static void CalculateDiagnosticsAndCode(DiagnosticAnalyzer diagnosticAnalyzer, Document document, ParseOptions parseOption,
-            out List<Diagnostic> diagnostics,
-            out string actualCode)
-        {
-            var project = document.Project;
-            if (parseOption != null)
-            {
-                project = project.WithParseOptions(parseOption);
-            }
-
-            diagnostics = GetDiagnostics(project.GetCompilationAsync().Result, diagnosticAnalyzer).ToList();
-            actualCode = document.GetSyntaxRootAsync().Result.GetText().ToString();
-        }
-
-        private static Document ApplyCodeFix(Document document, CodeAction codeAction)
-        {
-            var operations = codeAction.GetOperationsAsync(CancellationToken.None).Result;
-            var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
-            return solution.GetDocument(document.Id);
-        }
-
-        private static bool TryGetCodeActionToApply(string codeFixTitle, IEnumerable<CodeAction> codeActions,
-            out CodeAction codeAction)
-        {
-            codeAction = codeFixTitle != null
-                ? codeActions.SingleOrDefault(action => action.Title == codeFixTitle)
-                : codeActions.FirstOrDefault();
-
-            return codeAction != null;
-        }
-
-        private static IEnumerable<CodeAction> GetCodeActionsForDiagnostic(CodeFixProvider codeFixProvider, Document document,
-            Diagnostic diagnostic)
-        {
-            var actions = new List<CodeAction>();
-            var context = new CodeFixContext(document, diagnostic, (a, d) => actions.Add(a), CancellationToken.None);
-
-            codeFixProvider.RegisterCodeFixesAsync(context).Wait();
-            return actions;
-        }
-
-        #endregion
-
-        #region Suppression
-
-        private static bool isHooked = false;
-
-        private static ConcurrentDictionary<string, int> counters = new ConcurrentDictionary<string, int>();
-
-        private static void HookSuppression()
-        {
-            if (isHooked)
-            {
-                return;
-            }
-
-            SonarAnalysisContext.ShouldDiagnosticBeReported = (s, d) => { IncrementReportCount(d.Id); return true; };
-        }
-
-        private static void UnHookSuppression()
-        {
-            if (!isHooked)
-            {
-                return;
-            }
-
-            SonarAnalysisContext.ShouldDiagnosticBeReported = null;
-        }
-
-        internal static void IncrementReportCount(string ruleId)
-        {
-            counters.AddOrUpdate(ruleId, addValueFactory: key => 1, updateValueFactory: (key, count) => count + 1);
-        }
-
-        private static bool ExtensionMethodsCalledForAllDiagnostics(DiagnosticAnalyzer analyzer)
-        {
-            // In general this check is not very precise, because when the tests are run in parallel
-            // we cannot determine which diagnostic was reported from which analyzer instance. In other
-            // words, we cannot distinguish between diagnostics reported from different tests. That's
-            // why we require each diagnostic to be reported through the extension methods at least once.
-            return analyzer.SupportedDiagnostics
-                .Select(d => counters.GetValueOrDefault(d.Id))
-                .Any(count => count > 0);
-        }
-        #endregion
-
-        private class DocumentInfo
-        {
-            public DocumentInfo(FileInfo file) :
-                this(file.Name, File.ReadAllText(file.FullName, Encoding.UTF8))
-            {
-            }
-
-            public DocumentInfo(string name, string content)
-            {
-                Name = name;
-                Content = content;
-            }
-
-            public string Name { get; }
-            public string Content { get; }
         }
     }
 }


### PR DESCRIPTION
+ Creating NewVerifier in an attempt to replace the existing Verifier with more modular framework. NOTE: this is work in progress and some of the code in Verifier will be replaced with calls to the new classes.

Fix #1610 