### PR TITLE
Fixed #1486 - exception for classes that contain assembly-level setup/cleanup methods

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -42,6 +42,8 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestMethodAttribute = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_DataTestMethodAttribute = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_WorkItemAttribute = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.WorkItemAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssemblyInitializeAttribute = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyInitializeAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssemblyCleanupAttribute = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyCleanupAttribute");
         internal static readonly KnownType NUnit_Framework_Assert = new KnownType("NUnit.Framework.Assert");
         internal static readonly KnownType NUnit_Framework_ExpectedExceptionAttribute = new KnownType("NUnit.Framework.ExpectedExceptionAttribute");
         internal static readonly KnownType NUnit_Framework_IgnoreAttribute = new KnownType("NUnit.Framework.IgnoreAttribute");

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestClassShouldHaveTestMethod.MsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestClassShouldHaveTestMethod.MsTest.cs
@@ -68,3 +68,44 @@ namespace Tests.Diagnostics
 
     }
 }
+
+namespace TestSetupAndCleanupAttributes
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    // Regression tests for Bug 1486: https://github.com/SonarSource/sonar-csharp/issues/1486
+    // Don't raise for classes that test setup or cleanup attributes
+
+    [TestClass]
+    public class SetupAttributes1
+    {
+        [AssemblyInitialize]
+        public static void BeforeTests(TestContext context)
+        {
+        }
+    }
+
+    [TestClass]
+    public static class SetupAttributes2
+    {
+        [AssemblyCleanup]
+        public static void AfterTests()
+        {
+        }
+    }
+
+
+    [TestClass]
+    public static class SetupAttributes3
+    {
+        [AssemblyInitialize]
+        public static void BeforeTests(TestContext context)
+        {
+        }
+
+        [AssemblyCleanup]
+        public static void AfterTests()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixed #1486