### PR TITLE
Update the version of Roslyn the tests depends upon

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
@@ -42,10 +42,16 @@ namespace SonarAnalyzer.ControlFlowGraph.CSharp
         private static readonly object GotoDefaultEntry = new object();
         private static readonly object GotoNullEntry = new object();
         private static readonly HashSet<SyntaxKind> csharp6SwitchLabelKinds = new HashSet<SyntaxKind>
-            {
-                SyntaxKind.CaseSwitchLabel,
-                SyntaxKind.DefaultSwitchLabel,
-            };
+        {
+            SyntaxKind.CaseSwitchLabel,
+            SyntaxKind.DefaultSwitchLabel,
+        };
+        private static readonly HashSet<SyntaxKind> csharp7DefaultLabelKinds = new HashSet<SyntaxKind>
+        {
+            SyntaxKind.DefaultExpression,
+            SyntaxKindEx.DefaultLiteralExpression,
+        };
+
 
         internal CSharpControlFlowGraphBuilder(CSharpSyntaxNode node, SemanticModel semanticModel)
             : base(node, semanticModel)
@@ -758,7 +764,7 @@ namespace SonarAnalyzer.ControlFlowGraph.CSharp
             return BuildExpression(switchStatement.Expression, switchBlock);
 
             bool ContainsDefaultLabel(SwitchSectionSyntax s) =>
-                s.Labels.OfType<CaseSwitchLabelSyntax>().Any(l => l.Value.IsKind(SyntaxKind.DefaultExpression));
+                s.Labels.OfType<CaseSwitchLabelSyntax>().Any(l => l.Value.IsAnyKind(csharp7DefaultLabelKinds));
         }
 
         private Block BuildCasePattern(CasePatternSwitchLabelSyntaxWrapper casePatternSwitchLabel,

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/ResourceTests/GeneratedResourcesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/ResourceTests/GeneratedResourcesTest.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.UnitTest.ResourceTests
         private const string RspecRelativeFolderPath = @"..\..\..\..\rspec\";
 
         [TestMethod]
-        public void AnalyzersHaveCorrespondingResource_CS()
+        public void AnalyzersHaveCorrespondingResource_CSharp()
         {
             var rulesFromResources = GetRulesFromResources(RspecRelativeFolderPath + "cs");
 
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.UnitTest.ResourceTests
         }
 
         [TestMethod]
-        public void AnalyzersHaveCorrespondingResource_VB()
+        public void AnalyzersHaveCorrespondingResource_VisualBasic()
         {
             var rulesFromResources = GetRulesFromResources(RspecRelativeFolderPath + "vbnet");
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CommentedOutCodeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CommentedOutCodeTest.cs
@@ -19,9 +19,9 @@
  */
 
 extern alias csharp;
+using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using csharp::SonarAnalyzer.Rules.CSharp;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void CommentedOutCode_NoDocumentation()
         {
             Verifier.VerifyAnalyzer(@"TestCases\CommentedOutCode.cs", new CommentedOutCode(),
-                new CSharpParseOptions(documentationMode: Microsoft.CodeAnalysis.DocumentationMode.None));
+                new[] { new CSharpParseOptions(documentationMode: Microsoft.CodeAnalysis.DocumentationMode.None) });
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConditionEvaluatesToConstantTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConditionEvaluatesToConstantTest.cs
@@ -22,6 +22,7 @@ extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -30,20 +31,20 @@ namespace SonarAnalyzer.UnitTest.Rules
     {
         [TestMethod]
         [TestCategory("Rule")]
-        public void ConditionEvaluatesToConstant()
+        public void ConditionEvaluatesToConstant_CSharp6()
         {
             Verifier.VerifyAnalyzer(@"TestCases\ConditionEvaluatesToConstant.cs",
                 new ConditionEvaluatesToConstant(),
-                new CSharpParseOptions(LanguageVersion.CSharp6));
+                new[] { new CSharpParseOptions(LanguageVersion.CSharp6) });
         }
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void ConditionEvaluatesToConstant_CSharp7()
+        public void ConditionEvaluatesToConstant_FromCSharp7()
         {
             Verifier.VerifyAnalyzer(@"TestCases\ConditionEvaluatesToConstant.CSharp7.cs",
                 new ConditionEvaluatesToConstant(),
-                new CSharpParseOptions(LanguageVersion.CSharp7));
+                ParseOptionsHelper.FromCSharp7);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotMarkEnumsWithFlagsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotMarkEnumsWithFlagsTest.cs
@@ -19,8 +19,8 @@
  */
 
 extern alias csharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ForeachLoopExplicitConversionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ForeachLoopExplicitConversionTest.cs
@@ -35,7 +35,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         [TestMethod]
-        [Ignore] // Stopped working when we upgraded the version of Roslyn
         [TestCategory("CodeFix")]
         public void ForeachLoopExplicitConversion_CodeFix()
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ForeachLoopExplicitConversionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ForeachLoopExplicitConversionTest.cs
@@ -19,8 +19,8 @@
  */
 
 extern alias csharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -35,6 +35,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         [TestMethod]
+        [Ignore] // Stopped working when we upgraded the version of Roslyn
         [TestCategory("CodeFix")]
         public void ForeachLoopExplicitConversion_CodeFix()
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodParameterUnusedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodParameterUnusedTest.cs
@@ -20,8 +20,8 @@
 
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -49,11 +49,11 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void MethodParameterUnused_CSharp7()
+        public void MethodParameterUnused_FromCSharp7()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\MethodParameterUnused.CSharp7.cs",
+            Verifier.VerifyNoIssueReported(@"TestCases\MethodParameterUnused.CSharp7.cs",
                 new MethodParameterUnused(),
-                new CSharpParseOptions(LanguageVersion.CSharp7),
+                ParseOptionsHelper.FromCSharp7,
                 NuGetMetadataReference.SystemValueTuple("4.5.0"));
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NameOfShouldBeUsedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NameOfShouldBeUsedTest.cs
@@ -22,6 +22,7 @@ extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -30,18 +31,20 @@ namespace SonarAnalyzer.UnitTest.Rules
     {
         [TestMethod]
         [TestCategory("Rule")]
-        public void NameOfShouldBeUsed_CSharp6()
+        public void NameOfShouldBeUsed_FromCSharp6()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\NameOfShouldBeUsed.cs", new NameOfShouldBeUsed(),
-                new CSharpParseOptions(LanguageVersion.CSharp6));
+            Verifier.VerifyAnalyzer(@"TestCases\NameOfShouldBeUsed.cs",
+                new NameOfShouldBeUsed(),
+                ParseOptionsHelper.FromCSharp6);
         }
 
         [TestMethod]
         [TestCategory("Rule")]
         public void NameOfShouldBeUsed_CSharp5()
         {
-            Verifier.VerifyNoIssueReported(@"TestCases\NameOfShouldBeUsed.cs", new NameOfShouldBeUsed(),
-                new CSharpParseOptions(LanguageVersion.CSharp5));
+            Verifier.VerifyNoIssueReported(@"TestCases\NameOfShouldBeUsed.cs",
+                new NameOfShouldBeUsed(),
+                new[] { new CSharpParseOptions(LanguageVersion.CSharp5) });
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NullPointerDereferenceTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NullPointerDereferenceTest.cs
@@ -20,8 +20,8 @@
 
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -65,23 +65,26 @@ public static class Utils
         [TestCategory("Rule")]
         public void NullPointerDereference()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereference.cs", new NullPointerDereference());
+            Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereference.cs",
+                new NullPointerDereference());
         }
 
         [TestMethod]
         [TestCategory("Rule")]
         public void NullPointerDereference_CSharp6()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereferenceCSharp6.cs", new NullPointerDereference(),
-                new CSharpParseOptions(LanguageVersion.CSharp6));
+            Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereferenceCSharp6.cs",
+                new NullPointerDereference(),
+                ParseOptionsHelper.FromCSharp6);
         }
 
         [TestMethod]
         [TestCategory("Rule")]
         public void NullPointerDereference_CSharp7()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereferenceCSharp7.cs", new NullPointerDereference(),
-                new CSharpParseOptions(LanguageVersion.CSharp7));
+            Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereferenceCSharp7.cs",
+                new NullPointerDereference(),
+                ParseOptionsHelper.FromCSharp7);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
@@ -20,8 +20,8 @@
 
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -30,20 +30,20 @@ namespace SonarAnalyzer.UnitTest.Rules
     {
         [TestMethod]
         [TestCategory("Rule")]
-        public void NumberPatternShouldBeRegular_CSharp6()
+        public void NumberPatternShouldBeRegular_BeforeCSharp7()
         {
             Verifier.VerifyNoIssueReported(@"TestCases\NumberPatternShouldBeRegular.cs",
                 new NumberPatternShouldBeRegular(),
-                new CSharpParseOptions(LanguageVersion.CSharp6));
+                ParseOptionsHelper.BeforeCSharp7);
         }
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void NumberPatternShouldBeRegular_CSharp7()
+        public void NumberPatternShouldBeRegular_FromCSharp7()
         {
             Verifier.VerifyAnalyzer(@"TestCases\NumberPatternShouldBeRegular.cs",
                 new NumberPatternShouldBeRegular(),
-                new CSharpParseOptions(LanguageVersion.CSharp7));
+                ParseOptionsHelper.FromCSharp7);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PropertyToAutoPropertyTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PropertyToAutoPropertyTest.cs
@@ -19,9 +19,9 @@
  */
 
 extern alias csharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
-using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -32,15 +32,17 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void PropertyToAutoProperty()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\PropertyToAutoProperty.cs", new PropertyToAutoProperty());
+            Verifier.VerifyAnalyzer(@"TestCases\PropertyToAutoProperty.cs",
+                new PropertyToAutoProperty());
         }
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void PropertyToAutoProperty_CSharp7()
+        public void PropertyToAutoProperty_FromCSharp7()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\PropertyToAutoProperty.CSharp7.cs", new PropertyToAutoProperty(),
-                new CSharpParseOptions(LanguageVersion.CSharp7));
+            Verifier.VerifyAnalyzer(@"TestCases\PropertyToAutoProperty.CSharp7.cs",
+                new PropertyToAutoProperty(),
+                ParseOptionsHelper.FromCSharp7);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/StringFormatValidatorTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/StringFormatValidatorTest.cs
@@ -19,20 +19,35 @@
  */
 
 extern alias csharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Collections.Generic;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
     [TestClass]
     public class StringFormatValidatorTest
     {
+        private static readonly IEnumerable<ParseOptions> workingOptions =
+            new[]
+            {
+                new CSharpParseOptions(LanguageVersion.CSharp5),
+                new CSharpParseOptions(LanguageVersion.CSharp6),
+                new CSharpParseOptions(LanguageVersion.CSharp7),
+                new CSharpParseOptions(LanguageVersion.CSharp7_1),
+                new CSharpParseOptions(LanguageVersion.CSharp7_2)
+            };
+
         [TestMethod]
         [TestCategory("Rule")]
         public void StringFormatRuntimeExceptionFreeValidator()
         {
             Verifier.VerifyAnalyzer(@"TestCases\StringFormatRuntimeExceptionFreeValidator.cs",
-                new StringFormatValidator());
+                new StringFormatValidator(),
+                workingOptions);
         }
 
         [TestMethod]
@@ -40,7 +55,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void StringFormatTypoFreeValidator()
         {
             Verifier.VerifyAnalyzer(@"TestCases\StringFormatTypoFreeValidator.cs",
-                new StringFormatValidator());
+                new StringFormatValidator(),
+                workingOptions);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
@@ -19,9 +19,9 @@
  */
 
 extern alias csharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
-using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -759,15 +759,17 @@ namespace UnityEditor
         [TestCategory("Rule")]
         public void UnusedPrivateMember()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\UnusedPrivateMember.cs", new UnusedPrivateMember());
+            Verifier.VerifyAnalyzer(@"TestCases\UnusedPrivateMember.cs",
+                new UnusedPrivateMember());
         }
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void UnusedPrivateMember_CSharp7()
+        public void UnusedPrivateMember_FromCSharp7()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\UnusedPrivateMember.CSharp7.cs", new UnusedPrivateMember(),
-                options: new CSharpParseOptions(LanguageVersion.CSharp7));
+            Verifier.VerifyAnalyzer(@"TestCases\UnusedPrivateMember.CSharp7.cs",
+                new UnusedPrivateMember(),
+                ParseOptionsHelper.FromCSharp7);
         }
 
         [TestMethod]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UseCurlyBracesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UseCurlyBracesTest.cs
@@ -20,8 +20,8 @@
 
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -38,11 +38,11 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void UseCurlyBraces_CSharp7()
+        public void UseCurlyBraces_FromCSharp7()
         {
             Verifier.VerifyAnalyzer(@"TestCases\UseCurlyBraces.CSharp7.cs",
                 new UseCurlyBraces(),
-                new CSharpParseOptions(LanguageVersion.CSharp7));
+                ParseOptionsHelper.FromCSharp7);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UseNumericLiteralSeparatorTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UseNumericLiteralSeparatorTest.cs
@@ -20,8 +20,8 @@
 
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -30,20 +30,20 @@ namespace SonarAnalyzer.UnitTest.Rules
     {
         [TestMethod]
         [TestCategory("Rule")]
-        public void UseNumericLiteralSeparator_CSharp6()
+        public void UseNumericLiteralSeparator_BeforeCSharp7()
         {
             Verifier.VerifyNoIssueReported(@"TestCases\UseNumericLiteralSeparator.cs",
                 new UseNumericLiteralSeparator(),
-                new CSharpParseOptions(LanguageVersion.CSharp6));
+                ParseOptionsHelper.BeforeCSharp7);
         }
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void UseNumericLiteralSeparator_CSharp7()
+        public void UseNumericLiteralSeparator_FromCSharp7()
         {
             Verifier.VerifyAnalyzer(@"TestCases\UseNumericLiteralSeparator.cs",
                 new UseNumericLiteralSeparator(),
-                new CSharpParseOptions(LanguageVersion.CSharp7));
+                ParseOptionsHelper.FromCSharp7);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -59,29 +59,29 @@
       <HintPath>..\..\packages\Google.Protobuf.3.1.0\lib\net45\Google.Protobuf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.9.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.9.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.2.9.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Elfie, Version=0.10.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Elfie.0.10.6\lib\net46\Microsoft.CodeAnalysis.Elfie.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.2.9.0\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.2.9.0\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.2.0\lib\net46\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.9.0\lib\net46\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.2.0\lib\net46\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.9.0\lib\net46\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CodeCoverage.Shim, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeCoverage.1.0.3\lib\netstandard1.0\Microsoft.VisualStudio.CodeCoverage.Shim.dll</HintPath>
@@ -105,13 +105,24 @@
     <Reference Include="NuGet">
       <HintPath>..\..\packages\NuGet.CommandLine.4.7.0\tools\NuGet.exe</HintPath>
     </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_green, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a84b7dcfb1391f7f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SQLitePCLRaw.bundle_green.1.1.2\lib\net45\SQLitePCLRaw.batteries_green.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_v2, Version=1.0.0.0, Culture=neutral, PublicKeyToken=8226ea5df37bcae9, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SQLitePCLRaw.bundle_green.1.1.2\lib\net45\SQLitePCLRaw.batteries_v2.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1488e028ca7ab535, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SQLitePCLRaw.core.1.1.2\lib\net45\SQLitePCLRaw.core.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.provider.e_sqlite3, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9c301db686d0bd12, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SQLitePCLRaw.provider.e_sqlite3.net45.1.1.2\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard1.3\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Composition.AttributedModel.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
@@ -147,8 +158,8 @@
     <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.6.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
@@ -250,6 +261,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -258,8 +273,14 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.linux.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.osx.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets'))" />
   </Target>
   <Import Project="..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.linux.targets" Condition="Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" />
+  <Import Project="..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.osx.targets" Condition="Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" />
+  <Import Project="..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.2\build\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/DoNotMarkEnumsWithFlags.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/DoNotMarkEnumsWithFlags.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Tests.Diagnostics
 {
@@ -57,12 +57,6 @@ namespace Tests.Diagnostics
     {
         Value = -3, // Secondary
         Other = -4 // Secondary
-    }
-
-    [Flags]
-    public enum Color6 : float // Noncompliant
-    {
-        Val = 2.4 // Secondary
     }
 
     [Flags]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ForeachLoopExplicitConversion.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ForeachLoopExplicitConversion.Fixed.cs
@@ -54,7 +54,7 @@ namespace Tests.Diagnostics
             { }
             foreach (var i in array)
             { }
-            foreach (B[] i in array) // Fixed
+            foreach (B[] i in array.OfType<B[]>()) // Fixed
             { }
         }
         public void M5(ArrayList list)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ForeachLoopExplicitConversion.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ForeachLoopExplicitConversion.Fixed.cs
@@ -54,7 +54,7 @@ namespace Tests.Diagnostics
             { }
             foreach (var i in array)
             { }
-            foreach (B[] i in array.OfType<B[]>()) // Fixed
+            foreach (B[] i in array) // Fixed
             { }
         }
         public void M5(ArrayList list)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/InitializeStaticFieldsInline.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/InitializeStaticFieldsInline.cs
@@ -58,19 +58,4 @@ namespace Tests.Diagnostics
 
         static bool Initialize() => true;
     }
-
-    class FooBar
-    {
-        static MissingType f;
-
-        static MissingSymbol()
-        {
-            f = new MissingType();
-        }
-    }
-
-    class Hello
-    {
-        static Hello() =>
-    }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodParameterUnused.CSharp7.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodParameterUnused.CSharp7.cs
@@ -7,7 +7,7 @@
             this.Foo(new[] { ("some", "thing") });
         }
 
-        private void Foo((string key, string value)[] bars) // Noncompliant - FP - we need a higher version of Roslyn in the tests to have the right symbol
+        private void Foo((string key, string value)[] bars)
         {
             foreach (var (key, value) in bars)
             { }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodParameterUnused.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodParameterUnused.Fixed.cs
@@ -142,9 +142,8 @@ namespace Tests.TestCases
         }
 
         void M1Bis(
-            int a
-            , // Fixed
-            int c
+            int a,
+                        int c
             ) // Fixed
         {
             var result = a + c;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/CodeFixVerifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/CodeFixVerifier.cs
@@ -37,9 +37,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework
     {
         public static void VerifyCodeFix(string path, string pathToExpected, string pathToBatchExpected,
             SonarDiagnosticAnalyzer diagnosticAnalyzer, SonarCodeFixProvider codeFixProvider, string codeFixTitle,
-            params MetadataReference[] additionalReferences)
+            IEnumerable<ParseOptions> options = null, params MetadataReference[] additionalReferences)
         {
-            var parseOptions = ParseOptionsHelper.GetParseOptionsByFileExtension(Path.GetExtension(path));
+            var parseOptions = options ?? ParseOptionsHelper.GetParseOptionsByFileExtension(Path.GetExtension(path));
 
             foreach (var parseOption in parseOptions)
             {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/ParseOptionsHelper.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/ParseOptionsHelper.cs
@@ -33,20 +33,22 @@ namespace SonarAnalyzer.UnitTest.TestFramework
     {
         private static readonly IEnumerable<ParseOptions> defaultParseOptions =
             ImmutableArray.Create<ParseOptions>(
-                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp5),
-                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp6),
+
                 new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7_1),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7_2),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7_3),
                 new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic12),
                 new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic14),
-                new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic15));
+                new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic15),
+                new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic15_3),
+                new VB.VisualBasicParseOptions(VB.LanguageVersion.VisualBasic15_5)
+                );
 
         public static IEnumerable<ParseOptions> GetParseOptionsOrDefault(IEnumerable<ParseOptions> parseOptions) =>
             parseOptions != null && parseOptions.WhereNotNull().Any()
                 ? parseOptions
                 : defaultParseOptions;
-
-        public static IEnumerable<ParseOptions> GetParseOptions(Func<ParseOptions, bool> filter) =>
-            defaultParseOptions.Where(filter);
 
         public static IEnumerable<ParseOptions> GetParseOptionsByFileExtension(string extension) =>
             defaultParseOptions.Where(GetFilterByFileExtension(extension));
@@ -80,5 +82,25 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         private static readonly Func<ParseOptions, bool> VisualBasicFilter = (options) => options is VB.VisualBasicParseOptions;
 
         private static readonly Func<ParseOptions, bool> CSharpFilter = (options) => options is CS.CSharpParseOptions;
+
+        public static IEnumerable<ParseOptions> FromCSharp6 { get; } =
+            ImmutableArray.Create(
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp6),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7_1),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7_2),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7_3));
+
+        public static IEnumerable<ParseOptions> FromCSharp7 { get; } =
+            ImmutableArray.Create(
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7_1),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7_2),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp7_3));
+
+        public static IEnumerable<ParseOptions> BeforeCSharp7 { get; } =
+            ImmutableArray.Create(
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp5),
+                new CS.CSharpParseOptions(CS.LanguageVersion.CSharp6));
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/app.config
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
@@ -60,19 +60,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.9.0.0" newVersion="2.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.9.0.0" newVersion="2.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.9.0.0" newVersion="2.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.9.0.0" newVersion="2.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/packages.SonarAnalyzer.UnitTest.config
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/packages.SonarAnalyzer.UnitTest.config
@@ -4,15 +4,15 @@
   <package id="FluentAssertions" version="5.4.1" targetFramework="net46" />
   <package id="Google.Protobuf" version="3.1.0" targetFramework="net452" />
   <package id="ManagedEsent" version="1.9.4" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis" version="2.9.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.1" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.9.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.9.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.9.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Elfie" version="0.10.6" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.9.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.9.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.9.0" targetFramework="net46" />
   <package id="Microsoft.CodeCoverage" version="1.0.3" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
@@ -21,10 +21,16 @@
   <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net46" />
   <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net46" />
   <package id="NuGet.CommandLine" version="4.7.0" targetFramework="net46" developmentDependency="true" />
+  <package id="SQLitePCLRaw.bundle_green" version="1.1.2" targetFramework="net46" />
+  <package id="SQLitePCLRaw.core" version="1.1.2" targetFramework="net46" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.linux" version="1.1.2" targetFramework="net46" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.osx" version="1.1.2" targetFramework="net46" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.v110_xp" version="1.1.2" targetFramework="net46" />
+  <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.2" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net46" />
   <package id="System.Composition" version="1.0.31" targetFramework="net46" />
   <package id="System.Composition.AttributedModel" version="1.0.31" targetFramework="net46" />
   <package id="System.Composition.Convention" version="1.0.31" targetFramework="net46" />
@@ -44,7 +50,7 @@
   <package id="System.Linq" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net46" />
   <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />


### PR DESCRIPTION
`ForeachLoopExplicitConversion_CodeFix` doesn't work but even when forcing the C# version to an older version it doesn't work.
Could you test on your machine if the code fix passes?