### PR TITLE
Fix QG build issue

### DIFF
--- a/sonaranalyzer-dotnet/src/Directory.Build.props
+++ b/sonaranalyzer-dotnet/src/Directory.Build.props
@@ -1,4 +1,14 @@
 <Project>
+
+  <!-- Include the parent Directory.Build.props file, if there is one. -->
+  <PropertyGroup>
+    <!-- Search up the tree, starting at the folder above the one containing this file -->
+    <SearchRootDirectory>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)))</SearchRootDirectory>
+    <SearchRootDirectory>$([System.IO.Directory]::GetParent($(SearchRootDirectory)))</SearchRootDirectory>
+    <ParentDirectoryBuildProps>$([MSBuild]::GetDirectoryNameOfFileAbove($(SearchRootDirectory), Directory.Build.props))\Directory.Build.props</ParentDirectoryBuildProps>
+  </PropertyGroup>
+  <Import Project="$(ParentDirectoryBuildProps)" Condition="$(ParentDirectoryBuildProps)!=''" />
+
   <PropertyGroup>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>


### PR DESCRIPTION
Recent commit added a lower-level Directory-Build.props file that prevented the existing Directory.Build.props file from being imported -> $(DebugSymbols) property not set -> no code coverage -> QG failed