### PR TITLE
 Correct a unit test that was failing on a French Visual studio

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
@@ -189,8 +189,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             const string expectedErrorMessage =
                 "Expected diagnostics.Where(d => d.Id == AnalyzerFailedDiagnosticId) to be empty, but found {error AD0001: " +
-                "Analyzer 'SonarAnalyzer.Rules.CSharp.CheckFileLicense' threw an exception of type " +
-                "'System.InvalidOperationException' with message 'Invalid regular expression: " +
+                "* 'SonarAnalyzer.Rules.CSharp.CheckFileLicense' * System.InvalidOperationException * 'Invalid regular expression: " +
                 FailingSingleLineRegexHeader + "'.}.";
 
             Action action =

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
@@ -189,7 +189,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             const string expectedErrorMessage =
                 "Expected diagnostics.Where(d => d.Id == AnalyzerFailedDiagnosticId) to be empty, but found {error AD0001: " +
-                "* 'SonarAnalyzer.Rules.CSharp.CheckFileLicense' * System.InvalidOperationException * 'Invalid regular expression: " +
+                "* 'SonarAnalyzer.Rules.CSharp.CheckFileLicense' *System.InvalidOperationException*Invalid regular expression: " +
                 FailingSingleLineRegexHeader + "'.}.";
 
             Action action =


### PR DESCRIPTION
Use wildcards to check only the part of the message that remains in English even on a French Visual Studio.