### PR TITLE
Detect compilation errors in unit test code

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/FrameworkMetadataReference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/FrameworkMetadataReference.cs
@@ -62,6 +62,12 @@ namespace SonarAnalyzer.UnitTest
         internal static MetadataReference SystemRuntimeSerialization { get; }
             = Create("System.Runtime.Serialization.dll");
 
+        internal static MetadataReference SystemRuntime { get; }
+            = Create("System.Runtime.dll");
+
+        internal static MetadataReference SystemGlobalization { get; }
+            = Create("System.Globalization.dll");
+
         internal static MetadataReference SystemServiceModel { get; }
             = Create("System.ServiceModel.dll");
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyAnalyzer(@"TestCases\AssertionArgsShouldBePassedInCorrectOrder.MsTest.cs",
                 new AssertionArgsShouldBePassedInCorrectOrder(),
-                additionalReferences: NuGetMetadataReference.MSTestTestFramework(testFwkVersion));
+                additionalReferences:NuGetMetadataReference.MSTestTestFramework(testFwkVersion));
         }
 
         [DataTestMethod]
@@ -59,7 +59,9 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyAnalyzer(@"TestCases\AssertionArgsShouldBePassedInCorrectOrder.Xunit.cs",
                 new AssertionArgsShouldBePassedInCorrectOrder(),
-                additionalReferences: NuGetMetadataReference.XunitFramework(testFwkVersion)
+                additionalReferences:
+                    NuGetMetadataReference.XunitFramework(testFwkVersion).
+                    Concat(Enumerable.Repeat(FrameworkMetadataReference.Netstandard, 1))
                     .ToArray());
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AvoidExcessiveClassCouplingTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AvoidExcessiveClassCouplingTest.cs
@@ -154,7 +154,7 @@ public class Functions // Compliant, Func types are not counted
 using System;
 public class Pointers // Compliant, pointers are not counted
 {
-    public void Foo(int* pointer) { } // Ignore CS0214
+    public void Foo(int* pointer) { } // Error [CS0214]
 }
 ",
                 new AvoidExcessiveClassCoupling { Threshold = 0 });

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AvoidExcessiveClassCouplingTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AvoidExcessiveClassCouplingTest.cs
@@ -154,7 +154,7 @@ public class Functions // Compliant, Func types are not counted
 using System;
 public class Pointers // Compliant, pointers are not counted
 {
-    public void Foo(int* pointer) { }
+    public void Foo(int* pointer) { } // Ignore CS0214
 }
 ",
                 new AvoidExcessiveClassCoupling { Threshold = 0 });
@@ -168,7 +168,7 @@ public class Pointers // Compliant, pointers are not counted
 using System;
 public class Pointers // Compliant, enums are not counted
 {
-    public ConsoleColor Foo(ConsoleColor c) { }
+    public ConsoleColor Foo(ConsoleColor c) { return ConsoleColor.Black; }
 }
 ",
                 new AvoidExcessiveClassCoupling { Threshold = 0 });
@@ -180,6 +180,7 @@ public class Pointers // Compliant, enums are not counted
         {
             Verifier.VerifyCSharpAnalyzer(@"
 using System;
+using System.Collections.Generic;
 public class Lazyness // Noncompliant {{Split this class into smaller and more specialized ones to reduce its dependencies on other classes from 1 to the maximum authorized 0 or less.}}
 {
     public void Foo(Lazy<IEnumerable<int>> lazy) { } // +1 IEnumerable
@@ -199,7 +200,7 @@ public class Types // Compliant, pointers are not counted
     public void Foo(bool b1,
         byte b2, sbyte b3, int i1, uint i2, long i3, ulong i4,
         IntPtr p1, UIntPtr p2,
-        char c1, single d1,
+        char c1, float d1,
         double d2, string s1,
         object o1) { }
 }
@@ -256,7 +257,7 @@ public class Properties // Noncompliant {{Split this class into smaller and more
         }
     }
     // expression body
-    public object C6 => new Dictionary<int, int>();
+    public object C7 => new Dictionary<int, int>();
 }
 ",
                 new AvoidExcessiveClassCoupling { Threshold = 0 });
@@ -272,11 +273,11 @@ public class Indexers // Noncompliant {{Split this class into smaller and more s
 {
     // accessibility
     public IList<int> this[int i] { get { return null; } } // +1 IList
-    private ICollection<int> this[int i] { get { return null; } } // +1 ICollection
-    protected IEnumerable<int> this[int i] { get { return null; } } // +1 IEnumerable
-    internal IEnumerator<int> this[int i] { get { return null; } } // +1 IEnumerator
+    private ICollection<int> this[int i, int j] { get { return null; } } // +1 ICollection
+    protected IEnumerable<int> this[int i, int j, int k] { get { return null; } } // +1 IEnumerable
+    internal IEnumerator<int> this[int i, int j, int k, int l] { get { return null; } } // +1 IEnumerator
     // parameters
-    public int this[IEqualityComparer<int> i, Stack<int> j] { get { return null; } } // +1 IEqualityComparer, +1 Stack
+    public int this[IEqualityComparer<int> i, Stack<int> j] { get { return 0; } } // +1 IEqualityComparer, +1 Stack
 }
 ",
                 new AvoidExcessiveClassCoupling { Threshold = 0 });
@@ -333,16 +334,16 @@ public class Methods // Noncompliant {{Split this class into smaller and more sp
     // return type
     private IEqualityComparer<int> M5() { return null; } // +1 IEqualityComparer
     // generic constraints
-    private void M6<T>() where T : Stack<int> { return null; } // +1 Stack
+    private void M6<T>() where T : Stack<int> { return; } // +1 Stack
     // method body
     private void M8()
     {
         Queue<int> q; // +1 Queue
-        Console.Write(); // +1 Console
+        Console.Clear(); // +1 Console
 }
     // expression body
     private object M9() => new List<int>(); // +1 List
-    private void M10() => Debug.Write(); // +1 Debug
+    private void M10() => Debug.Write(1); // +1 Debug
 }
 ",
                 new AvoidExcessiveClassCoupling { Threshold = 0 });
@@ -452,7 +453,7 @@ using System;
 [Serializable]
 public class Self // Compliant, attributes are not counted
 {
-    [Serializable]
+    [Obsolete]
     void M1()
     {
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AvoidExcessiveClassCouplingTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AvoidExcessiveClassCouplingTest.cs
@@ -154,7 +154,7 @@ public class Functions // Compliant, Func types are not counted
 using System;
 public class Pointers // Compliant, pointers are not counted
 {
-    public void Foo(int* pointer) { } // Error [CS0214]
+    public void Foo(int* pointer) { } // Ignore [CS0214]
 }
 ",
                 new AvoidExcessiveClassCoupling { Threshold = 0 });

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CallerInformationParametersShouldBeLastTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CallerInformationParametersShouldBeLastTest.cs
@@ -34,5 +34,14 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(@"TestCases\CallerInformationParametersShouldBeLast.cs",
                 new CallerInformationParametersShouldBeLast());
         }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void CallerInformationParametersShouldBeLastInvalidSyntax()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\CallerInformationParametersShouldBeLastInvalidSyntax.cs",
+                new CallerInformationParametersShouldBeLast(),
+                checkMode:CheckMode.IgnoreCompilationErrors);
+        }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CallerInformationParametersShouldBeLastTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CallerInformationParametersShouldBeLastTest.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyAnalyzer(@"TestCases\CallerInformationParametersShouldBeLastInvalidSyntax.cs",
                 new CallerInformationParametersShouldBeLast(),
-                checkMode:CheckMode.IgnoreCompilationErrors);
+                checkMode:CompilationErrorBehavior.Ignore);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
@@ -216,7 +216,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Action action =
                 () => Verifier.VerifyAnalyzer(@"TestCases\CheckFileLicense_EmptyFile.cs",
                     new CheckFileLicense { HeaderFormat = SingleLineHeader });
-            action.Should().Throw<ErrorInCodeAnalyzedDuringUnitTests>()
+            action.Should().Throw<UnexpectedDiagnosticException>()
                   .WithMessage("Issue with message 'Add or update the header of this file.' not expected on line 1");
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
@@ -23,6 +23,7 @@ using System;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -215,7 +216,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Action action =
                 () => Verifier.VerifyAnalyzer(@"TestCases\CheckFileLicense_EmptyFile.cs",
                     new CheckFileLicense { HeaderFormat = SingleLineHeader });
-            action.Should().Throw<AssertFailedException>()
+            action.Should().Throw<ErrorInCodeAnalyzedDuringUnitTests>()
                   .WithMessage("Issue with message 'Add or update the header of this file.' not expected on line 1");
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CollectionsShouldImplementGenericInterfaceTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CollectionsShouldImplementGenericInterfaceTest.cs
@@ -32,7 +32,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void CollectionsShouldImplementGenericInterface()
         {
             Verifier.VerifyAnalyzer(@"TestCases\CollectionsShouldImplementGenericInterface.cs",
-                new CollectionsShouldImplementGenericInterface());
+                new CollectionsShouldImplementGenericInterface(),
+                checkMode:CompilationErrorBehavior.Ignore); // It would be too tedious to implement all those interfaces
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallExitMethodsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallExitMethodsTest.cs
@@ -33,8 +33,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyAnalyzer(@"TestCases\DoNotCallExitMethods.cs",
                 new DoNotCallExitMethods(),
-                null,
-                FrameworkMetadataReference.SystemWindowsForms);
+                additionalReferences:FrameworkMetadataReference.SystemWindowsForms);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithAssemblyVersionAttributeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithAssemblyVersionAttributeTest.cs
@@ -23,6 +23,7 @@ using System;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -44,7 +45,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Action action = () => Verifier.VerifyAnalyzer(
                 @"TestCases\MarkAssemblyWithAssemblyVersionAttributeNoncompliant.cs",
                 new MarkAssemblyWithAssemblyVersionAttribute());
-            action.Should().Throw<AssertFailedException>();
+            action.Should().Throw<ErrorInCodeAnalyzedDuringUnitTests>();
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithAssemblyVersionAttributeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithAssemblyVersionAttributeTest.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Action action = () => Verifier.VerifyAnalyzer(
                 @"TestCases\MarkAssemblyWithAssemblyVersionAttributeNoncompliant.cs",
                 new MarkAssemblyWithAssemblyVersionAttribute());
-            action.Should().Throw<ErrorInCodeAnalyzedDuringUnitTests>();
+            action.Should().Throw<UnexpectedDiagnosticException>();
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithClsCompliantAttributeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithClsCompliantAttributeTest.cs
@@ -23,6 +23,7 @@ using System;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -44,7 +45,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Action action = () => Verifier.VerifyAnalyzer(
                 @"TestCases\MarkAssemblyWithClsCompliantAttributeNoncompliant.cs",
                 new MarkAssemblyWithAssemblyVersionAttribute());
-            action.Should().Throw<AssertFailedException>();
+            action.Should().Throw<ErrorInCodeAnalyzedDuringUnitTests>();
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithClsCompliantAttributeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithClsCompliantAttributeTest.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Action action = () => Verifier.VerifyAnalyzer(
                 @"TestCases\MarkAssemblyWithClsCompliantAttributeNoncompliant.cs",
                 new MarkAssemblyWithAssemblyVersionAttribute());
-            action.Should().Throw<ErrorInCodeAnalyzedDuringUnitTests>();
+            action.Should().Throw<UnexpectedDiagnosticException>();
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithComVisibleAttributeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithComVisibleAttributeTest.cs
@@ -23,6 +23,7 @@ using System;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -44,7 +45,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Action action = () => Verifier.VerifyAnalyzer(
                 @"TestCases\MarkAssemblyWithComVisibleAttributeNoncompliant.cs",
                 new MarkAssemblyWithComVisibleAttribute());
-            action.Should().Throw<AssertFailedException>();
+            action.Should().Throw<ErrorInCodeAnalyzedDuringUnitTests>();
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithComVisibleAttributeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithComVisibleAttributeTest.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Action action = () => Verifier.VerifyAnalyzer(
                 @"TestCases\MarkAssemblyWithComVisibleAttributeNoncompliant.cs",
                 new MarkAssemblyWithComVisibleAttribute());
-            action.Should().Throw<ErrorInCodeAnalyzedDuringUnitTests>();
+            action.Should().Throw<UnexpectedDiagnosticException>();
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithNeutralResourcesLanguageAttributeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithNeutralResourcesLanguageAttributeTest.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                     @"TestCases\MarkAssemblyWithNeutralResourcesLanguageAttributeNonCompliant.cs",
                     @"ResourceTests\SomeResources.Designer.cs"
                 }, new MarkAssemblyWithNeutralResourcesLanguageAttribute());
-            action.Should().Throw<ErrorInCodeAnalyzedDuringUnitTests>().And
+            action.Should().Throw<UnexpectedDiagnosticException>().And
                   .Message.Should().Be("Issue with message 'Mark this assembly with 'System.Resources.NeutralResourcesLanguageAttribute'.' not expected on line 1");
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithNeutralResourcesLanguageAttributeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithNeutralResourcesLanguageAttributeTest.cs
@@ -23,6 +23,7 @@ using System;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -61,7 +62,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                     @"TestCases\MarkAssemblyWithNeutralResourcesLanguageAttributeNonCompliant.cs",
                     @"ResourceTests\SomeResources.Designer.cs"
                 }, new MarkAssemblyWithNeutralResourcesLanguageAttribute());
-            action.Should().Throw<AssertFailedException>().And
+            action.Should().Throw<ErrorInCodeAnalyzedDuringUnitTests>().And
                   .Message.Should().Be("Issue with message 'Mark this assembly with 'System.Resources.NeutralResourcesLanguageAttribute'.' not expected on line 1");
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldUseBaseTypesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldUseBaseTypesTest.cs
@@ -60,7 +60,7 @@ internal class Bar
 
             foreach (var compilation in solution.Compile())
             {
-                DiagnosticVerifier.Verify(compilation, new MethodsShouldUseBaseTypes(), CheckMode.CheckCompilationErrors);
+                DiagnosticVerifier.Verify(compilation, new MethodsShouldUseBaseTypes(), CompilationErrorBehavior.FailTest);
             }
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldUseBaseTypesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldUseBaseTypesTest.cs
@@ -60,7 +60,7 @@ internal class Bar
 
             foreach (var compilation in solution.Compile())
             {
-                DiagnosticVerifier.Verify(compilation, new MethodsShouldUseBaseTypes());
+                DiagnosticVerifier.Verify(compilation, new MethodsShouldUseBaseTypes(), CheckMode.CheckCompilationErrors);
             }
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestClassShouldHaveTestMethodTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestClassShouldHaveTestMethodTest.cs
@@ -35,8 +35,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyAnalyzer(@"TestCases\TestClassShouldHaveTestMethod.NUnit.cs",
                 new TestClassShouldHaveTestMethod(),
-                null,
-                NuGetMetadataReference.NUnit(testFwkVersion));
+                additionalReferences: NuGetMetadataReference.NUnit(testFwkVersion));
         }
 
         [DataTestMethod]
@@ -47,8 +46,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyAnalyzer(@"TestCases\TestClassShouldHaveTestMethod.MsTest.cs",
                 new TestClassShouldHaveTestMethod(),
-                null,
-                NuGetMetadataReference.MSTestTestFramework(testFwkVersion));
+                additionalReferences: NuGetMetadataReference.MSTestTestFramework(testFwkVersion));
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AbstractTypesShouldNotHaveConstructors.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AbstractTypesShouldNotHaveConstructors.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Tests.Diagnostics
@@ -13,22 +13,22 @@ namespace Tests.Diagnostics
                 //...
             }
 
-            private Base() // Compliant
+            private Base(int i) // Compliant
             {
 
             }
 
-            protected Base() // Compliant
+            protected Base(int i, int j) // Compliant
             {
 
             }
 
-            internal Base() // Noncompliant
+            internal Base(int i, int j, int k) // Noncompliant
             {
 
             }
 
-            internal protected Base() // Noncompliant
+            internal protected Base(int i, int j, int k, int l) // Noncompliant
             {
 
             }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AllBranchesShouldNotHaveSameImplementation.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AllBranchesShouldNotHaveSameImplementation.cs
@@ -4,7 +4,7 @@ namespace Tests.Diagnostics
 {
     public class Program
     {
-        public void IfElseCases()
+        public void IfElseCases(int b, int c)
         {
             if (b == 0)  // Noncompliant
             {
@@ -61,7 +61,7 @@ namespace Tests.Diagnostics
             }
         }
 
-        public void SwitchCases()
+        public void SwitchCases(int i)
         {
             switch (i) // Noncompliant {{Remove this 'switch' or edit its sections so that they are not all the same.}}
             {
@@ -127,14 +127,14 @@ namespace Tests.Diagnostics
             }
         }
 
-        public void TernaryCases(bool c)
+        public void TernaryCases(bool c, int a)
         {
             int b = a > 12 ? 4 : 4;  // Noncompliant
 
             var x = 1 > 18 ? true : true; // Noncompliant
             var y = 1 > 18 ? true : false;
             y = 1 > 18 ? (true) : true; // Noncompliant
-            TernaryCases(1 > 18 ? (true) : true); // Noncompliant
+            TernaryCases(1 > 18 ? (true) : true, a); // Noncompliant
         }
 
         private void DoSomething()

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ArrayCovariance.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ArrayCovariance.cs
@@ -11,7 +11,7 @@ namespace Tests.Diagnostics
     {
         public static object[] os = new int[0]; // Noncompliant {{Refactor the code to not rely on potentially unsafe array conversions.}}
 //                                  ^^^^^^^^^^
-                                                // Ignore@-2 CS0029
+                                                // Error@-2 [CS0029]
         public static object[] os2 = new object[0];
 
         static void Main(string[] args)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ArrayCovariance.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ArrayCovariance.cs
@@ -11,7 +11,7 @@ namespace Tests.Diagnostics
     {
         public static object[] os = new int[0]; // Noncompliant {{Refactor the code to not rely on potentially unsafe array conversions.}}
 //                                  ^^^^^^^^^^
-                                                // Error@-2 [CS0029]
+                                                // Ignore@-2 [CS0029]
         public static object[] os2 = new object[0];
 
         static void Main(string[] args)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ArrayCovariance.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ArrayCovariance.cs
@@ -11,6 +11,7 @@ namespace Tests.Diagnostics
     {
         public static object[] os = new int[0]; // Noncompliant {{Refactor the code to not rely on potentially unsafe array conversions.}}
 //                                  ^^^^^^^^^^
+                                                // Ignore@-2 CS0029
         public static object[] os2 = new object[0];
 
         static void Main(string[] args)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AssertionArgsShouldBePassedInCorrectOrder.Xunit.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AssertionArgsShouldBePassedInCorrectOrder.Xunit.cs
@@ -3,9 +3,9 @@ using Xunit;
 
 namespace Tests.Diagnostics
 {
-    [Fact]
     class Program
     {
+        [Fact]
         public void Foo()
         {
             var str = "";

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AssignmentInsideSubExpression.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AssignmentInsideSubExpression.cs
@@ -45,7 +45,7 @@ namespace Tests.Diagnostics
             foo(i == 42);
 
             foo(
-                (int x) =>
+                (int xx) =>
                 {
                     int a;
                     a = 42;
@@ -82,12 +82,12 @@ namespace Tests.Diagnostics
             if (!string.IsNullOrEmpty(result)) result = result + " ";
             var v1 = new Action(delegate { });
             var v2 = new Action(delegate { var foo = 42; });
-            var v3 = new Func<object, object>((x) => x = 42);
-            var v4 = new Action<object>((x) => { x = 42; });
+            var v3 = new Func<object, object>((xx) => xx = 42);
+            var v4 = new Action<object>((xx) => { xx = 42; });
             var v5 = new { MyField = 42 };
             var v6 = new MyClass { MyField = 42 };
             var v7 = new MyClass() { MyField = 42 };
-            var v8 = foo(x => { x = 42; return 0; });
+            var v8 = foo(xx => { xx = 42; return 0; });
 
             var index = 0;
             new int[] { 0, 1, 2 }[index = 2] = 10; // Noncompliant
@@ -103,9 +103,9 @@ namespace Tests.Diagnostics
             oo = (o) ?? (object)(o = new object()); // Compliant
 
             oo = oo ?? (o = new object()); // Noncompliant
-
-            if ((a = b = 0) != 0) { }  // Compliant
-            int x = (a = b) + 5; // Noncompliant
+            int xa = 0, xb = 0;
+            if ((xa = xb = 0) != 0) { }  // Compliant
+            int x = (xa = xb) + 5; // Noncompliant
         }
         public void TestMethod1()
         {
@@ -117,6 +117,6 @@ namespace Tests.Diagnostics
                 k = 10;
         }
 
-        public bool GetBool() => return true;
+        public bool GetBool() => true;
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AvoidExcessiveClassCoupling.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AvoidExcessiveClassCoupling.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Tests.Diagnostics
 {
-    interface IFoo { }
+    public interface IFoo { }
     class FooBase : IFoo { }
     class Foo1 : FooBase { }
     public struct MyStruct { }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AvoidExcessiveInheritance_DefaultValues.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AvoidExcessiveInheritance_DefaultValues.cs
@@ -1,24 +1,24 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Tests.Diagnostics
 {
-    class BaseClass { }
+    public class BaseClass { }
 
-    class DerivedClass_1 : BaseClass { }
+    public class DerivedClass_1 : BaseClass { }
 
-    class DerivedClass_2 : DerivedClass_1 { }
+    public class DerivedClass_2 : DerivedClass_1 { }
 
-    class DerivedClass_3 : DerivedClass_2 { }
+    public class DerivedClass_3 : DerivedClass_2 { }
 
-    class DerivedClass_4 : DerivedClass_3 { }
+    public class DerivedClass_4 : DerivedClass_3 { }
 
-    class DerivedClass_5 : DerivedClass_4 { }
+    public class DerivedClass_5 : DerivedClass_4 { }
 
-    class DerivedClass_6 : DerivedClass_5 { } // Noncompliant {{This class has 6 parents which is greater than 5 authorized.}}
-//        ^^^^^^^^^^^^^^
-    class DerivedClass_7 : DerivedClass_6 { } // Noncompliant {{This class has 7 parents which is greater than 5 authorized.}}
-//        ^^^^^^^^^^^^^^
+    public class DerivedClass_6 : DerivedClass_5 { } // Noncompliant {{This class has 6 parents which is greater than 5 authorized.}}
+//               ^^^^^^^^^^^^^^
+    public class DerivedClass_7 : DerivedClass_6 { } // Noncompliant {{This class has 7 parents which is greater than 5 authorized.}}
+//               ^^^^^^^^^^^^^^
 
     public class SubClass_0 : Exception { }
     public class SubClass_1 : SubClass_0 { }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Tests.Diagnostics
 {
@@ -7,13 +7,10 @@ namespace Tests.Diagnostics
     {
     }
 
-    protected class MyOtherAttribute : Attribute // Noncompliant
+    public class MyOtherAttribute : Attribute // Noncompliant
     {
     }
 
-    protected internal class MyOtherAttribute2 : Attribute // Noncompliant
-    {
-    }
 
     public sealed class Bar : Attribute // Compliant - sealed
     { }
@@ -29,6 +26,10 @@ namespace Tests.Diagnostics
             public class InnerInnerAttr : Attribute // Compliant - effective accessibility is private
             {
             }
+        }
+
+        protected class InnerAttr2 : Attribute // Noncompliant
+        {
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BinaryOperationWithIdenticalExpressions.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BinaryOperationWithIdenticalExpressions.cs
@@ -33,7 +33,7 @@ namespace Tests.TestCases
             int k = 5 - 5; //Noncompliant
             // Secondary@-1
 
-            l = 5 | 5; // Noncompliant
+            int l = 5 | 5; // Noncompliant
             // Secondary@-1
             l |= (l); // Noncompliant
             // Secondary@-1
@@ -53,7 +53,7 @@ namespace Tests.TestCases
 //          ^^^^^^^^^^^^^^ {{Change one instance of 'new object()' to a different value; comparing 'new object()' to itself always returns true.}}
 //                                ^^^^^^^^^^^^ Secondary@-1
 
-            Foo f;
+            Foo f = new Foo();
             f.Equals(f); // Noncompliant
             // Secondary@-1
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.Batch.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.Batch.cs
@@ -28,7 +28,7 @@ namespace Tests.Diagnostics
             var c = true && (new int[0].Length != 0); // Fixed
 
             int[] args = { };
-            var a = !(args.Length != 0); // Fixed
+            bool ba = !(args.Length != 0); // Fixed
 
             SomeFunc(a < 10); // Fixed
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.cs
@@ -28,7 +28,7 @@ namespace Tests.Diagnostics
             var c = true && (new int[0].Length != 0); // Fixed
 
             int[] args = { };
-            var a = args.Length == 0; // Fixed
+            bool ba = args.Length == 0; // Fixed
 
             SomeFunc(a < 10); // Fixed
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.cs
@@ -30,7 +30,7 @@ namespace Tests.Diagnostics
             var c = true && !(new int[0].Length == 0); // Noncompliant
 
             int[] args = { };
-            var a = !!(args.Length == 0); // Noncompliant
+            bool ba = !!(args.Length == 0); // Noncompliant
 
             SomeFunc(!(a >= 10)); // Noncompliant
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CallToAsyncMethodShouldNotBeBlocking.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CallToAsyncMethodShouldNotBeBlocking.cs
@@ -16,7 +16,7 @@ namespace Tests.Diagnostics
         {
             return Task.Run(() => "George");
         }
-
+        void nop(int i) { }
         public void ResultExamples()
         {
             var x = GetFooAsync().Result; // Noncompliant {{Replace this use of 'Task.Result' with 'await'.}}
@@ -26,11 +26,11 @@ namespace Tests.Diagnostics
             Task.Delay(0).GetAwaiter().GetResult(); // Noncompliant
 
             // Compliant - the following constructions don't cause deadlock
-            Task.Run(GetFooAsync).Result;
+            nop(Task.Run(GetFooAsync).Result);
             Task.Run(GetFooAsync).GetAwaiter().GetResult();
             Task.Factory.StartNew(GetFooAsync).GetAwaiter().GetResult();
             Task.Factory.StartNew(GetFooAsync).Unwrap().GetAwaiter().GetResult();
-            (((Task.Factory.StartNew(GetFooAsync).Unwrap()))).Result;
+            nop((((Task.Factory.StartNew(GetFooAsync).Unwrap()))).Result);
 
             // FP - the following cases should be valid
             var y = GetNameAsync().Result; // Noncompliant

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CallerInformationParametersShouldBeLast.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CallerInformationParametersShouldBeLast.cs
@@ -26,7 +26,7 @@ namespace Tests.Diagnostics
             [CallerFilePath]string callerFilePath = null, [CallerLineNumber]int callerLineNumber = 0) { }
 
         public Program([CallerFilePath]string callerFilePath, string other) { } // Noncompliant
-        public Program(string other, [CallerFilePath]string callerFilePath) { }
+        public Program(int other, [CallerFilePath]string callerFilePath) { }
     }
 
     class BaseClass
@@ -36,30 +36,17 @@ namespace Tests.Diagnostics
 
     interface MyInterface
     {
-        void Method2(string callerFilePath, string other) { }
+        void Method2(string callerFilePath, string other);
     }
 
     class DerivedClass : BaseClass, MyInterface
     {
-        public override void Method1([CallerFilePath]string callerFilePath, string other) // Compliant, method overriden
+        public override void Method1([CallerFilePath]string callerFilePath, string other = "") // Compliant, method overriden
         {
         }
 
         public void Method2([CallerFilePath]string callerFilePath, string other) // Compliant, method from interface
         {
         }
-    }
-
-    class InvalidSyntax
-    {
-        public void Method0() {}
-        public void () {}
-        public void Method1( { }
-        public void Method2) { }
-        public void Method3([CallerFilePath]) { }
-        public void Method4([CallerFilePath],string other) { }
-        public void Method5([CallerFilePath] string, string other) { }
-        public void Method6([CallerFilePathAttribute string parameter) { }
-        public void Method6([CallerLineNumber][CallerFilePath]string callerFilePath, string other) { } // Noncompliant
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CallerInformationParametersShouldBeLast.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CallerInformationParametersShouldBeLast.cs
@@ -5,28 +5,28 @@ namespace Tests.Diagnostics
     class Program
     {
         public void Method1(string callerFilePath) { }
-        public void Method2([CallerFilePath]string callerFilePath) { }
-        public void Method3(string other, [CallerFilePath]string callerFilePath) { }
-        public void Method4([CallerFilePath]string callerFilePath, string other) { } // Noncompliant {{Move 'callerFilePath' to the end of the parameter list.}}
-//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        public void Method5([CallerFilePath]string callerFilePath, string other, [CallerLineNumber]int callerLineNumber) { }
-//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        public void Method6(string first, [CallerFilePath]string callerFilePath, [CallerLineNumber]int callerLineNumber, string other) { }
-//                                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ @-1
+        public void Method2([CallerFilePath]string callerFilePath = "") { }
+        public void Method3(string other, [CallerFilePath]string callerFilePath = "") { }
+        public void Method4([CallerFilePath]string callerFilePath = "", string other = "") { } // Noncompliant {{Move 'callerFilePath' to the end of the parameter list.}}
+//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        public void Method5([CallerFilePath]string callerFilePath = "", string other = "", [CallerLineNumber]int callerLineNumber = 0) { }
+//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        public void Method6(string first, [CallerFilePath]string callerFilePath = "", [CallerLineNumber]int callerLineNumber = 0, string other = "") { }
+//                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ @-1
 
-        public void Method7([CallerFilePath]string callerFilePath,
-//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            [CallerLineNumber]int callerLineNumber,
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            [CallerMemberName]string callerMemberName, string other) { }
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        public void Method7([CallerFilePath]string callerFilePath = "",
+//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            [CallerLineNumber]int callerLineNumber = 0,
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            [CallerMemberName]string callerMemberName = "", string other = "") { }
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
         public void Method8([CallerMemberName]string callerMemberName = null,
             [CallerFilePath]string callerFilePath = null, [CallerLineNumber]int callerLineNumber = 0) { }
 
-        public Program([CallerFilePath]string callerFilePath, string other) { } // Noncompliant
-        public Program(int other, [CallerFilePath]string callerFilePath) { }
+        public Program([CallerFilePath]string callerFilePath = "", string other = "") { } // Noncompliant
+        public Program(int other, [CallerFilePath]string callerFilePath = "") { }
     }
 
     class BaseClass
@@ -41,11 +41,11 @@ namespace Tests.Diagnostics
 
     class DerivedClass : BaseClass, MyInterface
     {
-        public override void Method1([CallerFilePath]string callerFilePath, string other = "") // Compliant, method overriden
+        public override void Method1([CallerFilePath]string callerFilePath = "", string other = "") // Compliant, method overriden
         {
         }
 
-        public void Method2([CallerFilePath]string callerFilePath, string other) // Compliant, method from interface
+        public void Method2([CallerFilePath]string callerFilePath = "", string other = "") // Compliant, method from interface
         {
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CallerInformationParametersShouldBeLastInvalidSyntax.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CallerInformationParametersShouldBeLastInvalidSyntax.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+namespace Tests.Diagnostics
+{
+    class InvalidSyntax
+    {
+        public void Method0() {}
+        public void () {}
+        public void Method1( { }
+        public void Method2) { }
+        public void Method3([CallerFilePath]) { }
+        public void Method4([CallerFilePath],string other) { }
+        public void Method5([CallerFilePath] string, string other) { }
+        public void Method6([CallerFilePathAttribute string parameter) { }
+        public void Method6([CallerLineNumber][CallerFilePath]string callerFilePath, string other) { } // Noncompliant
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CastShouldNotBeDuplicated.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CastShouldNotBeDuplicated.cs
@@ -45,9 +45,9 @@ namespace Tests.Diagnostics
 
         public void UnknownFoo(object x)
         {
-            if (x is Car)  // Compliant because we ignore what the type is // Error [CS0246]
+            if (x is Car)  // Compliant because we ignore what the type is // Ignore [CS0246]
             {
-                var c = (Car)x; // Error [CS0246]
+                var c = (Car)x; // Ignore [CS0246]
             }
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CastShouldNotBeDuplicated.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CastShouldNotBeDuplicated.cs
@@ -45,9 +45,9 @@ namespace Tests.Diagnostics
 
         public void UnknownFoo(object x)
         {
-            if (x is Car)  // Compliant because we ignore what the type is // Ignore CS0246
+            if (x is Car)  // Compliant because we ignore what the type is // Error [CS0246]
             {
-                var c = (Car)x; // Ignore CS0246
+                var c = (Car)x; // Error [CS0246]
             }
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CastShouldNotBeDuplicated.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CastShouldNotBeDuplicated.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Tests.Diagnostics
@@ -7,12 +7,12 @@ namespace Tests.Diagnostics
 
     class Program
     {
-        public void Foo()
+        public void Foo(Object x)
         {
             if (x is Fruit)  // Noncompliant
             {
-                var f = (Fruit)x;
-//                      ^^^^^^^^ Secondary
+                var f1 = (Fruit)x;
+//                       ^^^^^^^^ Secondary
             }
 
             var f = x as Fruit;
@@ -22,7 +22,7 @@ namespace Tests.Diagnostics
             }
         }
 
-        public void Bar()
+        public void Bar(object x)
         {
             if (!(x is Fruit))
             {
@@ -35,7 +35,7 @@ namespace Tests.Diagnostics
 
         }
 
-        public void FooBar()
+        public void FooBar(object x)
         {
             if (x is int)
             {
@@ -43,11 +43,11 @@ namespace Tests.Diagnostics
             }
         }
 
-        public void UnknownFoo()
+        public void UnknownFoo(object x)
         {
-            if (x is Car)  // Compliant because we ignore what the type is (there will be an error)
+            if (x is Car)  // Compliant because we ignore what the type is // Ignore CS0246
             {
-                var c = (Car)x;
+                var c = (Car)x; // Ignore CS0246
             }
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CheckArgumentException.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CheckArgumentException.cs
@@ -93,7 +93,7 @@ namespace Tests.Diagnostics
 
         void Foo7(int a)
         {
-            var res =
+            Action<int> res =
                 i =>
                 {
                     throw new ArgumentNullException("i");
@@ -105,7 +105,7 @@ namespace Tests.Diagnostics
 
         void Foo8(int a)
         {
-            var res =
+            Action<int, int> res =
                 (i, j) =>
                 {
                     throw new ArgumentNullException("i");
@@ -122,7 +122,7 @@ namespace Tests.Diagnostics
             throw new ArgumentOutOfRangeException(nameof(item2), item2, null); // Noncompliant
         }
 
-        public int Foo
+        public int Foo9
         {
             get
             {
@@ -151,9 +151,9 @@ namespace Tests.Diagnostics
 
         void ComplexCase(int a)
         {
-            var simple = b =>
+            Action<int> simple = b =>
                 {
-                    var parenthesized = (c, d) =>
+                    Action<int, int> parenthesized = (c, d) =>
                     {
                         throw new ArgumentNullException("a"); // Noncompliant
                         throw new ArgumentNullException("b"); // Noncompliant
@@ -161,7 +161,7 @@ namespace Tests.Diagnostics
                 };
         }
 
-        void Bar(int a)
+        void Bar2(int a)
         {
             // See https://github.com/SonarSource/sonar-csharp/issues/1867
             throw new ArgumentNullException(null, string.Empty); // Noncompliant

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassName.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassName.cs
@@ -1,4 +1,4 @@
-﻿namespace Tests.Diagnostics
+﻿namespace t1
 {
     class FSM // Noncompliant {{Rename class 'FSM' to match camel case naming rules, consider using 'Fsm'.}}
 //        ^^^
@@ -12,7 +12,9 @@
     class foo // Noncompliant {{Rename class 'foo' to match camel case naming rules, consider using 'Foo'.}}
     {
     }
-
+}
+namespace t2
+{
     interface foo // Noncompliant {{Rename interface 'foo' to match camel case naming rules, consider using 'IFoo'.}}
     {
     }
@@ -40,7 +42,9 @@
     interface IIIFoo // Compliant
     {
     }
-
+}
+namespace t3
+{
     partial class Foo
     {
     }
@@ -75,13 +79,16 @@
 
     }
 
-    [System.Runtime.InteropServices.ComImport()]
+    [System.Runtime.InteropServices.ComImport(),
+     System.Runtime.InteropServices.Guid("00000000-0000-0000-0000-000000000001")]
     internal interface SVsLog  // Compliant
     {
     }
 
     class IILMarker { } // Noncompliant {{Rename class 'IILMarker' to match camel case naming rules, consider using 'IilMarker'.}}
-
+}
+namespace t4
+{
     interface IILMarker { } // Compliant
 
     interface ITVImageScraper { }
@@ -98,13 +105,16 @@
     class ABCDEFGHIJK { }// Noncompliant
     class Abcd4a { }// Noncompliant
 
-    class A_B_C { } // Noncompliant;
+    class A_B_C { } // Noncompliant
 
     class AB { } // Compliant
     class AbABaa { } // Compliant
     class _AbABaa { } // Noncompliant {{Rename class '_AbABaa' to match camel case naming rules, trim underscores from the name.}}
 
     class 你好 { } // Compliant
+}
 
-    public partial class ELN { }
+namespace Tests.Diagnostics
+{
+    public partial class ELN { } // Compliant because the other subpart is generated
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeAbstract.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeAbstract.cs
@@ -9,7 +9,7 @@ namespace Tests.Diagnostics
     }
     public abstract partial class A
     {
-        public void Y();
+        public void Y() { }
     }
 
     public abstract class Empty //Noncompliant {{Convert this 'abstract' class to a concrete class with a protected constructor.}}
@@ -20,15 +20,17 @@ namespace Tests.Diagnostics
 
     public abstract class Animal //Noncompliant {{Convert this 'abstract' class to an interface.}}
     {
-        abstract void move();
-        abstract void feed();
+        protected abstract void move();
+        protected abstract void feed();
 
     }
 
+    public class SomeBaseClass { }
+
     public abstract class Animal2 : SomeBaseClass //Compliant
     {
-        abstract void move();
-        abstract void feed();
+        protected abstract void move();
+        protected abstract void feed();
 
     }
 
@@ -99,12 +101,13 @@ namespace Tests.Diagnostics
     public abstract class View2Derived : View2 //Compliant, still has abstract parts
     {
         public string Content3 { get; }
-        public override string Content1 { get { return 1; } }
+        public override string Content1 { get { return ""; } }
     }
 
     public abstract class View3Derived : SomeUnknownType // Noncompliant
+                                                         // Ignore@-1 CS0246
     {
         public string Content3 { get; }
-        public override string Content1 { get { return 1; } }
+        public override int Content1 { get { return 1; } } // Ignore CS0115
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeAbstract.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeAbstract.cs
@@ -105,9 +105,9 @@ namespace Tests.Diagnostics
     }
 
     public abstract class View3Derived : SomeUnknownType // Noncompliant
-                                                         // Ignore@-1 CS0246
+                                                         // Error@-1 [CS0246]
     {
         public string Content3 { get; }
-        public override int Content1 { get { return 1; } } // Ignore CS0115
+        public override int Content1 { get { return 1; } } // Error [CS0115]
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeAbstract.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeAbstract.cs
@@ -105,9 +105,9 @@ namespace Tests.Diagnostics
     }
 
     public abstract class View3Derived : SomeUnknownType // Noncompliant
-                                                         // Error@-1 [CS0246]
+                                                         // Ignore@-1 [CS0246]
     {
         public string Content3 { get; }
-        public override int Content1 { get { return 1; } } // Error [CS0115]
+        public override int Content1 { get { return 1; } } // Ignore [CS0115]
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassWithEqualityShouldImplementIEquatable.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassWithEqualityShouldImplementIEquatable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Tests.Diagnostics
@@ -16,6 +16,7 @@ namespace Tests.Diagnostics
     {
         public bool Equals(ClassWithEqualsT other)
         {
+            return false;
         }
     }
 
@@ -23,6 +24,7 @@ namespace Tests.Diagnostics
     {
         protected bool Equals(Foo other)
         {
+            return false;
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CognitiveComplexity.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CognitiveComplexity.cs
@@ -317,12 +317,12 @@ namespace Tests.Diagnostics
             }
         }
 
-        void EmptyMethodBody() => Console.Write();
+        void EmptyMethodBody() => Console.Write("");
 
-        void IfMethodBody() => a && b || c;
+        bool IfMethodBody(bool a, bool b, bool c) => a && b || c;
 //           ^^^^^^^^^^^^ {{Refactor this method to reduce its Cognitive Complexity from 2 to the 0 allowed.}}
-//                               ^^ Secondary@-1 {{+1}}
-//                                    ^^ Secondary@-2 {{+1}}
+//                                                     ^^ Secondary@-1 {{+1}}
+//                                                          ^^ Secondary@-2 {{+1}}
 
         void MethodWithInnerMethod() // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 2 to the 0 allowed.}}
         {
@@ -423,7 +423,7 @@ namespace Tests.Diagnostics
             if (foo == null)
 //          ^^ Secondary {{+1}}
             {
-                throw ArgumentNullException();
+                throw new ArgumentNullException();
             }
         }
     }
@@ -434,8 +434,11 @@ namespace Tests.Diagnostics
         {
 
         }
+    }
 
-        ~DestructorsComplexity() // Noncompliant {{Refactor this destructor to reduce its Cognitive Complexity from 1 to the 0 allowed.}}
+    class DestructorsComplexity2
+    {
+        ~DestructorsComplexity2() // Noncompliant {{Refactor this destructor to reduce its Cognitive Complexity from 1 to the 0 allowed.}}
         {
             if (true)
 //          ^^ Secondary {{+1}}
@@ -495,7 +498,7 @@ namespace Tests.Diagnostics
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ {{Refactor this method to reduce its Cognitive Complexity from 1 to the 0 allowed.}}
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Secondary@-1 {{+1 (recursion)}}
         {
-            var act = () => IndirectRecursionFromLocalLambda();
+            Action act = () => IndirectRecursionFromLocalLambda();
             act();
         }
     }
@@ -507,7 +510,7 @@ namespace Tests.Diagnostics
             var a = true;
         }
 
-        void SimpleAnd() // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 1 to the 0 allowed.}}
+        void SimpleAnd2() // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 1 to the 0 allowed.}}
         {
             var a = true && false;
 //                       ^^ Secondary {{+1}}
@@ -531,7 +534,7 @@ namespace Tests.Diagnostics
 //                                ^^ Secondary@-1 {{+1}}
         }
 
-        void AndOrIf() // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 4 to the 0 allowed.}}
+        void AndOrIf(bool a, bool b, bool c, bool d, bool e, bool f) // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 4 to the 0 allowed.}}
         {
             if (a
 //          ^^ Secondary {{+1}}
@@ -546,7 +549,7 @@ namespace Tests.Diagnostics
             }
         }
 
-        void AndNotIf() // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 2 to the 0 allowed.}}
+        void AndNotIf(bool a, bool b, bool c, bool d) // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 2 to the 0 allowed.}}
         {
             var res =
                 a
@@ -557,7 +560,7 @@ namespace Tests.Diagnostics
                 && d;
         }
 
-        void AndOrNot1() // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 3 to the 0 allowed.}}
+        void AndOrNot1(bool a, bool b, bool c, bool d) // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 3 to the 0 allowed.}}
         {
             var res =
                 d
@@ -570,7 +573,7 @@ namespace Tests.Diagnostics
 //                  ^^ Secondary {{+1}}
         }
 
-        void AndOrNot2() // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 3 to the 0 allowed.}}
+        void AndOrNot2(bool a, bool b, bool c, bool d) // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 3 to the 0 allowed.}}
         {
             var res =
                 a
@@ -582,14 +585,14 @@ namespace Tests.Diagnostics
 //              ^^ Secondary {{+1}}
         }
 
-        void AndNot3() // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 2 to the 0 allowed.}}
+        void AndNot3(bool a, bool b, bool c, bool d) // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 2 to the 0 allowed.}}
         {
             var res = a && d && !(b && c);
 //                      ^^ Secondary {{+1}}
 //                                  ^^ Secondary@-1 {{+1}}
         }
 
-        void AndNotParenthesis() // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 2 to the 0 allowed.}}
+        void AndNotParenthesis(bool a, bool b, bool c) // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 2 to the 0 allowed.}}
         {
             var res =
                 a
@@ -599,7 +602,7 @@ namespace Tests.Diagnostics
 //                    ^^ Secondary {{+1}}
         }
 
-        void ChainedConditionsWithParentheses() // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 1 to the 0 allowed.}}
+        void ChainedConditionsWithParentheses(bool a, bool b, bool c, bool d) // Noncompliant {{Refactor this method to reduce its Cognitive Complexity from 1 to the 0 allowed.}}
         {
             var res = a && b && (c && d);
 //                      ^^ Secondary {{+1}}
@@ -644,7 +647,7 @@ namespace Tests.Diagnostics
                 }
             };
 
-        private Func<int, string> act = // Noncompliant {{Refactor this field to reduce its Cognitive Complexity from 2 to the 0 allowed.}}
+        private Func<int, string> act2 = // Noncompliant {{Refactor this field to reduce its Cognitive Complexity from 2 to the 0 allowed.}}
             x =>
             {
                 if (x > 0)
@@ -685,7 +688,7 @@ namespace Tests.Diagnostics
 
         void SimpleAction()
         {
-            Action<string> act = x => Console.Write();
+            Action<string> act = x => Console.Write(x);
         }
 
         void BlockAction()

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionEmptinessChecking.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionEmptinessChecking.cs
@@ -23,6 +23,7 @@ namespace Tests.Diagnostics
         private static bool HasContent2b(List<string> l)
         {
             return 1UL <= Enumerable.Count(l); // Noncompliant
+                                               // Ignore@-1 CS0034
         }
         private static bool HasContent3(List<string> l)
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionEmptinessChecking.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionEmptinessChecking.cs
@@ -23,7 +23,7 @@ namespace Tests.Diagnostics
         private static bool HasContent2b(List<string> l)
         {
             return 1UL <= Enumerable.Count(l); // Noncompliant
-                                               // Error@-1 [CS0034]
+                                               // Ignore@-1 [CS0034]
         }
         private static bool HasContent3(List<string> l)
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionEmptinessChecking.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionEmptinessChecking.cs
@@ -23,7 +23,7 @@ namespace Tests.Diagnostics
         private static bool HasContent2b(List<string> l)
         {
             return 1UL <= Enumerable.Count(l); // Noncompliant
-                                               // Ignore@-1 CS0034
+                                               // Error@-1 [CS0034]
         }
         private static bool HasContent3(List<string> l)
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionQuerySimplification.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionQuerySimplification.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections;
 using System.Linq;
 
 namespace Tests.Diagnostics
@@ -13,7 +14,7 @@ namespace Tests.Diagnostics
             x = coll.Select((element) => ((element as object))).Any(element => (element != null) && CheckCondition(element) && true);  // Noncompliant use OfType
             var y = coll.Where(element => element is object).Select(element => element as object); // Noncompliant use OfType
 //                       ^^^^^
-            var y = coll.Where(element => element is object).Select(element => element as object[]);
+            y = coll.Where(element => element is object).Select(element => element as object[]);
             y = coll.Where(element => element is object).Select(element => (object)element); // Noncompliant use OfType
             x = coll.Where(element => element == null).Any();  // Noncompliant use Any([expression])
 //                   ^^^^^
@@ -32,7 +33,7 @@ namespace Tests.Diagnostics
                 .AsEnumerable()
                 .Where(e => e == null);
 
-            var z = coll
+            var z2 = coll
                 .Select(element => element as object)
                 .ToList();
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionsShouldImplementGenericInterface.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionsShouldImplementGenericInterface.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -19,7 +19,7 @@ namespace Tests.Diagnostics
     class TestClass_06 : IEnumerable, ICollection<string> { }
     class TestClass_07 : IEnumerable, IList<string> { }
     class TestClass_08 : IEnumerable, IEnumerable<string> { }
-    class TestClass_09 : IEnumerable, Collection<string> { }
+    class TestClass_09 : Collection<string>, IEnumerable { }
     class TestClass_10<T> : IEnumerable, IList<T> { }
 
     class TestClass_11<T> : IEnumerable, ICollection, ICollection<T> { }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ComparableInterfaceImplementation.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ComparableInterfaceImplementation.cs
@@ -180,11 +180,11 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return true;
         }
 
-        public bool Equals { get; set; } // Error [CS0102]
+        public bool Equals { get; set; } // Ignore [CS0102]
 
-        public bool Equals => true; // Error [CS0102]
+        public bool Equals => true; // Ignore [CS0102]
 
-        public bool Equals() => true; // Error [CS0102,CS0111]
+        public bool Equals() => true; // Ignore [CS0102,CS0111]
 
         public static bool operator ==(DifferentEquals left, DifferentEquals right)
         {
@@ -387,7 +387,7 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right) // Error [CS0216]
+        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right) // Ignore [CS0216]
         {
             return Compare(left, right) <= 0;
         }
@@ -449,7 +449,7 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right) // Error [CS0216]
+        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right) // Ignore [CS0216]
         {
             return Compare(left, right) >= 0;
         }
@@ -835,7 +835,7 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right) // Error [CS0216]
+        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right) // Ignore [CS0216]
         {
             return Compare(left, right) <= 0;
         }
@@ -897,7 +897,7 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right) // Error [CS0216]
+        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right) // Ignore [CS0216]
         {
             return Compare(left, right) >= 0;
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ComparableInterfaceImplementation.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ComparableInterfaceImplementation.cs
@@ -58,12 +58,12 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return Compare(left, right) > 0;
         }
 
-        public static bool operator >=(MissingEquals left, MissingEquals right)
+        public static bool operator >=(Compliant left, Compliant right)
         {
             return Compare(left, right) >= 0;
         }
 
-        public static bool operator <=(MissingEquals left, MissingEquals right)
+        public static bool operator <=(Compliant left, Compliant right)
         {
             return Compare(left, right) <= 0;
         }
@@ -134,17 +134,17 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
 
     }
 
-    public class DiferentEquals : IComparable // Noncompliant {{When implementing IComparable, you should also override Equals.}}
-//               ^^^^^^^^^^^^^^
+    public class DifferentEquals : IComparable // Noncompliant {{When implementing IComparable, you should also override Equals.}}
+//               ^^^^^^^^^^^^^^^
     {
         public string Name { get; set; }
 
         public int CompareTo(object obj)
         {
-            return Compare(this, obj as DiferentEquals);
+            return Compare(this, obj as DifferentEquals);
         }
 
-        private static int Compare(DiferentEquals left, DiferentEquals right)
+        private static int Compare(DifferentEquals left, DifferentEquals right)
         {
             if (left == null && right == null)
             {
@@ -166,50 +166,53 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
 
         public bool Equals(object obj, string someParam)
         {
-            var other = obj as DiferentEquals;
+            var other = obj as DifferentEquals;
             return other != null && this.Name != other.Name;
         }
 
-        public void Equals(object obj)
+        public bool Equals(object obj)
         {
+            return true;
         }
 
         public bool Equals()
         {
+            return true;
         }
 
-        public bool Equals { get; set; }
+        public bool Equals { get; set; } // Ignore CS0102
 
-        public bool Equals => true;
+        public bool Equals => true; // Ignore CS0102
 
-        public bool Equals() => true;
+        public bool Equals() => true; // Ignore CS0102
+                                      // Ignore@-1 CS0111
 
-        public static bool operator ==(DiferentEquals left, DiferentEquals right)
+        public static bool operator ==(DifferentEquals left, DifferentEquals right)
         {
             return left.Equals(right);
         }
 
-        public static bool operator !=(DiferentEquals left, DiferentEquals right)
+        public static bool operator !=(DifferentEquals left, DifferentEquals right)
         {
             return !(left == right);
         }
 
-        public static bool operator <(DiferentEquals left, DiferentEquals right)
+        public static bool operator <(DifferentEquals left, DifferentEquals right)
         {
             return Compare(left, right) < 0;
         }
 
-        public static bool operator >(DiferentEquals left, DiferentEquals right)
+        public static bool operator >(DifferentEquals left, DifferentEquals right)
         {
             return Compare(left, right) > 0;
         }
 
-        public static bool operator >=(MissingEquals left, MissingEquals right)
+        public static bool operator >=(DifferentEquals left, DifferentEquals right)
         {
             return Compare(left, right) >= 0;
         }
 
-        public static bool operator <=(MissingEquals left, MissingEquals right)
+        public static bool operator <=(DifferentEquals left, DifferentEquals right)
         {
             return Compare(left, right) <= 0;
         }
@@ -261,12 +264,12 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator >=(MissingEquals left, MissingEquals right)
+        public static bool operator >=(MissingGreaterThan left, MissingGreaterThan right)
         {
             return Compare(left, right) >= 0;
         }
 
-        public static bool operator <=(MissingEquals left, MissingEquals right)
+        public static bool operator <=(MissingGreaterThan left, MissingGreaterThan right)
         {
             return Compare(left, right) <= 0;
         }
@@ -318,12 +321,12 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return Compare(left, right) > 0;
         }
 
-        public static bool operator >=(MissingEquals left, MissingEquals right)
+        public static bool operator >=(MissingNotEqual left, MissingNotEqual right)
         {
             return Compare(left, right) >= 0;
         }
 
-        public static bool operator <=(MissingEquals left, MissingEquals right)
+        public static bool operator <=(MissingNotEqual left, MissingNotEqual right)
         {
             return Compare(left, right) <= 0;
         }
@@ -385,7 +388,7 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right)
+        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right) // Ignore CS0216
         {
             return Compare(left, right) <= 0;
         }
@@ -398,7 +401,7 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
 
         public int CompareTo(object obj)
         {
-            return Compare(this, obj as MissingNotEqual);
+            return Compare(this, obj as MissingLessThanOrEqualTo);
         }
 
         private static int Compare(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right)
@@ -447,7 +450,7 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right)
+        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right) // Ignore CS0216
         {
             return Compare(left, right) >= 0;
         }
@@ -518,12 +521,12 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
         {
             return Compare(left, right) > 0;
         }
-        public static bool operator >=(MissingEquals left, MissingEquals right)
+        public static bool operator >=(Compliant left, Compliant right)
         {
             return Compare(left, right) >= 0;
         }
 
-        public static bool operator <=(MissingEquals left, MissingEquals right)
+        public static bool operator <=(Compliant left, Compliant right)
         {
             return Compare(left, right) <= 0;
         }
@@ -591,17 +594,17 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
         }
     }
 
-    public class DiferentEquals : IComparable<DiferentEquals> // Noncompliant {{When implementing IComparable<T>, you should also override Equals.}}
-//               ^^^^^^^^^^^^^^
+    public class DifferentEquals : IComparable<DifferentEquals> // Noncompliant {{When implementing IComparable<T>, you should also override Equals.}}
+//               ^^^^^^^^^^^^^^^
     {
         public string Name { get; set; }
 
-        public int CompareTo(DiferentEquals obj)
+        public int CompareTo(DifferentEquals obj)
         {
             return Compare(this, obj);
         }
 
-        private static int Compare(DiferentEquals left, DiferentEquals right)
+        private static int Compare(DifferentEquals left, DifferentEquals right)
         {
             if (left == null && right == null)
             {
@@ -623,40 +626,41 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
 
         public bool Equals(object obj, string someParam)
         {
-            var other = obj as DiferentEquals;
+            var other = obj as DifferentEquals;
             return other != null && this.Name != other.Name;
         }
 
-        public void Equals(object obj)
+        public bool Equals(object obj)
         {
+            return true;
         }
 
-        public static bool operator ==(DiferentEquals left, DiferentEquals right)
+        public static bool operator ==(DifferentEquals left, DifferentEquals right)
         {
             return left.Equals(right);
         }
 
-        public static bool operator !=(DiferentEquals left, DiferentEquals right)
+        public static bool operator !=(DifferentEquals left, DifferentEquals right)
         {
             return !(left == right);
         }
 
-        public static bool operator <(DiferentEquals left, DiferentEquals right)
+        public static bool operator <(DifferentEquals left, DifferentEquals right)
         {
             return Compare(left, right) < 0;
         }
 
-        public static bool operator >(DiferentEquals left, DiferentEquals right)
+        public static bool operator >(DifferentEquals left, DifferentEquals right)
         {
             return Compare(left, right) > 0;
         }
 
-        public static bool operator >=(MissingEquals left, MissingEquals right)
+        public static bool operator >=(DifferentEquals left, DifferentEquals right)
         {
             return Compare(left, right) >= 0;
         }
 
-        public static bool operator <=(MissingEquals left, MissingEquals right)
+        public static bool operator <=(DifferentEquals left, DifferentEquals right)
         {
             return Compare(left, right) <= 0;
         }
@@ -708,12 +712,12 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator >=(MissingEquals left, MissingEquals right)
+        public static bool operator >=(MissingGreaterThan left, MissingGreaterThan right)
         {
             return Compare(left, right) >= 0;
         }
 
-        public static bool operator <=(MissingEquals left, MissingEquals right)
+        public static bool operator <=(MissingGreaterThan left, MissingGreaterThan right)
         {
             return Compare(left, right) <= 0;
         }
@@ -765,12 +769,12 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
             return Compare(left, right) > 0;
         }
 
-        public static bool operator >=(MissingEquals left, MissingEquals right)
+        public static bool operator >=(MissingNotEqual left, MissingNotEqual right)
         {
             return Compare(left, right) >= 0;
         }
 
-        public static bool operator <=(MissingEquals left, MissingEquals right)
+        public static bool operator <=(MissingNotEqual left, MissingNotEqual right)
         {
             return Compare(left, right) <= 0;
         }
@@ -786,7 +790,7 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
             return Compare(this, obj);
         }
 
-        private static int Compare(MissingNotEqual left, MissingNotEqual right)
+        private static int Compare(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right)
         {
             if (left == null && right == null)
             {
@@ -812,27 +816,27 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
             return other != null && this.Name != other.Name;
         }
 
-        public static bool operator <(MissingNotEqual left, MissingNotEqual right)
+        public static bool operator <(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right)
         {
             return Compare(left, right) < 0;
         }
 
-        public static bool operator >(MissingNotEqual left, MissingNotEqual right)
+        public static bool operator >(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right)
         {
             return Compare(left, right) > 0;
         }
 
-        public static bool operator ==(MissingGreaterThan left, MissingGreaterThan right)
+        public static bool operator ==(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right)
         {
             return left.Equals(right);
         }
 
-        public static bool operator !=(MissingGreaterThan left, MissingGreaterThan right)
+        public static bool operator !=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right)
         {
             return !(left == right);
         }
 
-        public static bool operator <=(MissingEquals left, MissingEquals right)
+        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right) // Ignore CS0216
         {
             return Compare(left, right) <= 0;
         }
@@ -848,7 +852,7 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
             return Compare(this, obj);
         }
 
-        private static int Compare(MissingNotEqual left, MissingNotEqual right)
+        private static int Compare(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right)
         {
             if (left == null && right == null)
             {
@@ -874,27 +878,27 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
             return other != null && this.Name != other.Name;
         }
 
-        public static bool operator <(MissingNotEqual left, MissingNotEqual right)
+        public static bool operator <(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right)
         {
             return Compare(left, right) < 0;
         }
 
-        public static bool operator >(MissingNotEqual left, MissingNotEqual right)
+        public static bool operator >(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right)
         {
             return Compare(left, right) > 0;
         }
 
-        public static bool operator ==(MissingGreaterThan left, MissingGreaterThan right)
+        public static bool operator ==(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right)
         {
             return left.Equals(right);
         }
 
-        public static bool operator !=(MissingGreaterThan left, MissingGreaterThan right)
+        public static bool operator !=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right)
         {
             return !(left == right);
         }
 
-        public static bool operator >=(MissingEquals left, MissingEquals right)
+        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right) // Ignore CS0216
         {
             return Compare(left, right) >= 0;
         }
@@ -906,6 +910,11 @@ namespace Tests.Diagnostics.BothInterfacesImplementation
     public class NonCompliant : IComparable, IComparable<NonCompliant> // Noncompliant {{When implementing IComparable or IComparable<T>, you should also override Equals, <, >, <=, >=, ==, !=.}}
     {
         public string Name { get; set; }
+
+        public int CompareTo(object obj)
+        {
+            return 0;
+        }
 
         public int CompareTo(NonCompliant obj)
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ComparableInterfaceImplementation.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ComparableInterfaceImplementation.cs
@@ -180,12 +180,11 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return true;
         }
 
-        public bool Equals { get; set; } // Ignore CS0102
+        public bool Equals { get; set; } // Error [CS0102]
 
-        public bool Equals => true; // Ignore CS0102
+        public bool Equals => true; // Error [CS0102]
 
-        public bool Equals() => true; // Ignore CS0102
-                                      // Ignore@-1 CS0111
+        public bool Equals() => true; // Error [CS0102,CS0111]
 
         public static bool operator ==(DifferentEquals left, DifferentEquals right)
         {
@@ -388,7 +387,7 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right) // Ignore CS0216
+        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right) // Error [CS0216]
         {
             return Compare(left, right) <= 0;
         }
@@ -450,7 +449,7 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right) // Ignore CS0216
+        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right) // Error [CS0216]
         {
             return Compare(left, right) >= 0;
         }
@@ -836,7 +835,7 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right) // Ignore CS0216
+        public static bool operator <=(MissingGreaterThanOrEqualTo left, MissingGreaterThanOrEqualTo right) // Error [CS0216]
         {
             return Compare(left, right) <= 0;
         }
@@ -898,7 +897,7 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
             return !(left == right);
         }
 
-        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right) // Ignore CS0216
+        public static bool operator >=(MissingLessThanOrEqualTo left, MissingLessThanOrEqualTo right) // Error [CS0216]
         {
             return Compare(left, right) >= 0;
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CompareNaN.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CompareNaN.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace Tests.Diagnostics
 {
+    struct Point { public float X; public float Y; }
     class CompareNaN
     {
         void TestDouble()

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.CSharp7.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.CSharp7.cs
@@ -73,7 +73,7 @@
             }
             while (o is string s);
 
-            for (int i = 0; i < length && items[i] is string s; i++)
+            for (int i = 0; i < items.Length && items[i] is string s; i++)
             {
                 if (s != null) // Noncompliant, always true
                 {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.cs
@@ -140,9 +140,10 @@ namespace Tests.Diagnostics
             }
         }
 
-        void Pointer(int* a)
+        void Pointer(int* a) // Ignore CS0214
         {
-            if (a != null) // Compliant
+            if (a != null)  // Ignore CS0214
+                            // Compliant
             {
             }
         }
@@ -255,7 +256,7 @@ namespace Tests.Diagnostics
 
         public void Method8(bool cond)
         {
-            foreach (var item in new int[][] { { 1, 2, 3 } })
+            foreach (var item in new int[][] { new int[] { 1, 2, 3 } })
             {
                 foreach (var i in item)
                 {
@@ -420,7 +421,7 @@ namespace Tests.Diagnostics
                 x = true;
             }
         }
-
+        static object GetObject() { return null; }
         public void M()
         {
             var o1 = GetObject();
@@ -498,8 +499,8 @@ namespace Tests.Diagnostics
             }
 
             var fail = false;
-            Action a = new Action(() => { fail = true; });
-            a();
+            Action ac = new Action(() => { fail = true; });
+            ac();
             if (!fail) // This is compliant, we don't know anything about 'fail'
             {
             }
@@ -772,12 +773,17 @@ namespace Tests.Diagnostics
             return false;
         }
 
+        public static bool operator !=(ConditionEvaluatesToConstant a, ConditionEvaluatesToConstant b)
+        {
+            return false;
+        }
+
         public void StringEmpty(string s1)
         {
             string s = null;
             if (string.IsNullOrEmpty(s)) { } // Noncompliant {{Change this condition so that it does not always evaluate to 'true'.}}
             if (string.IsNullOrWhiteSpace(s)) { } // Noncompliant {{Change this condition so that it does not always evaluate to 'true'.}}
-            if (string.IsInterned(s)) { }
+            if (string.IsInterned(s) != null) { }
             s = "";
             if (string.IsNullOrEmpty(s)) { } // Noncompliant
 //Secondary@-1
@@ -829,7 +835,7 @@ namespace Tests.Diagnostics
             }
         }
 
-        int ValueEquals(int i, int j)
+        void ValueEquals(int i, int j)
         {
             if (i == j)
             {
@@ -840,7 +846,7 @@ namespace Tests.Diagnostics
 
         void DefaultExpression(object o)
         {
-            if (default(o) == null) { } // Noncompliant {{Change this condition so that it does not always evaluate to 'true'.}}
+            if (default(object) == null) { } // Noncompliant {{Change this condition so that it does not always evaluate to 'true'.}}
             int? nullableInt = null;
             if (nullableInt == null) { } // Noncompliant
             if (default(int?) == null) { } // Noncompliant
@@ -859,6 +865,7 @@ namespace Tests.Diagnostics
             where TStruct : struct
         {
             if (default(TStruct) != null) { } // Noncompliant {{Change this condition so that it does not always evaluate to 'true'.}}
+                                              // Ignore@-1 CS0019
         }
 
         void DefaultUnconstrainedGenericExpression<T>(T arg)
@@ -951,7 +958,7 @@ namespace Tests.Diagnostics
             if (object.Equals(i, j)) { } // Noncompliant
         }
 
-        async Task Test_Await_Constraint(object o, Task t)
+        async Task Test_Await_Constraint(Task<string> t)
         {
             if (t != null)
             {
@@ -1203,6 +1210,7 @@ namespace Tests.Diagnostics
             public static void M(MyStructWithNoOperator a)
             {
                 if (a == null) // Noncompliant, also a compiler error
+                               // Ignore@-1 CS0019
                 { // Secondary
                 }
             }
@@ -1384,7 +1392,7 @@ namespace Tests.Diagnostics
                 {
                     Console.WriteLine();
                 }
-                if (Exceptions.F)
+                if (ConstantExpressionsAreExcluded.F)
                 {
                     Console.WriteLine();
                 }
@@ -1400,7 +1408,7 @@ namespace Tests.Diagnostics
                     Console.WriteLine();
                 }
                 while (ConstantExpressionsAreExcluded.F);
-                var x = Exceptions.T ? 1 : 2;
+                var x = ConstantExpressionsAreExcluded.T ? 1 : 2;
             }
         }
     }
@@ -1432,7 +1440,7 @@ namespace Tests.Diagnostics
             Stream stream = null;
             try
             {
-                stream = File.Open("file");
+                stream = File.Open("file", FileMode.Open);
                 using (var reader = new StreamReader(stream))
                 {
                     // read the file here
@@ -1496,7 +1504,7 @@ namespace Tests.Diagnostics
         {
             object o = null;
             _foo1 = o;
-            System.Threading.Monitor.Wait(); // This is a multi-threaded application, the fields could change
+            System.Threading.Monitor.Wait(o); // This is a multi-threaded application, the fields could change
             if (_foo1 != null) { } // Compliant S2583
             if (_foo1 == null) { } // Compliant S2589
             if (o != null) { } // Noncompliant

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.cs
@@ -140,9 +140,9 @@ namespace Tests.Diagnostics
             }
         }
 
-        void Pointer(int* a) // Ignore CS0214
+        void Pointer(int* a) // Error [CS0214]
         {
-            if (a != null)  // Ignore CS0214
+            if (a != null)  // Error [CS0214]
                             // Compliant
             {
             }
@@ -865,7 +865,7 @@ namespace Tests.Diagnostics
             where TStruct : struct
         {
             if (default(TStruct) != null) { } // Noncompliant {{Change this condition so that it does not always evaluate to 'true'.}}
-                                              // Ignore@-1 CS0019
+                                              // Error@-1 [CS0019]
         }
 
         void DefaultUnconstrainedGenericExpression<T>(T arg)
@@ -1210,7 +1210,7 @@ namespace Tests.Diagnostics
             public static void M(MyStructWithNoOperator a)
             {
                 if (a == null) // Noncompliant, also a compiler error
-                               // Ignore@-1 CS0019
+                               // Error@-1 [CS0019]
                 { // Secondary
                 }
             }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.cs
@@ -140,9 +140,9 @@ namespace Tests.Diagnostics
             }
         }
 
-        void Pointer(int* a) // Error [CS0214]
+        void Pointer(int* a) // Ignore [CS0214]
         {
-            if (a != null)  // Error [CS0214]
+            if (a != null)  // Ignore [CS0214]
                             // Compliant
             {
             }
@@ -865,7 +865,7 @@ namespace Tests.Diagnostics
             where TStruct : struct
         {
             if (default(TStruct) != null) { } // Noncompliant {{Change this condition so that it does not always evaluate to 'true'.}}
-                                              // Error@-1 [CS0019]
+                                              // Ignore@-1 [CS0019]
         }
 
         void DefaultUnconstrainedGenericExpression<T>(T arg)
@@ -1210,7 +1210,7 @@ namespace Tests.Diagnostics
             public static void M(MyStructWithNoOperator a)
             {
                 if (a == null) // Noncompliant, also a compiler error
-                               // Error@-1 [CS0019]
+                               // Ignore@-1 [CS0019]
                 { // Secondary
                 }
             }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.Fixed.cs
@@ -84,7 +84,7 @@ namespace Tests.TestCases
             }
             else
             {
-                elem = new NonExistentType(); // Error [CS0246]
+                elem = new NonExistentType(); // Ignore [CS0246]
             }
 
             elem = false ? null : (null);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.Fixed.cs
@@ -84,7 +84,7 @@ namespace Tests.TestCases
             }
             else
             {
-                elem = new NonExistentType(); // Ignore CS0246
+                elem = new NonExistentType(); // Error [CS0246]
             }
 
             elem = false ? null : (null);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.Fixed.cs
@@ -84,7 +84,7 @@ namespace Tests.TestCases
             }
             else
             {
-                elem = new NonExistendType();
+                elem = new NonExistentType(); // Ignore CS0246
             }
 
             elem = false ? null : (null);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.cs
@@ -147,7 +147,7 @@ namespace Tests.TestCases
             }
             else
             {
-                elem = new NonExistentType(); // Ignore CS0246
+                elem = new NonExistentType(); // Error [CS0246]
             }
 
             if (false) // Noncompliant

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.cs
@@ -147,7 +147,7 @@ namespace Tests.TestCases
             }
             else
             {
-                elem = new NonExistentType(); // Error [CS0246]
+                elem = new NonExistentType(); // Ignore [CS0246]
             }
 
             if (false) // Noncompliant

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalSimplification.cs
@@ -147,7 +147,7 @@ namespace Tests.TestCases
             }
             else
             {
-                elem = new NonExistendType();
+                elem = new NonExistentType(); // Ignore CS0246
             }
 
             if (false) // Noncompliant

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsShouldStartOnNewLine.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsShouldStartOnNewLine.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Tests.Diagnostics
 {
@@ -34,7 +34,7 @@ namespace Tests.Diagnostics
                 //...
             }
 
-
+            Action a = () => { };
             {} a(); if (true) { }
 
             /*}*/  if (true)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConsoleLogging.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConsoleLogging.cs
@@ -56,7 +56,7 @@ namespace Tests.Diagnostics
 
     internal class Exceptions_MethodLevelConditionals
     {
-        [System.Diagnostics.Conditional("Wrong conditional")] // Ignore CS0633
+        [System.Diagnostics.Conditional("Wrong conditional")] // Error [CS0633]
         public static void LogDebugA(string message)
         {
             Console.WriteLine(); // Noncompliant - wrong conditional

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConsoleLogging.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConsoleLogging.cs
@@ -56,7 +56,7 @@ namespace Tests.Diagnostics
 
     internal class Exceptions_MethodLevelConditionals
     {
-        [System.Diagnostics.Conditional("Wrong conditional")] // Error [CS0633]
+        [System.Diagnostics.Conditional("Wrong conditional")] // Ignore [CS0633]
         public static void LogDebugA(string message)
         {
             Console.WriteLine(); // Noncompliant - wrong conditional

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConsoleLogging.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConsoleLogging.cs
@@ -8,11 +8,10 @@ namespace Tests.Diagnostics
     {
         private static byte[] GenerateKey(byte[] key)
         {
-            GenerateKey2(key);
             Console.WriteLine("debug key = {0}", BitConverter.ToString(key)); //Noncompliant {{Remove this logging statement.}}
 //          ^^^^^^^^^^^^^^^^^
 
-            Console.WriteLine(); //Noncopmliant
+            Console.WriteLine(); //Noncompliant
 //          ^^^^^^^^^^^^^^^^^
 
             Console.Write("debug key = {0}", BitConverter.ToString(key)); //Noncompliant
@@ -45,19 +44,19 @@ namespace Tests.Diagnostics
             get
             {
                 Console.WriteLine("Property1 read"); // Noncompliant
-                return property;
+                return property1;
             }
             set
             {
                 Console.WriteLine("Property1 written"); // Noncompliant
-                property = value;
+                property1 = value;
             }
         }
     }
 
     internal class Exceptions_MethodLevelConditionals
     {
-        [System.Diagnostics.Conditional("Wrong conditional")]
+        [System.Diagnostics.Conditional("Wrong conditional")] // Ignore CS0633
         public static void LogDebugA(string message)
         {
             Console.WriteLine(); // Noncompliant - wrong conditional

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/DisposableMemberInNonDisposableClass.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/DisposableMemberInNonDisposableClass.cs
@@ -41,7 +41,7 @@ namespace Tests.Diagnostics
     {
         protected FileStream fs;
 
-        protected ResourceHolder3()
+        protected ResourceHolder3(string path)
         {
             this.fs = new FileStream(path, FileMode.Open);
         }
@@ -53,6 +53,7 @@ namespace Tests.Diagnostics
 
     public class ResourceHolder4 : ResourceHolder3 // Compliant; it doesn't have its own field
     {
+        ResourceHolder4(string path) : base(path) { }
         public void OpenResource(string path)
         {
             this.fs = new FileStream(path, FileMode.Open);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodName.Partial.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodName.Partial.cs
@@ -12,6 +12,6 @@ namespace Tests.Diagnostics
 {
     public partial class SomeClass
     {
-        public partial void MY_METHOD();
+        partial void MY_METHOD();
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodName.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodName.cs
@@ -82,6 +82,6 @@
 
     public class Invalid
     {
-        public int () => 42; // Error [CS1519,CS8124,CS1519]
+        public int () => 42; // Ignore [CS1519,CS8124,CS1519]
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodName.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodName.cs
@@ -82,8 +82,6 @@
 
     public class Invalid
     {
-        public int () => 42; // Ignore CS1519
-                             // Ignore@-1 CS8124
-                             // Ignore@-2 CS1519
+        public int () => 42; // Error [CS1519,CS8124,CS1519]
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodName.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MethodName.cs
@@ -35,11 +35,11 @@
 
         public void Should_Define_Convention_That_Returns_Metadata_Module_Type() { } // Compliant
 
-        public void Should_return_JSON_serialized_querystring { } // Compliant
+        public void Should_return_JSON_serialized_querystring() { } // Compliant
 
-        public void IsLocal_should_return_true_if_userHostAddr_is_localhost_IPV4 { } // Compliant
+        public void IsLocal_should_return_true_if_userHostAddr_is_localhost_IPV4() { } // Compliant
 
-        public void 你好 { }
+        public void 你好() { }
 
         public void Łódź() { }
 
@@ -50,14 +50,15 @@
         public int ArrowedProperty2
         {
             get => 41;
-            set => null;
+            set => bar();
         }
     }
 
-    [System.Runtime.InteropServices.ComImport()]
-    public class MMMM
+    [System.Runtime.InteropServices.ComImport(),
+     System.Runtime.InteropServices.Guid("00000000-0000-0000-0000-000000000001")]
+    public abstract class MMMM
     {
-        public void MMMMMethod() { } // Compliant
+        public abstract void MMMMMethod(); // Compliant
     }
 
     public class Base
@@ -74,13 +75,15 @@
 
     public partial class SomeClass
     {
-        public partial void MY_METHOD()
+        partial void MY_METHOD()
         {
         }
     }
 
     public class Invalid
     {
-        public int () => 42;
+        public int () => 42; // Ignore CS1519
+                             // Ignore@-1 CS8124
+                             // Ignore@-2 CS1519
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/CodeFixVerifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/CodeFixVerifier.cs
@@ -126,7 +126,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 (doc, ids, ct) => Task.FromResult(
                     DiagnosticVerifier.GetDiagnostics(
                         currentDocument.Project.GetCompilationAsync(ct).Result,
-                        diagnosticAnalyzer, CheckMode.IgnoreCompilationErrors)), // TODO: Is that the right decision?
+                        diagnosticAnalyzer, CompilationErrorBehavior.Ignore)), // TODO: Is that the right decision?
                 null);
 
             var fixAllContext = new FixAllContext(currentDocument, codeFixProvider, FixAllScope.Document,
@@ -153,7 +153,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             }
 
             diagnostics = DiagnosticVerifier.GetDiagnostics(project.GetCompilationAsync().Result,
-                diagnosticAnalyzer, CheckMode.IgnoreCompilationErrors).ToList(); // TODO: Is that the right choice?
+                diagnosticAnalyzer, CompilationErrorBehavior.Ignore).ToList(); // TODO: Is that the right choice?
             actualCode = document.GetSyntaxRootAsync().Result.GetText().ToString();
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/CodeFixVerifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/CodeFixVerifier.cs
@@ -124,7 +124,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             var fixAllDiagnosticProvider = new FixAllDiagnosticProvider(
                 codeFixProvider.FixableDiagnosticIds.ToHashSet(),
                 (doc, ids, ct) => Task.FromResult(
-                    DiagnosticVerifier.GetDiagnostics(currentDocument.Project.GetCompilationAsync(ct).Result, diagnosticAnalyzer)),
+                    DiagnosticVerifier.GetDiagnostics(
+                        currentDocument.Project.GetCompilationAsync(ct).Result,
+                        diagnosticAnalyzer, CheckMode.IgnoreCompilationErrors)), // TODO: Is that the right decision?
                 null);
 
             var fixAllContext = new FixAllContext(currentDocument, codeFixProvider, FixAllScope.Document,
@@ -150,7 +152,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 project = project.WithParseOptions(parseOption);
             }
 
-            diagnostics = DiagnosticVerifier.GetDiagnostics(project.GetCompilationAsync().Result, diagnosticAnalyzer).ToList();
+            diagnostics = DiagnosticVerifier.GetDiagnostics(project.GetCompilationAsync().Result,
+                diagnosticAnalyzer, CheckMode.IgnoreCompilationErrors).ToList(); // TODO: Is that the right choice?
             actualCode = document.GetSyntaxRootAsync().Result.GetText().ToString();
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
@@ -66,7 +66,13 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
         public ErrorInCodeAnalyzedDuringUnitTests(Location loc, string message) : base(message)
         {
-            var pathToRealSource = GetFullPathOfRealSourceCode(loc.GetLineSpan().Path);
+            var reportedPath = loc.GetLineSpan().Path;
+            if (string.IsNullOrEmpty(reportedPath))
+            {
+                additionalStackTraceLine = string.Empty;
+                return;
+            }
+            var pathToRealSource = GetFullPathOfRealSourceCode(reportedPath);
             var line = loc.GetLineNumberToReport();
             additionalStackTraceLine = $"{at} Analyzed code {string.Format(inFileLineNum, pathToRealSource, line)}{Environment.NewLine}";
         }
@@ -152,7 +158,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         }
 
         public static void VerifyNoIssueReported(Compilation compilation, DiagnosticAnalyzer diagnosticAnalyzer,
-            CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest)
+            CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default)
         {
             GetDiagnostics(compilation, diagnosticAnalyzer, checkMode).Should().BeEmpty();
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         private const string ISSUE_IDS_PATTERN = @"\s*(\[(?<issueIds>.*)\])*";
         private const string MESSAGE_PATTERN = @"\s*(\{\{(?<message>.*)\}\})*";
         private const string TYPE_PATTERN = @"(?<issueType>Noncompliant|Secondary)";
-        private const string BUILD_ERROR_PATTERN = @"Ignore";
+        private const string BUILD_ERROR_PATTERN = @"Error";
         private const string BUILD_ERROR_ID_PATTERN = @"\s*(?<message>CS[0-9]+)";
         private const string PRECISE_LOCATION_PATTERN = @"\s*(?<position>\^+)\s*";
         private const string NO_PRECISE_LOCATION_PATTERN = @"\s*(?<!\^+\s{1})";
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         private const string PRECISE_ISSUE_LOCATION_PATTERN =
             @"^" + COMMENT_PATTERN + PRECISE_LOCATION_PATTERN + TYPE_PATTERN + "*" + OFFSET_PATTERN + ISSUE_IDS_PATTERN + MESSAGE_PATTERN + "$";
         internal const string BUILD_ERROR_LOCATION_PATTERN =
-            COMMENT_PATTERN + "*" + NO_PRECISE_LOCATION_PATTERN + BUILD_ERROR_PATTERN + OFFSET_PATTERN + BUILD_ERROR_ID_PATTERN;
+            COMMENT_PATTERN + "*" + NO_PRECISE_LOCATION_PATTERN + BUILD_ERROR_PATTERN + OFFSET_PATTERN + ISSUE_IDS_PATTERN + "$";
 
         public IList<IIssueLocation> GetExpectedIssueLocations(IEnumerable<TextLine> lines)
         {
@@ -73,8 +73,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .Cast<IIssueLocation>()
                 .ToList();
         }
-
-
 
         public static bool IsNotIssueLocationLine(string line)
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
@@ -37,7 +37,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         private const string MESSAGE_PATTERN = @"\s*(\{\{(?<message>.*)\}\})*";
         private const string TYPE_PATTERN = @"(?<issueType>Noncompliant|Secondary)";
         private const string BUILD_ERROR_PATTERN = @"Error";
-        private const string BUILD_ERROR_ID_PATTERN = @"\s*(?<message>CS[0-9]+)";
         private const string PRECISE_LOCATION_PATTERN = @"\s*(?<position>\^+)\s*";
         private const string NO_PRECISE_LOCATION_PATTERN = @"\s*(?<!\^+\s{1})";
         private const string COMMENT_PATTERN = @"(?<comment>\/\/|\')";

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
@@ -36,6 +36,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         private const string ISSUE_IDS_PATTERN = @"\s*(\[(?<issueIds>.*)\])*";
         private const string MESSAGE_PATTERN = @"\s*(\{\{(?<message>.*)\}\})*";
         private const string TYPE_PATTERN = @"(?<issueType>Noncompliant|Secondary)";
+        private const string BUILD_ERROR_PATTERN = @"Ignore";
+        private const string BUILD_ERROR_ID_PATTERN = @"\s*(?<message>CS[0-9]+)";
         private const string PRECISE_LOCATION_PATTERN = @"\s*(?<position>\^+)\s*";
         private const string NO_PRECISE_LOCATION_PATTERN = @"\s*(?<!\^+\s{1})";
         private const string COMMENT_PATTERN = @"(?<comment>\/\/|\')";
@@ -44,6 +46,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             COMMENT_PATTERN + "*" + NO_PRECISE_LOCATION_PATTERN + TYPE_PATTERN + OFFSET_PATTERN + ISSUE_IDS_PATTERN + MESSAGE_PATTERN;
         private const string PRECISE_ISSUE_LOCATION_PATTERN =
             @"^" + COMMENT_PATTERN + PRECISE_LOCATION_PATTERN + TYPE_PATTERN + "*" + OFFSET_PATTERN + ISSUE_IDS_PATTERN + MESSAGE_PATTERN + "$";
+        internal const string BUILD_ERROR_LOCATION_PATTERN =
+            COMMENT_PATTERN + "*" + NO_PRECISE_LOCATION_PATTERN + BUILD_ERROR_PATTERN + OFFSET_PATTERN + BUILD_ERROR_ID_PATTERN;
 
         public IList<IIssueLocation> GetExpectedIssueLocations(IEnumerable<TextLine> lines)
         {
@@ -59,6 +63,18 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
             return MergeLocations(locations, preciseLocations);
         }
+
+        internal IList<IIssueLocation> GetExpectedBuildErrors(IEnumerable<TextLine> lines)
+        {
+            return lines
+                .SelectMany(GetBuildErrorsLocations)
+                .WhereNotNull()
+                .ToList()
+                .Cast<IIssueLocation>()
+                .ToList();
+        }
+
+
 
         public static bool IsNotIssueLocationLine(string line)
         {
@@ -92,9 +108,19 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
         internal /*for testing*/ IEnumerable<IssueLocation> GetIssueLocations(TextLine line)
         {
+            return GetLocations(line, ISSUE_LOCATION_PATTERN);
+        }
+
+        internal /*for testing*/ IEnumerable<IssueLocation> GetBuildErrorsLocations(TextLine line)
+        {
+            return GetLocations(line, BUILD_ERROR_LOCATION_PATTERN);
+        }
+
+        private IEnumerable<IssueLocation> GetLocations(TextLine line, string pattern)
+        {
             var lineText = line.ToString();
 
-            var match = Regex.Match(lineText, ISSUE_LOCATION_PATTERN);
+            var match = Regex.Match(lineText, pattern);
             if (match.Success)
             {
                 return CreateIssueLocations(match, line.LineNumber + 1);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         private const string ISSUE_IDS_PATTERN = @"\s*(\[(?<issueIds>.*)\])*";
         private const string MESSAGE_PATTERN = @"\s*(\{\{(?<message>.*)\}\})*";
         private const string TYPE_PATTERN = @"(?<issueType>Noncompliant|Secondary)";
-        private const string BUILD_ERROR_PATTERN = @"Error";
+        private const string BUILD_ERROR_PATTERN = @"Ignore";
         private const string PRECISE_LOCATION_PATTERN = @"\s*(?<position>\^+)\s*";
         private const string NO_PRECISE_LOCATION_PATTERN = @"\s*(?<!\^+\s{1})";
         private const string COMMENT_PATTERN = @"(?<comment>\/\/|\')";

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollectorTests/IssueLocationCollector_GetExpectedBuildErrors.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollectorTests/IssueLocationCollector_GetExpectedBuildErrors.cs
@@ -26,10 +26,10 @@ using System.Linq;
 namespace SonarAnalyzer.UnitTest.TestFramework.IssueLocationCollectorTests
 {
     [TestClass]
-    public class IssueLocationCollector_GetExpectedIssueLocations
+    public class IssueLocationCollector_GetExpectedBuildErrors
     {
         [TestMethod]
-        public void GetExpectedIssueLocations_No_Comments()
+        public void GetExpectedBuildErrors_No_Comments()
         {
             var code = @"public class Foo
 {
@@ -38,48 +38,28 @@ namespace SonarAnalyzer.UnitTest.TestFramework.IssueLocationCollectorTests
         Console.WriteLine(o);
     }
 }";
-            var locations = new IssueLocationCollector().GetExpectedIssueLocations(SourceText.From(code).Lines);
+            var expectedErrors = new IssueLocationCollector().GetExpectedBuildErrors(SourceText.From(code).Lines);
 
-            locations.Should().BeEmpty();
+            expectedErrors.Should().BeEmpty();
         }
 
         [TestMethod]
-        public void GetExpectedIssueLocations_Locations()
+        public void GetExpectedBuildErrors_expectedErrors()
         {
             var code = @"public class Foo
 {
-    public void Bar(object o) // Noncompliant
+    public void Bar(object o) // Ignore CS1234
     {
-        // Noncompliant@+1
+        // Ignore@+1 CS3456
         Console.WriteLine(o);
     }
 }";
-            var locations = new IssueLocationCollector().GetExpectedIssueLocations(SourceText.From(code).Lines);
+            var expectedErrors = new IssueLocationCollector().GetExpectedBuildErrors(SourceText.From(code).Lines);
 
-            locations.Should().HaveCount(2);
+            expectedErrors.Should().HaveCount(2);
 
-            locations.Select(l => l.IsPrimary).Should().Equal(new[] { true, true });
-            locations.Select(l => l.LineNumber).Should().Equal(new[] { 3, 6 });
-        }
-
-        [TestMethod]
-        public void GetExpectedIssueLocations_ExactLocations()
-        {
-            var code = @"public class Foo
-{
-    public void Bar(object o)
-//              ^^^
-//                         ^ Secondary@-1
-    {
-        Console.WriteLine(o);
-    }
-}";
-            var locations = new IssueLocationCollector().GetExpectedIssueLocations(SourceText.From(code).Lines);
-
-            locations.Should().HaveCount(2);
-
-            locations.Select(l => l.IsPrimary).Should().BeEquivalentTo(new[] { true, false });
-            locations.Select(l => l.LineNumber).Should().Equal(new[] { 3, 3 });
+            expectedErrors.Select(l => l.IsPrimary).Should().Equal(new[] { true, true });
+            expectedErrors.Select(l => l.LineNumber).Should().Equal(new[] { 3, 6 });
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollectorTests/IssueLocationCollector_GetExpectedBuildErrors.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollectorTests/IssueLocationCollector_GetExpectedBuildErrors.cs
@@ -48,9 +48,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework.IssueLocationCollectorTests
         {
             var code = @"public class Foo
 {
-    public void Bar(object o) // Error [CS1234]
+    public void Bar(object o) // Ignore [CS1234]
     {
-        // Error@+1 [CS3456]
+        // Ignore@+1 [CS3456]
         Console.WriteLine(o);
     }
 }";
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework.IssueLocationCollectorTests
         {
             var code = @"public class Foo
 {
-    public void Bar(object o) // Error [CS1234,CS2345,CS3456]
+    public void Bar(object o) // Ignore [CS1234,CS2345,CS3456]
     {
     }
 }";

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollectorTests/IssueLocationCollector_GetExpectedBuildErrors.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollectorTests/IssueLocationCollector_GetExpectedBuildErrors.cs
@@ -44,13 +44,13 @@ namespace SonarAnalyzer.UnitTest.TestFramework.IssueLocationCollectorTests
         }
 
         [TestMethod]
-        public void GetExpectedBuildErrors_expectedErrors()
+        public void GetExpectedBuildErrors_ExpectedErrors()
         {
             var code = @"public class Foo
 {
-    public void Bar(object o) // Ignore CS1234
+    public void Bar(object o) // Error [CS1234]
     {
-        // Ignore@+1 CS3456
+        // Error@+1 [CS3456]
         Console.WriteLine(o);
     }
 }";
@@ -60,6 +60,24 @@ namespace SonarAnalyzer.UnitTest.TestFramework.IssueLocationCollectorTests
 
             expectedErrors.Select(l => l.IsPrimary).Should().Equal(new[] { true, true });
             expectedErrors.Select(l => l.LineNumber).Should().Equal(new[] { 3, 6 });
+        }
+
+        [TestMethod]
+        public void GetExpectedBuildErrors_Multiple_ExpectedErrors()
+        {
+            var code = @"public class Foo
+{
+    public void Bar(object o) // Error [CS1234,CS2345,CS3456]
+    {
+    }
+}";
+            var expectedErrors = new IssueLocationCollector().GetExpectedBuildErrors(SourceText.From(code).Lines);
+
+            expectedErrors.Should().HaveCount(3);
+
+            expectedErrors.Select(l => l.IsPrimary).Should().Equal(new[] { true, true, true });
+            expectedErrors.Select(l => l.LineNumber).Should().Equal(new[] { 3, 3, 3 });
+            expectedErrors.Select(l => l.IssueId).Should().Equal(new[] { "CS1234", "CS2345", "CS3456" });
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
@@ -62,7 +62,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .AddReferences(
                     FrameworkMetadataReference.Mscorlib,
                     FrameworkMetadataReference.System,
-                    FrameworkMetadataReference.SystemCore);
+                    FrameworkMetadataReference.SystemCore,
+                    FrameworkMetadataReference.SystemRuntime,
+                    FrameworkMetadataReference.SystemGlobalization);
 
             if (createExtraEmptyFile)
             {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/UnexpectedDiagnosticException.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/UnexpectedDiagnosticException.cs
@@ -1,0 +1,69 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.IO;
+using System.Resources;
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.UnitTest.TestFramework
+{
+    /// <summary>
+    /// This exception class is used in unit tests that analyze some code to report a violation.
+    /// It differs from classical unit test failure reporting in that it injects in its call
+    /// stack a location that correspond to the source file that is being analyzed (when analysing
+    /// inline code snippets, this location will be incorrect).
+    /// As a result, in the UI, we can just click on this line to directly open the right file at
+    /// the right place to see the actual issue.
+    /// </summary>
+    ///
+    public class UnexpectedDiagnosticException : Exception
+    {
+        private static readonly ResourceManager mscorlibResources = new ResourceManager("mscorlib", typeof(object).Assembly);
+        private static readonly string at = mscorlibResources.GetString("Word_At");
+        private static readonly string stackTraceFormat = mscorlibResources.GetString("StackTrace_InFileLineNumber");
+
+        private readonly string additionalLine;
+
+        public UnexpectedDiagnosticException(Location location, string message) : base(message)
+        {
+            var locationPath = location.GetLineSpan().Path;
+            if (string.IsNullOrEmpty(locationPath))
+            {
+                return;
+            }
+
+            var testCasePath = GetTestCasePath(locationPath);
+            var testCaseLine = location.GetLineNumberToReport();
+
+            additionalLine = $"{at} Test Case {GetStackTraceLocation(testCasePath, testCaseLine)}" + Environment.NewLine;
+        }
+
+        public override string StackTrace =>
+            additionalLine + base.StackTrace;
+
+        private static string GetStackTraceLocation(string testCasePath, int testCaseLine) =>
+            string.Format(stackTraceFormat, testCasePath, testCaseLine);
+
+        private static string GetTestCasePath(string path) =>
+            Path.GetFullPath(Path.Combine(@"..\..\TestCases", path));
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Verifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Verifier.cs
@@ -35,13 +35,14 @@ namespace SonarAnalyzer.UnitTest
     public enum CompilationErrorBehavior
     {
         FailTest,
-        Ignore
+        Ignore,
+        Default = Ignore
     }
 
     internal static class Verifier
     {
         public static void VerifyNoExceptionThrown(string path,
-            IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers, CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest)
+            IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers, CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default)
         {
             var compilation = SolutionBuilder
                 .Create()
@@ -53,7 +54,7 @@ namespace SonarAnalyzer.UnitTest
         }
 
         public static void VerifyCSharpAnalyzer(string snippet, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest, params MetadataReference[] additionalReferences)
+            CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default, params MetadataReference[] additionalReferences)
         {
             var solution = SolutionBuilder
                .Create()
@@ -71,7 +72,7 @@ namespace SonarAnalyzer.UnitTest
         }
 
         public static void VerifyVisualBasicAnalyzer(string snippet, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest, params MetadataReference[] additionalReferences)
+            CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default, params MetadataReference[] additionalReferences)
         {
             var solution = SolutionBuilder
                .Create()
@@ -89,14 +90,14 @@ namespace SonarAnalyzer.UnitTest
         }
 
         public static void VerifyAnalyzer(string path, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest,
+            IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
             params MetadataReference[] additionalReferences)
         {
             VerifyAnalyzer(new[] { path }, diagnosticAnalyzer, options, checkMode, additionalReferences);
         }
 
         public static void VerifyUtilityAnalyzer<TMessage>(IEnumerable<string> paths, UtilityAnalyzerBase diagnosticAnalyzer,
-            string protobufPath, Action<IList<TMessage>> verifyProtobuf, CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest)
+            string protobufPath, Action<IList<TMessage>> verifyProtobuf, CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default)
             where TMessage : IMessage<TMessage>, new()
         {
             var solutionBuilder = SolutionBuilder.CreateSolutionFromPaths(paths);
@@ -122,7 +123,7 @@ namespace SonarAnalyzer.UnitTest
         }
 
         public static void VerifyAnalyzer(IEnumerable<string> paths, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest,
+            IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
             params MetadataReference[] additionalReferences)
         {
             var solutionBuilder = SolutionBuilder.CreateSolutionFromPaths(paths, additionalReferences);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Verifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Verifier.cs
@@ -32,16 +32,16 @@ using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest
 {
-    public enum CheckMode
+    public enum CompilationErrorBehavior
     {
-        CheckCompilationErrors,
-        IgnoreCompilationErrors
+        FailTest,
+        Ignore
     }
 
     internal static class Verifier
     {
         public static void VerifyNoExceptionThrown(string path,
-            IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers, CheckMode checkMode = CheckMode.CheckCompilationErrors)
+            IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers, CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest)
         {
             var compilation = SolutionBuilder
                 .Create()
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.UnitTest
         }
 
         public static void VerifyCSharpAnalyzer(string snippet, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            CheckMode checkMode = CheckMode.CheckCompilationErrors, params MetadataReference[] additionalReferences)
+            CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest, params MetadataReference[] additionalReferences)
         {
             var solution = SolutionBuilder
                .Create()
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.UnitTest
         }
 
         public static void VerifyVisualBasicAnalyzer(string snippet, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            CheckMode checkMode = CheckMode.CheckCompilationErrors, params MetadataReference[] additionalReferences)
+            CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest, params MetadataReference[] additionalReferences)
         {
             var solution = SolutionBuilder
                .Create()
@@ -89,14 +89,14 @@ namespace SonarAnalyzer.UnitTest
         }
 
         public static void VerifyAnalyzer(string path, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            IEnumerable<ParseOptions> options = null, CheckMode checkMode = CheckMode.CheckCompilationErrors,
+            IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest,
             params MetadataReference[] additionalReferences)
         {
             VerifyAnalyzer(new[] { path }, diagnosticAnalyzer, options, checkMode, additionalReferences);
         }
 
         public static void VerifyUtilityAnalyzer<TMessage>(IEnumerable<string> paths, UtilityAnalyzerBase diagnosticAnalyzer,
-            string protobufPath, Action<IList<TMessage>> verifyProtobuf, CheckMode checkMode = CheckMode.CheckCompilationErrors)
+            string protobufPath, Action<IList<TMessage>> verifyProtobuf, CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest)
             where TMessage : IMessage<TMessage>, new()
         {
             var solutionBuilder = SolutionBuilder.CreateSolutionFromPaths(paths);
@@ -122,7 +122,7 @@ namespace SonarAnalyzer.UnitTest
         }
 
         public static void VerifyAnalyzer(IEnumerable<string> paths, SonarDiagnosticAnalyzer diagnosticAnalyzer,
-            IEnumerable<ParseOptions> options = null, CheckMode checkMode = CheckMode.CheckCompilationErrors,
+            IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.FailTest,
             params MetadataReference[] additionalReferences)
         {
             var solutionBuilder = SolutionBuilder.CreateSolutionFromPaths(paths, additionalReferences);


### PR DESCRIPTION
Fixes #2012 
By default, this detection is currently disabled. To enable it, in https://github.com/SonarSource/sonar-csharp/blob/26e817d94c7a97227ced09c6acc17ff064f230fd/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Verifier.cs#L39 replace `Default = Ignore` by `Default = Fail`