### PR TITLE
Attempt to improve performance of locally run tests

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/NuGetMetadataReference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/NuGetMetadataReference.cs
@@ -177,10 +177,14 @@ namespace SonarAnalyzer.UnitTest
         [AssemblyInitialize]
         public static void SetupAssembly(TestContext context)
         {
-            // Install new nugets only once per week to improve the performance when running tests locally
+            // Choosing one day to reduce the waiting time when a new version of the used nugets is
+            // released. If the waiting time when running tests locally is big we can increase.
+            const int VersionCheckDelayInDays = 1;
+
+            // Install new nugets only once per day to improve the performance when running tests locally
             // When adding a new nuget it is recommended to delete the content of
             // sonar -csharp\sonaranalyzer-dotnet\TestResults
-            if (DateTime.Now.Subtract(TestResultHelper.GetPreviousRunDate(context)).TotalDays < 7)
+            if (DateTime.Now.Subtract(TestResultHelper.GetPreviousRunDate(context)).TotalDays < VersionCheckDelayInDays)
             {
                 return;
             }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/NuGetMetadataReference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/NuGetMetadataReference.cs
@@ -177,9 +177,16 @@ namespace SonarAnalyzer.UnitTest
         [AssemblyInitialize]
         public static void SetupAssembly(TestContext context)
         {
+            // Install new nugets only once per week to improve the performance when running tests locally
+            // When adding a new nuget it is recommended to delete the content of
+            // sonar -csharp\sonaranalyzer-dotnet\TestResults
+            if (DateTime.Now.Subtract(TestResultHelper.GetPreviousRunDate(context)).TotalDays < 7)
+            {
+                return;
+            }
+
             foreach (var (packageId, packageVersion) in allNuGets)
             {
-                // TODO: Find a way to avoid the NuGet web round-trip for checking latest version of a package.
                 if (packageVersion == Constants.NuGetLatestVersion ||
                     !Directory.Exists(GetRealVersionFolder(packageId, packageVersion)))
                 {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/TestResultHelper.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/TestResultHelper.cs
@@ -23,50 +23,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SonarAnalyzer.UnitTest
 {
-    [TestClass]
     public class TestResultHelper
     {
-        [TestMethod]
-        public void TestResultHelper_ParseDate_Tests()
-        {
-            ParseDate("some gibberish").Should().Be(DateTime.MinValue);
-            ParseDate("2018-08-17").Should().Be(DateTime.MinValue);
-            ParseDate("Deploy_FirstName LastName 2018-08-17 14_52_41").Should().Be(new DateTime(2018, 8, 17));
-        }
-
-        [TestMethod]
-        public void TestResultHelper_GetPreviousRunDate_Tests()
-        {
-            var expected = new DateTime(2018, 8, 17);
-            GetPreviousRunDate(new[]
-            {
-                "Deploy_FirstName LastName 2018-08-17 14_52_41",
-                "Deploy_FirstName LastName 2018-08-17 14_52_41",
-                "Deploy_FirstName LastName 2018-08-17 14_52_41"
-            }).Should().Be(expected);
-
-            GetPreviousRunDate(Array.Empty<string>()).Should().Be(DateTime.MinValue);
-
-            GetPreviousRunDate(new[]
-            {
-                "some gibberish",
-                "other biggerish"
-            }).Should().Be(DateTime.MinValue);
-
-            GetPreviousRunDate(new[]
-            {
-                "Deploy_FirstName LastName 2018-04-17 14_52_41",
-                "Deploy_FirstName LastName 2018-09-17 14_52_41",
-                "Deploy_FirstName LastName 2018-08-17 14_52_41",
-                "Deploy_FirstName LastName 2018-06-17 14_52_41",
-            }).Should().Be(expected);
-        }
-
         /// <summary>
         /// Returns the date of the previous test run. If no other test runs were found returns DateTime.MinValue.
         /// </summary>
@@ -74,7 +36,7 @@ namespace SonarAnalyzer.UnitTest
             GetPreviousRunDate(
                 Directory.GetDirectories(Path.GetDirectoryName(context.TestRunDirectory)));
 
-        private static DateTime GetPreviousRunDate(IEnumerable<string> directoryNames)
+        public static DateTime GetPreviousRunDate(IEnumerable<string> directoryNames)
         {
             // Directory names are alphabetically comparable, skip the latest result
             var previousTestRunDir = directoryNames
@@ -89,7 +51,7 @@ namespace SonarAnalyzer.UnitTest
         /// <summary>
         /// Returns parsed DateTime from MSBuild test run directory name. If cannot parse, returns DateTime.MinValue.
         /// </summary>
-        private static DateTime ParseDate(string testRunDirectory)
+        public static DateTime ParseDate(string testRunDirectory)
         {
             // The format is "Deploy_Valeri Hristov 2018-08-17 14_52_41"
             var match = Regex.Match(testRunDirectory, "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}) \\d{2}_\\d{2}_\\d{2}");

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/TestResultHelper.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/TestResultHelper.cs
@@ -27,7 +27,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SonarAnalyzer.UnitTest
 {
-    public class TestResultHelper
+    internal class TestResultHelper
     {
         /// <summary>
         /// Returns the date of the previous test run. If no other test runs were found returns DateTime.MinValue.
@@ -36,13 +36,13 @@ namespace SonarAnalyzer.UnitTest
             GetPreviousRunDate(
                 Directory.GetDirectories(Path.GetDirectoryName(context.TestRunDirectory)));
 
-        public static DateTime GetPreviousRunDate(IEnumerable<string> directoryNames)
+        internal /*for test*/ static DateTime GetPreviousRunDate(IEnumerable<string> directoryNames)
         {
-            // Directory names are alphabetically comparable, skip the latest result
+            // Directory names are alphabetically comparable
             var previousTestRunDir = directoryNames
                 .OrderByDescending(name => name)
-                .Skip(1)
-                .FirstOrDefault();
+                .Skip(1) // Skip current run (the newest directory)
+                .FirstOrDefault(); // The previous run
 
             // Coalesce to avoid NRE in case there are less than 2 directories
             return ParseDate(previousTestRunDir ?? string.Empty);
@@ -51,9 +51,9 @@ namespace SonarAnalyzer.UnitTest
         /// <summary>
         /// Returns parsed DateTime from MSBuild test run directory name. If cannot parse, returns DateTime.MinValue.
         /// </summary>
-        public static DateTime ParseDate(string testRunDirectory)
+        internal /*for test*/ static DateTime ParseDate(string testRunDirectory)
         {
-            // The format is "Deploy_Valeri Hristov 2018-08-17 14_52_41"
+            // The format is "Deploy_UserFirstName UserLastName 2018-08-17 14_52_41"
             var match = Regex.Match(testRunDirectory, "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}) \\d{2}_\\d{2}_\\d{2}");
             if (match.Success &&
                 match.Groups.Count == 4 &&

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/TestResultHelperTests/TestResultHelper_Tests.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/TestResultHelperTests/TestResultHelper_Tests.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SonarAnalyzer.UnitTest
+{
+    [TestClass]
+    public class TestResultHelper_Tests
+    {
+        private static readonly DateTime expected = new DateTime(2018, 8, 17);
+
+        [TestMethod]
+        public void TestResultHelper_ParseDate_Invalid()
+        {
+            TestResultHelper.ParseDate("some gibberish").Should().Be(DateTime.MinValue);
+        }
+
+        [TestMethod]
+        public void TestResultHelper_ParseDate_Incomplete()
+        {
+            TestResultHelper.ParseDate("2018-08-17").Should().Be(DateTime.MinValue);
+        }
+
+        [TestMethod]
+        public void TestResultHelper_ParseDate_Valid()
+        {
+            TestResultHelper.ParseDate("Deploy_FirstName LastName 2018-08-17 14_52_41").Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void TestResultHelper_GetPreviousRunDate_Same_Date()
+        {
+            TestResultHelper.GetPreviousRunDate(new[]
+            {
+                "Deploy_FirstName LastName 2018-08-17 14_52_41",
+                "Deploy_FirstName LastName 2018-08-17 14_52_41",
+                "Deploy_FirstName LastName 2018-08-17 14_52_41"
+            }).Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void TestResultHelper_GetPreviousRunDate_Empty_Tests()
+        {
+            TestResultHelper.GetPreviousRunDate(Array.Empty<string>())
+                .Should().Be(DateTime.MinValue);
+        }
+
+        [TestMethod]
+        public void TestResultHelper_GetPreviousRunDate_Invalid_Tests()
+        {
+            TestResultHelper.GetPreviousRunDate(new[]
+            {
+                "some gibberish",
+                "other biggerish"
+            }).Should().Be(DateTime.MinValue);
+        }
+
+        [TestMethod]
+        public void TestResultHelper_GetPreviousRunDate_Unordered_Tests()
+        {
+            TestResultHelper.GetPreviousRunDate(new[]
+            {
+                "Deploy_FirstName LastName 2018-04-17 14_52_41",
+                "Deploy_FirstName LastName 2018-09-17 14_52_41",
+                "Deploy_FirstName LastName 2018-08-17 14_52_41",
+                "Deploy_FirstName LastName 2018-06-17 14_52_41",
+            }).Should().Be(expected);
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestResultHelper.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestResultHelper.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest
     public class TestResultHelper
     {
         [TestMethod]
-        public void ParseDate_Tests()
+        public void TestResultHelper_ParseDate_Tests()
         {
             ParseDate("some gibberish").Should().Be(DateTime.MinValue);
             ParseDate("2018-08-17").Should().Be(DateTime.MinValue);
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.UnitTest
         }
 
         [TestMethod]
-        public void GetPreviousRunDate_Tests()
+        public void TestResultHelper_GetPreviousRunDate_Tests()
         {
             var expected = new DateTime(2018, 8, 17);
             GetPreviousRunDate(new[]
@@ -49,6 +49,8 @@ namespace SonarAnalyzer.UnitTest
                 "Deploy_FirstName LastName 2018-08-17 14_52_41",
                 "Deploy_FirstName LastName 2018-08-17 14_52_41"
             }).Should().Be(expected);
+
+            GetPreviousRunDate(Array.Empty<string>()).Should().Be(DateTime.MinValue);
 
             GetPreviousRunDate(new[]
             {
@@ -72,9 +74,17 @@ namespace SonarAnalyzer.UnitTest
             GetPreviousRunDate(
                 Directory.GetDirectories(Path.GetDirectoryName(context.TestRunDirectory)));
 
-        private static DateTime GetPreviousRunDate(IEnumerable<string> directoryNames) =>
+        private static DateTime GetPreviousRunDate(IEnumerable<string> directoryNames)
+        {
             // Directory names are alphabetically comparable, skip the latest result
-            ParseDate(directoryNames.OrderByDescending(name => name).Skip(1).FirstOrDefault());
+            var previousTestRunDir = directoryNames
+                .OrderByDescending(name => name)
+                .Skip(1)
+                .FirstOrDefault();
+
+            // Coalesce to avoid NRE in case there are less than 2 directories
+            return ParseDate(previousTestRunDir ?? string.Empty);
+        }
 
         /// <summary>
         /// Returns parsed DateTime from MSBuild test run directory name. If cannot parse, returns DateTime.MinValue.

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestResultHelper.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestResultHelper.cs
@@ -1,0 +1,97 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SonarAnalyzer.UnitTest
+{
+    [TestClass]
+    public class TestResultHelper
+    {
+        [TestMethod]
+        public void ParseDate_Tests()
+        {
+            ParseDate("some gibberish").Should().Be(DateTime.MinValue);
+            ParseDate("2018-08-17").Should().Be(DateTime.MinValue);
+            ParseDate("Deploy_FirstName LastName 2018-08-17 14_52_41").Should().Be(new DateTime(2018, 8, 17));
+        }
+
+        [TestMethod]
+        public void GetPreviousRunDate_Tests()
+        {
+            var expected = new DateTime(2018, 8, 17);
+            GetPreviousRunDate(new[]
+            {
+                "Deploy_FirstName LastName 2018-08-17 14_52_41",
+                "Deploy_FirstName LastName 2018-08-17 14_52_41",
+                "Deploy_FirstName LastName 2018-08-17 14_52_41"
+            }).Should().Be(expected);
+
+            GetPreviousRunDate(new[]
+            {
+                "some gibberish",
+                "other biggerish"
+            }).Should().Be(DateTime.MinValue);
+
+            GetPreviousRunDate(new[]
+            {
+                "Deploy_FirstName LastName 2018-04-17 14_52_41",
+                "Deploy_FirstName LastName 2018-09-17 14_52_41",
+                "Deploy_FirstName LastName 2018-08-17 14_52_41",
+                "Deploy_FirstName LastName 2018-06-17 14_52_41",
+            }).Should().Be(expected);
+        }
+
+        /// <summary>
+        /// Returns the date of the previous test run. If no other test runs were found returns DateTime.MinValue.
+        /// </summary>
+        public static DateTime GetPreviousRunDate(TestContext context) =>
+            GetPreviousRunDate(
+                Directory.GetDirectories(Path.GetDirectoryName(context.TestRunDirectory)));
+
+        private static DateTime GetPreviousRunDate(IEnumerable<string> directoryNames) =>
+            // Directories are alphabetically comparable, skip the latest result
+            ParseDate(directoryNames.OrderBy(dir => dir).Reverse().Skip(1).Max());
+
+        /// <summary>
+        /// Returns parsed DateTime from MSBuild test run directory name. If cannot parse, returns DateTime.MinValue.
+        /// </summary>
+        private static DateTime ParseDate(string testRunDirectory)
+        {
+            // The format is "Deploy_Valeri Hristov 2018-08-17 14_52_41"
+            var match = Regex.Match(testRunDirectory, "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}) \\d{2}_\\d{2}_\\d{2}");
+            if (match.Success &&
+                match.Groups.Count == 4 &&
+                int.TryParse(match.Groups["year"].Value, out var year) &&
+                int.TryParse(match.Groups["month"].Value, out var month) &&
+                int.TryParse(match.Groups["day"].Value, out var day))
+            {
+                return new DateTime(year, month, day);
+            }
+            return DateTime.MinValue;
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestResultHelper.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestResultHelper.cs
@@ -73,8 +73,8 @@ namespace SonarAnalyzer.UnitTest
                 Directory.GetDirectories(Path.GetDirectoryName(context.TestRunDirectory)));
 
         private static DateTime GetPreviousRunDate(IEnumerable<string> directoryNames) =>
-            // Directories are alphabetically comparable, skip the latest result
-            ParseDate(directoryNames.OrderBy(dir => dir).Reverse().Skip(1).Max());
+            // Directory names are alphabetically comparable, skip the latest result
+            ParseDate(directoryNames.OrderByDescending(name => name).Skip(1).FirstOrDefault());
 
         /// <summary>
         /// Returns parsed DateTime from MSBuild test run directory name. If cannot parse, returns DateTime.MinValue.


### PR DESCRIPTION
There are a few limitations of this approach:
- if a new nuget is added to the helper everyone will have to delete his TestResults folder. This should not happen very often though.
- not sure about the period, perhaps 7 days is a bit long, but in general should be ok because our release cycle is longer and we should be able to include a quick fix in the current release.