### PR TITLE
Fix S1449: Do not raise issues inside of an Expression

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
@@ -280,7 +280,7 @@ namespace SonarAnalyzer.Helpers
                     case SyntaxKind.SimpleLambdaExpression:
                     case SyntaxKind.ParenthesizedLambdaExpression:
                         return semanticModel.GetTypeInfo(n).ConvertedType?.OriginalDefinition.Is(KnownType.System_Linq_Expressions_Expression_T)
-                            ??false;
+                            ?? false;
                     default:
                         continue;
                 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
@@ -279,7 +279,8 @@ namespace SonarAnalyzer.Helpers
                         return true;
                     case SyntaxKind.SimpleLambdaExpression:
                     case SyntaxKind.ParenthesizedLambdaExpression:
-                        return semanticModel.GetTypeInfo(n).ConvertedType.OriginalDefinition.Is(KnownType.System_Linq_Expressions_Expression_T);
+                        return semanticModel.GetTypeInfo(n).ConvertedType?.OriginalDefinition.Is(KnownType.System_Linq_Expressions_Expression_T)
+                            ??false;
                     default:
                         continue;
                 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -27,6 +28,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.ShimLayer.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {
@@ -63,6 +65,11 @@ namespace SonarAnalyzer.Rules.CSharp
             if (!(context.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol calledMethod))
             {
                 return;
+            }
+
+            if (invocation.IsInExpressionTree(context.SemanticModel))
+            {
+                return; // We cannot specify the culture in an expression tree
             }
 
             if (calledMethod.IsInType(KnownType.System_String) &&

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantArgument.Named.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantArgument.Named.Fixed.cs
@@ -56,11 +56,14 @@ namespace Tests.Diagnostics
         Func<string> normalProperty => () => FuncWithOptionals(str: null); //Fixed
         Expression<Action> expTreeProperty => () => FuncWithOptionals(null); //Compliant
 
+        void takeExpression(Expression<Func<int, int>> expr) { }
+
         public static void Method1()
         {
             // Variable declaration
             Func<string> var1 = () => FuncWithOptionals(null); //Fixed
             Expression<Action> expTreeVar = () => FuncWithOptionals(null); //Compliant
+            takeExpression(() => FuncWithOptionals(null)); //Compliant
 
             // Simple assigment
             var1 = () => FuncWithOptionals(str: null, args: "123"); //Fixed

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantArgument.NoNamed.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantArgument.NoNamed.Fixed.cs
@@ -53,11 +53,14 @@ namespace Tests.Diagnostics
         Func<string> normalProperty => () => FuncWithOptionals(); //Fixed
         Expression<Action> expTreeProperty => () => FuncWithOptionals(null); //Compliant
 
+        void takeExpression(Expression<Func<int, int>> expr) { }
+
         public static void Method1()
         {
             // Variable declaration
             Func<string> var1 = () => FuncWithOptionals(); //Fixed
             Expression<Action> expTreeVar = () => FuncWithOptionals(null); //Compliant
+            takeExpression(() => FuncWithOptionals(null)); //Compliant
 
             // Simple assigment
             var1 = () => FuncWithOptionals(args: "123"); //Fixed

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantArgument.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantArgument.cs
@@ -60,11 +60,14 @@ namespace Tests.Diagnostics
         Func<string> normalProperty => () => FuncWithOptionals(str: null); //Noncompliant
         Expression<Action> expTreeProperty => () => FuncWithOptionals(null); //Compliant
 
+        void takeExpression(Expression<Func<int, int>> expr) { }
+
         public static void Method1()
         {
             // Variable declaration
             Func<string> var1 = () => FuncWithOptionals(null); //Noncompliant
             Expression<Action> expTreeVar = () => FuncWithOptionals(null); //Compliant
+            takeExpression(() => FuncWithOptionals(null)); //Compliant
 
             // Simple assigment
             var1 = () => FuncWithOptionals(str: null, args: "123"); //Noncompliant

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/StringOperationWithoutCulture.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/StringOperationWithoutCulture.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Globalization;
+using System.Linq.Expressions;
 
 namespace Tests.Diagnostics
 {
@@ -42,9 +43,19 @@ namespace Tests.Diagnostics
             i = "".IndexOf('');
             i = "".LastIndexOf(""); // Noncompliant
             i = "".LastIndexOf("", StringComparison.CurrentCulture);
+        }
+
+        void TestExpressions()
+        {
             // Make sure we don't report it for Expressions
             Expression<Func<string, bool>> e = s => s.ToUpper() == "TOTO";
             Func<string, bool> f = s => s.ToUpper() == "TOTO"; // Noncompliant
+            var primes = new List<string> { "two", "three", "five", "seven" };
+            var withT = primes.Where(s => s.ToUpper().StartsWith("T")); // Noncompliant
+            var withTQuery = primes.AsQueryable().Where(s => s.ToUpper().StartsWith("T"));
+            var withoutT = from s in primes where !s.ToUpper().StartsWith("T") select s; // False negative
+            var withoutTQuery = from s in primes.AsQueryable() where !s.ToUpper().StartsWith("T") select s;
+
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/StringOperationWithoutCulture.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/StringOperationWithoutCulture.cs
@@ -42,6 +42,9 @@ namespace Tests.Diagnostics
             i = "".IndexOf('');
             i = "".LastIndexOf(""); // Noncompliant
             i = "".LastIndexOf("", StringComparison.CurrentCulture);
+            // Make sure we don't report it for Expressions
+            Expression<Func<string, bool>> e = s => s.ToUpper() == "TOTO";
+            Func<string, bool> f = s => s.ToUpper() == "TOTO"; // Noncompliant
         }
     }
 }


### PR DESCRIPTION
~~No change in behaviour, the unit test was already working :)~~
Sorry, I was wrong about that... Here is a proper correction.

Related to community thread:
https://community.sonarsource.com/t/c-rule-culture-should-be-specified-for-string-operations/2364

closes #1841 
closes #1994