### PR TITLE
Rule S2148: Underscores should be used to make large numbers readable

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Hosting.Aspnet-{E127FED3-01C0-41BA-BF83-D8DCDD827D6A}-S2148.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Demo.Hosting.Aspnet-{E127FED3-01C0-41BA-BF83-D8DCDD827D6A}-S2148.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Demo.Hosting.Aspnet\MainModule.cs",
+"region":  {
+"startLine":  78,
+"startColumn":  71,
+"endLine":  78,
+"endColumn":  78
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests-{776D244D-BC4D-4BBB-A478-CAF2D04520E1}-S2148.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.Tests-{776D244D-BC4D-4BBB-A478-CAF2D04520E1}-S2148.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Tests\Unit\DynamicDictionaryValueFixture.cs",
+"region":  {
+"startLine":  579,
+"startColumn":  35,
+"endLine":  579,
+"endColumn":  55
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.Spark.Tests-{06F89662-C2F0-4C1D-8581-E0C4A615B7E2}-S2148.json
+++ b/sonaranalyzer-dotnet/its/expected/Nancy/Nancy.ViewEngines.Spark.Tests-{06F89662-C2F0-4C1D-8581-E0C4A615B7E2}-S2148.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.Spark.Tests\SparkViewEngineFixture.cs",
+"region":  {
+"startLine":  160,
+"startColumn":  80,
+"endLine":  160,
+"endColumn":  90
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote-{EA4FF8FD-7C53-49C8-B9AA-02E458B3E6A7}-S2148.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote-{EA4FF8FD-7C53-49C8-B9AA-02E458B3E6A7}-S2148.json
@@ -1,0 +1,56 @@
+{
+"issues":  [
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Endpoint.cs",
+"region":  {
+"startLine":  1125,
+"startColumn":  46,
+"endLine":  1125,
+"endColumn":  54
+}
+}
+},
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Endpoint.cs",
+"region":  {
+"startLine":  1390,
+"startColumn":  54,
+"endLine":  1390,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Endpoint.cs",
+"region":  {
+"startLine":  1391,
+"startColumn":  54,
+"endLine":  1391,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Endpoint.cs",
+"region":  {
+"startLine":  1392,
+"startColumn":  52,
+"endLine":  1392,
+"endColumn":  63
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote.Tests-{95E921AB-1F5A-4AF9-B7FE-284E317A97F4}-S2148.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Remote.Tests-{95E921AB-1F5A-4AF9-B7FE-284E317A97F4}-S2148.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.Tests\Transport\ThrottleModeSpec.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  37,
+"endLine":  26,
+"endColumn":  44
+}
+}
+},
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote.Tests\Transport\ThrottleModeSpec.cs",
+"region":  {
+"startLine":  35,
+"startColumn":  37,
+"endLine":  35,
+"endColumn":  44
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Tests.Performance-{B17DEDCB-D2AA-472D-82A0-D242B711F488}-S2148.json
+++ b/sonaranalyzer-dotnet/its/expected/akka.net/Akka.Tests.Performance-{B17DEDCB-D2AA-472D-82A0-D242B711F488}-S2148.json
@@ -1,0 +1,43 @@
+{
+"issues":  [
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests.Performance\Actor\ActorPathSpec.cs",
+"region":  {
+"startLine":  12,
+"startColumn":  69,
+"endLine":  12,
+"endColumn":  79
+}
+}
+},
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests.Performance\Actor\ActorThroughputSpecBase.cs",
+"region":  {
+"startLine":  15,
+"startColumn":  50,
+"endLine":  15,
+"endColumn":  58
+}
+}
+},
+{
+"id":  "S2148",
+"message":  "Add underscores to this numeric value for readability.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests.Performance\Actor\AddressSpec.cs",
+"region":  {
+"startLine":  14,
+"startColumn":  69,
+"endLine":  14,
+"endColumn":  79
+}
+}
+}
+]
+}

--- a/sonaranalyzer-dotnet/rspec/cs/S2148_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S2148_c#.html
@@ -1,0 +1,42 @@
+<p>Beginning with C# 7, it is possible to add underscores ('_') to numeric literals to enhance readability. The addition of underscores in this manner
+has no semantic meaning, but makes it easier for maintainers to understand the code.</p>
+<p>The number of digits to the left of a decimal point needed to trigger this rule varies by base.</p>
+<table>
+  <tbody>
+    <tr>
+      <th>Base</th>
+      <th> Minimum digits</th>
+    </tr>
+    <tr>
+      <td>binary</td>
+      <td> 9 </td>
+    </tr>
+    <tr>
+      <td>octal</td>
+      <td> 9 </td>
+    </tr>
+    <tr>
+      <td>decimal</td>
+      <td> 6 </td>
+    </tr>
+    <tr>
+      <td>hexadecimal</td>
+      <td> 9 </td>
+    </tr>
+  </tbody>
+</table>
+<p>It is only the presence of underscores, not their spacing that is scrutinized by this rule.</p>
+<p><strong>Note</strong> that this rule is automatically disabled when the project's <code>C# version</code> is lower than <code>7</code>.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+int i = 10000000;  // Noncompliant; is this 10 million or 100 million?
+int  j = 0b01101001010011011110010101011110;  // Noncompliant
+long l = 0x7fffffffffffffffL;  // Noncompliant
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+int i = 10_000_000;
+int  j = 0b01101001_01001101_11100101_01011110;
+long l = 0x7fff_ffff_ffff_ffffL;
+</pre>
+

--- a/sonaranalyzer-dotnet/rspec/cs/S2148_c#.json
+++ b/sonaranalyzer-dotnet/rspec/cs/S2148_c#.json
@@ -1,0 +1,16 @@
+{
+  "title": "Underscores should be used to make large numbers readable",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "convention"
+  ],
+  "defaultSeverity": "Minor",
+  "ruleSpecification": "RSPEC-2148",
+  "sqKey": "S2148",
+  "scope": "All"
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -2804,6 +2804,36 @@
   </data>
   <data name="S2123_Type" xml:space="preserve">
     <value>BUG</value>
+  </data>
+  <data name="S2148_Category" xml:space="preserve">
+    <value>Minor Code Smell</value>
+  </data>
+  <data name="S2148_Description" xml:space="preserve">
+    <value>Beginning with C# 7, it is possible to add underscores ('_') to numeric literals to enhance readability. The addition of underscores in this manner has no semantic meaning, but makes it easier for maintainers to understand the code.</value>
+  </data>
+  <data name="S2148_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S2148_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S2148_RemediationCost" xml:space="preserve">
+    <value>5min</value>
+  </data>
+  <data name="S2148_Scope" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="S2148_Severity" xml:space="preserve">
+    <value>Minor</value>
+  </data>
+  <data name="S2148_Tags" xml:space="preserve">
+    <value>convention</value>
+  </data>
+  <data name="S2148_Title" xml:space="preserve">
+    <value>Underscores should be used to make large numbers readable</value>
+  </data>
+  <data name="S2148_Type" xml:space="preserve">
+    <value>CODE_SMELL</value>
   </data>
   <data name="S2156_Category" xml:space="preserve">
     <value>Minor Code Smell</value>
@@ -9607,7 +9637,7 @@
     <value>Major Code Smell</value>
   </data>
   <data name="S4144_Description" xml:space="preserve">
-    <value>When two methods have the same implementation, either it was a mistake - something else was intended - or the duplication was intentional, but may be confusing to maintainers. In the latter case, one implementation should invoke the other. Numerical and string literals are not taken into account. </value>
+    <value>When two methods have the same implementation, either it was a mistake - something else was intended - or the duplication was intentional, but may be confusing to maintainers. In the latter case, one implementation should invoke the other.</value>
   </data>
   <data name="S4144_IsActivatedByDefault" xml:space="preserve">
     <value>True</value>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UseNumericLiteralSeparator.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UseNumericLiteralSeparator.cs
@@ -1,0 +1,88 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+using SonarAnalyzer.ShimLayer.CSharp;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(DiagnosticId)]
+    public sealed class UseNumericLiteralSeparator : SonarDiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "S2148";
+        private const string MessageFormat = "Add underscores to this numeric value for readability.";
+
+        private const int BinaryMinimumDigits = 9 + 2; // +2 for 0b
+        private const int HexadecimalMinimumDigits = 9 + 2; // +2 for 0x
+        private const int DecimalMinimumDigits = 6;
+
+        private static readonly DiagnosticDescriptor rule =
+            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionInNonGenerated(
+                c =>
+                {
+                    if (!c.Compilation.IsAtLeastLanguageVersion(LanguageVersionEx.CSharp7))
+                    {
+                        return;
+                    }
+
+                    var numericLiteral = (LiteralExpressionSyntax)c.Node;
+
+                    if (numericLiteral.Token.Text.IndexOf('_') < 0 &&
+                        ShouldHaveSeparator(numericLiteral))
+                    {
+                        c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, numericLiteral.GetLocation()));
+                    }
+                },
+                SyntaxKind.NumericLiteralExpression);
+        }
+
+        private static bool ShouldHaveSeparator(LiteralExpressionSyntax numericLiteral)
+        {
+            if (numericLiteral.Token.Text.StartsWith("0x"))
+            {
+                return numericLiteral.Token.Text.Length > HexadecimalMinimumDigits;
+            }
+
+            if (numericLiteral.Token.Text.StartsWith("0b"))
+            {
+                return numericLiteral.Token.Text.Length > BinaryMinimumDigits;
+            }
+
+            var indexOfDot = numericLiteral.Token.Text.IndexOf('.');
+            var beforeDotPartLength = indexOfDot < 0
+                ? numericLiteral.Token.Text.Length
+                : numericLiteral.Token.Text.Remove(indexOfDot).Length;
+
+            return beforeDotPartLength > DecimalMinimumDigits;
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S2148.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S2148.html
@@ -1,0 +1,42 @@
+<p>Beginning with C# 7, it is possible to add underscores ('_') to numeric literals to enhance readability. The addition of underscores in this manner
+has no semantic meaning, but makes it easier for maintainers to understand the code.</p>
+<p>The number of digits to the left of a decimal point needed to trigger this rule varies by base.</p>
+<table>
+  <tbody>
+    <tr>
+      <th>Base</th>
+      <th> Minimum digits</th>
+    </tr>
+    <tr>
+      <td>binary</td>
+      <td> 9 </td>
+    </tr>
+    <tr>
+      <td>octal</td>
+      <td> 9 </td>
+    </tr>
+    <tr>
+      <td>decimal</td>
+      <td> 6 </td>
+    </tr>
+    <tr>
+      <td>hexadecimal</td>
+      <td> 9 </td>
+    </tr>
+  </tbody>
+</table>
+<p>It is only the presence of underscores, not their spacing that is scrutinized by this rule.</p>
+<p><strong>Note</strong> that this rule is automatically disabled when the project's <code>C# version</code> is lower than <code>7</code>.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+int i = 10000000;  // Noncompliant; is this 10 million or 100 million?
+int  j = 0b01101001010011011110010101011110;  // Noncompliant
+long l = 0x7fffffffffffffffL;  // Noncompliant
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+int i = 10_000_000;
+int  j = 0b01101001_01001101_11100101_01011110;
+long l = 0x7fff_ffff_ffff_ffffL;
+</pre>
+

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/PackagingTests/CsRuleTypeMapping.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/PackagingTests/CsRuleTypeMapping.cs
@@ -2145,7 +2145,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
             //["2145"],
             //["2146"],
             //["2147"],
-            //["2148"],
+            ["2148"] = "CODE_SMELL",
             //["2149"],
             //["2150"],
             //["2151"],

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UseNumericLiteralSeparatorTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UseNumericLiteralSeparatorTest.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+extern alias csharp;
+using csharp::SonarAnalyzer.Rules.CSharp;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class UseNumericLiteralSeparatorTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void UseNumericLiteralSeparator_CSharp6()
+        {
+            Verifier.VerifyNoIssueReported(@"TestCases\UseNumericLiteralSeparator.cs",
+                new UseNumericLiteralSeparator(),
+                new CSharpParseOptions(LanguageVersion.CSharp6));
+        }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void UseNumericLiteralSeparator_CSharp7()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\UseNumericLiteralSeparator.cs",
+                new UseNumericLiteralSeparator(),
+                new CSharpParseOptions(LanguageVersion.CSharp7));
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UseNumericLiteralSeparator.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UseNumericLiteralSeparator.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Tests.Diagnostics
+{
+    class Program
+    {
+        void Invalid()
+        {
+            int i = 10000000;  // Noncompliant; is this 10 million or 100 million?
+            int j = 0b01101001010011011110010101011110;  // Noncompliant {{Add underscores to this numeric value for readability.}}
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            long l = 0x7fffffffffffffffL;  // Noncompliant
+        }
+
+        void Valid()
+        {
+            int i = 10_000_000;
+            int j = 0b01101001_01001101_11100101_01011110;
+            long k = 0x7fff_ffff_ffff_ffffL;
+            var l = 1000;
+            var m = 0b001;
+            var n = 0x000;
+        }
+    }
+}


### PR DESCRIPTION
Fix #248 