### PR TITLE
Fix #1705: support recognized test attributes

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.sonarsource.ucfg</groupId>
       <artifactId>sonar-ucfg</artifactId>
-      <version>1.2.0.103</version>
+      <version>1.2.0.107</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldNotBeIgnored.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldNotBeIgnored.cs
@@ -44,13 +44,19 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static readonly ISet<KnownType> TrackedTestMethodAttributes = new HashSet<KnownType>
         {
+            // xUnit has it's own "ignore" mechanism (by providing a (Skip = "reason") string in
+            // the attribute, so there is always an explanation for the test being skipped).
+            // However, it is possible to mix test frameworks i.e. have an xUnit [Fact] that has an 
+            // MSTest [Ignore]. This seems like a weird corner case, but the rule handles it.
             KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_TestMethodAttribute,
+            KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_DataTestMethodAttribute,
             KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_TestClassAttribute,
             KnownType.NUnit_Framework_TestAttribute,
             KnownType.NUnit_Framework_TestCaseAttribute,
             KnownType.NUnit_Framework_TestCaseSourceAttribute,
             KnownType.Xunit_FactAttribute,
-            KnownType.Xunit_TheoryAttribute
+            KnownType.Xunit_TheoryAttribute,
+            KnownType.LegacyXunit_TheoryAttribute
         };
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldNotBeIgnoredTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldNotBeIgnoredTest.cs
@@ -66,5 +66,17 @@ namespace SonarAnalyzer.UnitTest.Rules
                     .Concat(MetadataReferenceHelper.FromNuGet("xunit.extensibility.core", testFwkVersion))
                     .ToArray());
         }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void TestMethodShouldNotBeIgnored_Xunit_v1()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\TestMethodShouldNotBeIgnored.Xunit.v1.cs",
+                new TestMethodShouldNotBeIgnored(),
+                additionalReferences: MetadataReferenceHelper.FromNuGet("MSTest.TestFramework", "1.1.11")
+                    .Concat(MetadataReferenceHelper.FromNuGet("xunit.extensions", "1.9.1"))
+                    .Concat(MetadataReferenceHelper.FromNuGet("xunit", "1.9.1"))
+                    .ToArray());
+        }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.MsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.MsTest.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Tests.Diagnostics
+namespace Tests.Diagnostics.TestMethods
 {
-    class MsTestClass
+    [TestClass]
+    public class MsTestClass_TestMethods
     {
         [TestMethod]
         [Ignore]
@@ -30,6 +30,41 @@ namespace Tests.Diagnostics
         }
 
         [TestMethod]
+        [Ignore]
+        [WorkItem(1234)]
+        public void Foo5()
+        {
+        }
+    }
+
+    [TestClass]
+    public class MsTestClass_DataTestMethods
+    {
+        [DataTestMethod]
+        [Ignore]
+//       ^^^^^^ Noncompliant {{Either remove this 'Ignore' attribute or add an explanation about why this test is ignored.}}
+        public void Foo1()
+        {
+        }
+
+        [DataTestMethod]
+        [Ignore] // This test is ignored because 'blah blah'
+        public void Foo2()
+        {
+        }
+
+        [Ignore, DataTestMethod] // This test is ignored because 'blah blah'
+        public void Foo3()
+        {
+        }
+
+        [DataTestMethod]
+        [Ignore("Ignored because reasons")]
+        public void Foo4()
+        {
+        }
+
+        [DataTestMethod]
         [Ignore]
         [WorkItem(1234)]
         public void Foo5()

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.MsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.MsTest.cs
@@ -74,22 +74,26 @@ namespace Tests.Diagnostics.TestMethods
 
     [Ignore, TestClass]
 //   ^^^^^^ Noncompliant
-    class MsTestClass1
+    public class MsTestClass1
     {
+        [TestMethod]
+        public void Test1()
+        {
+        }
     }
 
     [Ignore]
-    class MsTestClass2 // No TestClass attribute
+    public class MsTestClass2 // No TestClass attribute
     {
     }
 
     [Ignore, TestClass] // This test is ignored because 'blah blah'
-    class MsTestClass3
+    public class MsTestClass3
     {
     }
 
     [Ignore("Ignored because reasons"), TestClass]
-    class MsTestClass4
+    public class MsTestClass4
     {
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.NUnit.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.NUnit.cs
@@ -1,11 +1,14 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
+using MSTest = Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Tests.Diagnostics
 {
-    class NUnitClass
+    [TestFixture]
+    public class NUnitClass
     {
+        // False positive: using an MSTest Ignore against an NUnit test does nothing,
+        // but we still raise an issue.
         [Test]
         [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore]
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant
@@ -14,41 +17,41 @@ namespace Tests.Diagnostics
         }
 
         [Test]
-        [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore] // This test is ignored because 'blah blah'
+        [NUnit.Framework.Ignore] // This test is ignored because 'blah blah'
         public void Foo2()
         {
         }
 
         [Test]
-        [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore]
-        [WorkItem(1234)]
+        [Ignore]
+        [MSTest.WorkItem(1234)]
         public void Foo3()
         {
         }
 
         [TestCase("")]
-        [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore]
-//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant
+        [Ignore()]
+//       ^^^^^^^^ Noncompliant
         public void Foo4(string s)
         {
         }
 
         [TestCase("")]
-        [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore] // This test is ignored because 'blah blah'
+        [NUnit.Framework.Ignore] // This test is ignored because 'blah blah'
         public void Foo5(string s)
         {
         }
 
         [TestCase("")]
-        [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore]
-        [WorkItem(1234)]
+        [Ignore]
+        [MSTest.WorkItem(1234)]
         public void Foo6(string s)
         {
         }
 
         [TestCaseSource("DivideCases")]
-        [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore]
-//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant
+        [Ignore]
+//       ^^^^^^ Noncompliant
         public void DivideTest(int n, int d, int q)
         {
             Assert.AreEqual(q, n / d);
@@ -56,9 +59,53 @@ namespace Tests.Diagnostics
 
         static object[] DivideCases =
         {
-            new object[] { 12, 3, 4 },
-            new object[] { 12, 2, 6 },
-            new object[] { 12, 4, 3 }
+            new object[] { 12, 3, 4 }
         };
+
+        [Datapoint]
+        public int Data = 42;
+
+        [Theory]
+        [Ignore]
+//       ^^^^^^ Noncompliant
+        public void Theory1(int arg)
+        {
+        }
+
+        [Theory]
+        [Ignore] // some reason
+        public void Theory2(int arg) // Compliant
+        {
+        }
+
+        [Theory]
+        [Ignore("a reason")]
+        public void Theory3(int arg)
+        {
+        }
+    }
+
+    [TestFixture, Ignore]
+    public class IgnoredClass1
+    {
+        [Test]
+        public void TestInIgnoredClass()
+        {
+        }
+    }
+
+    [Ignore]
+    public class IgnoredClass2 // No TestClass attribute
+    {
+    }
+
+    [Ignore, TestFixture] // This test is ignored because 'blah blah'
+    public class IgnoredClass3
+    {
+    }
+
+    [Ignore("Ignored because reasons"), TestFixture]
+    public class IgnoredClass4
+    {
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.Xunit.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.Xunit.cs
@@ -1,54 +1,25 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using MSTest = Microsoft.VisualStudio.TestTools.UnitTesting;
 using Xunit;
 
-// Note: we're mixing test frameworks here - xUnit and MSTest.
-// This is deliberate. See the comments in the rule implementation for more info.
+// Regression test for #1705: https://github.com/SonarSource/sonar-csharp/issues/1705
+// The rule should not be applied to xUnit tests. Previously, the rule was raising if
+// an MSTest [Ignore] attribute was applied to a xUnit test.
 
 namespace Tests.Diagnostics
 {
-    class XUnitClass
+    [MSTest.Ignore()]
+    public class XUnitClass
     {
         [Fact]
-        [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore]
-//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant
+        [MSTest.Ignore()]
         public void Foo1()
         {
         }
 
-        [Fact]
-        [Ignore] // This test is ignored because 'blah blah'
-        public void Foo2()
-        {
-        }
-
-        [Fact]
-        [Ignore]
-        [WorkItem(1234)]
-        public void Foo3()
-        {
-        }
-
         [Theory]
         [InlineData("")]
-        [Ignore]
-//       ^^^^^^ Noncompliant
-        public void Foo4(string s)
-        {
-        }
-
-        [Theory]
-        [InlineData("")]
-        [Ignore] // This test is ignored because 'blah blah'
-        public void Foo5(string s)
-        {
-        }
-
-        [Theory]
-        [InlineData("")]
-        [Ignore]
-        [WorkItem(1234)]
-        public void Foo6(string s)
+        [MSTest.Ignore]
+        public void Foo2(string s)
         {
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.Xunit.v1.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.Xunit.v1.cs
@@ -1,57 +1,28 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using MSTest = Microsoft.VisualStudio.TestTools.UnitTesting;
 using Xunit;
 using Xunit.Extensions;
 
 // Legacy xUnit (v1.9.1)
 
-// Note: we're mixing test frameworks here - xUnit and MSTest.
-// This is deliberate. See the comments in the rule implementation for more info.
+// Regression test for #1705: https://github.com/SonarSource/sonar-csharp/issues/1705
+// The rule should not be applied to xUnit tests. Previously, the rule was raising if
+// an MSTest [Ignore] attribute was applied to a xUnit test.
 
 namespace Tests.Diagnostics
 {
-    class XUnitClass
+    [MSTest.Ignore()]
+    public class XUnitClass
     {
         [Fact]
-        [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore()]
-//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant
+        [MSTest.Ignore()]
         public void Foo1()
         {
         }
 
-        [Fact]
-        [Ignore] // This test is ignored because 'blah blah'
-        public void Foo2()
-        {
-        }
-
-        [Fact]
-        [Ignore]
-        [WorkItem(1234)]
-        public void Foo3()
-        {
-        }
-
         [Theory]
         [InlineData("")]
-        [Ignore]
-//       ^^^^^^ Noncompliant
-        public void Foo4(string s)
-        {
-        }
-
-        [Theory]
-        [InlineData("")]
-        [Ignore] // This test is ignored because 'blah blah'
-        public void Foo5(string s)
-        {
-        }
-
-        [Theory]
-        [InlineData("")]
-        [Ignore]
-        [WorkItem(1234)]
-        public void Foo6(string s)
+        [MSTest.Ignore]
+        public void Foo2(string s)
         {
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.Xunit.v1.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.Xunit.v1.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Xunit;
+using Xunit.Extensions;
+
+// Legacy xUnit (v1.9.1)
 
 // Note: we're mixing test frameworks here - xUnit and MSTest.
 // This is deliberate. See the comments in the rule implementation for more info.
@@ -10,8 +13,8 @@ namespace Tests.Diagnostics
     class XUnitClass
     {
         [Fact]
-        [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore]
-//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant
+        [Microsoft.VisualStudio.TestTools.UnitTesting.Ignore()]
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Noncompliant
         public void Foo1()
         {
         }


### PR DESCRIPTION
Fixed #1705 

* add support for NUnit _Theory_ and MSTest _DataTestMethod_ tests
* exclude xUnit from rule to remove FPs